### PR TITLE
Implement Special Secondary Subjects steps

### DIFF
--- a/app/views/publish/course_wizards/steps/_design_technology_specialisms.html.erb
+++ b/app/views/publish/course_wizards/steps/_design_technology_specialisms.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.design_technology_specialisms.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.design_technology_specialisms.caption")) %>
+  <%= t("course_wizard.steps.design_technology_specialisms.heading") %>
+</h1>
+
+<%= form.govuk_check_boxes_fieldset :design_technology_ids,
+      legend: { hidden: true, text: t("course_wizard.steps.design_technology_specialisms.heading") },
+      hint: { text: t("course_wizard.steps.design_technology_specialisms.hint") } do %>
+  <% current_step.design_technologies.each_with_index do |specialism, index| %>
+    <%= form.govuk_check_box :design_technology_ids,
+          specialism.id.to_s,
+          label: { text: specialism.subject_name },
+          include_hidden: false,
+          link_errors: index.zero? %>
+  <% end %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.design_technology_specialisms.submit") %>

--- a/app/views/publish/course_wizards/steps/_modern_languages_specialisms.html.erb
+++ b/app/views/publish/course_wizards/steps/_modern_languages_specialisms.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.modern_languages_specialisms.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.modern_languages_specialisms.caption")) %>
+  <%= t("course_wizard.steps.modern_languages_specialisms.heading") %>
+</h1>
+
+<%= form.govuk_check_boxes_fieldset :language_ids,
+      legend: { hidden: true, text: t("course_wizard.steps.modern_languages_specialisms.heading") },
+      hint: { text: t("course_wizard.steps.modern_languages_specialisms.hint") } do %>
+  <% current_step.modern_languages.each_with_index do |language, index| %>
+    <%= form.govuk_check_box :language_ids,
+          language.id.to_s,
+          label: { text: language.subject_name },
+          include_hidden: false,
+          link_errors: index.zero? %>
+  <% end %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.modern_languages_specialisms.submit") %>

--- a/app/views/publish/course_wizards/steps/_physics_specialisms.html.erb
+++ b/app/views/publish/course_wizards/steps/_physics_specialisms.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.physics_specialisms.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.physics_specialisms.caption")) %>
+  <%= t("course_wizard.steps.physics_specialisms.heading") %>
+</h1>
+
+<p class="govuk-body"><%= t("course_wizard.steps.physics_specialisms.programme_description") %></p>
+
+<%= form.govuk_radio_buttons_fieldset :campaign_name, legend: { text: t("course_wizard.steps.physics_specialisms.question") } do %>
+  <%= form.govuk_radio_button :campaign_name, "engineers_teach_physics", label: { text: t("course_wizard.steps.physics_specialisms.options.engineers_teach_physics.label") } %>
+  <%= form.govuk_radio_button :campaign_name, "no_campaign", label: { text: t("course_wizard.steps.physics_specialisms.options.no_campaign.label") } %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.physics_specialisms.submit") %>

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -15,6 +15,9 @@ class CourseWizard
            :fee_based?,
            :skilled_worker_visa_sponsorship_required?,
            :deadline_for_application_visa_sponsorship_required?,
+           :design_technology_specialisms?,
+           :physics_specialisms?,
+           :modern_languages_specialisms?,
            to: :state_store
 
   def steps_processor
@@ -24,6 +27,12 @@ class CourseWizard
       graph.add_node :level, Steps::Level
       graph.add_node :primary_subjects, Steps::PrimarySubjects
       graph.add_node :secondary_subjects, Steps::SecondarySubjects
+
+      # Secondary Subject specialist flows
+      graph.add_node :design_technology_specialisms, Steps::DesignTechnologySpecialisms
+      graph.add_node :physics_specialisms, Steps::PhysicsSpecialisms
+      graph.add_node :modern_languages_specialisms, Steps::ModernLanguagesSpecialisms
+
       graph.add_node :age_range, Steps::AgeRange
       graph.add_node :qualifications, Steps::Qualifications
       graph.add_node :funding_type, Steps::FundingType
@@ -49,6 +58,35 @@ class CourseWizard
       )
 
       graph.add_multiple_conditional_edges(
+        from: :secondary_subjects,
+        branches: [
+          { when: :physics_specialisms?, then: :physics_specialisms },
+          { when: :modern_languages_specialisms?, then: :modern_languages_specialisms },
+          { when: :design_technology_specialisms?, then: :design_technology_specialisms },
+        ],
+        default: :age_range,
+      )
+
+      graph.add_multiple_conditional_edges(
+        from: :physics_specialisms,
+        branches: [
+          { when: :modern_languages_specialisms?, then: :modern_languages_specialisms },
+          { when: :design_technology_specialisms?, then: :design_technology_specialisms },
+        ],
+        default: :age_range,
+      )
+
+      graph.add_multiple_conditional_edges(
+        from: :modern_languages_specialisms,
+        branches: [
+          { when: :design_technology_specialisms?, then: :design_technology_specialisms },
+        ],
+        default: :age_range,
+      )
+
+      graph.add_edge from: :design_technology_specialisms, to: :age_range
+
+      graph.add_multiple_conditional_edges(
         from: :qualifications,
         branches: [
           { when: :undergraduate_degree_with_qts?, then: :schools },
@@ -57,7 +95,6 @@ class CourseWizard
       )
 
       graph.add_edge from: :primary_subjects, to: :age_range
-      graph.add_edge from: :secondary_subjects, to: :age_range
 
       graph.add_edge from: :age_range, to: :qualifications
 

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -37,6 +37,30 @@ class CourseWizard
       def deadline_for_application_visa_sponsorship_required?
         ActiveModel::Type::Boolean.new.cast(visa_sponsorship_application_deadline_required)
       end
+
+      def design_technology_specialisms?
+        secondary_subject_selected?(SecondarySubject.design_technology&.id)
+      end
+
+      def physics_specialisms?
+        secondary_subject_selected?(SecondarySubject.physics&.id)
+      end
+
+      def modern_languages_specialisms?
+        secondary_subject_selected?(SecondarySubject.modern_languages&.id)
+      end
+
+    private
+
+      def secondary_subject_selected?(subject_id)
+        return false if subject_id.blank?
+
+        selected_secondary_subject_ids.include?(subject_id.to_s)
+      end
+
+      def selected_secondary_subject_ids
+        [secondary_master_subject_id, subordinate_subject_id].compact_blank.map(&:to_s)
+      end
     end
   end
 end

--- a/app/wizards/course_wizard/steps/design_technology_specialisms.rb
+++ b/app/wizards/course_wizard/steps/design_technology_specialisms.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class DesignTechnologySpecialisms
+      include DfE::Wizard::Step
+
+      attribute :design_technology_ids
+
+      validate :specialisms_selected
+
+      def design_technologies
+        DesignTechnologySubject.all.sort_by(&:subject_name)
+      end
+
+      def self.permitted_params
+        [{ design_technology_ids: [] }]
+      end
+
+    private
+
+      def specialisms_selected
+        return if selected_specialism_ids.any?
+
+        errors.add(:design_technology_ids, I18n.t("course_wizard.steps.design_technology_specialisms.errors.design_technology_ids.blank"))
+      end
+
+      def selected_specialism_ids
+        Array(design_technology_ids).compact_blank
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/modern_languages_specialisms.rb
+++ b/app/wizards/course_wizard/steps/modern_languages_specialisms.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class ModernLanguagesSpecialisms
+      include DfE::Wizard::Step
+
+      attribute :language_ids
+
+      validate :languages_selected
+
+      def modern_languages
+        ModernLanguagesSubject.all.sort_by(&:subject_name)
+      end
+
+      def self.permitted_params
+        [{ language_ids: [] }]
+      end
+
+    private
+
+      def languages_selected
+        return if selected_language_ids.any?
+
+        errors.add(:language_ids, I18n.t("course_wizard.steps.modern_languages_specialisms.errors.language_ids.blank"))
+      end
+
+      def selected_language_ids
+        Array(language_ids).compact_blank
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/physics_specialisms.rb
+++ b/app/wizards/course_wizard/steps/physics_specialisms.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class PhysicsSpecialisms
+      include DfE::Wizard::Step
+
+      CAMPAIGN_NAMES = Course.campaign_names.keys.freeze
+
+      attribute :campaign_name, :string
+
+      validates :campaign_name,
+                inclusion: { in: CAMPAIGN_NAMES, message: I18n.t("course_wizard.steps.physics_specialisms.errors.campaign_name.blank") }
+
+      def self.permitted_params
+        [:campaign_name]
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/secondary_subjects.rb
+++ b/app/wizards/course_wizard/steps/secondary_subjects.rb
@@ -14,7 +14,7 @@ class CourseWizard
       validate :validate_secondary_master_subject_id_is_not_same_as_subordinate_subject_id
 
       def selectable_subjects
-        SubjectsCache.new.secondary_subjects.map { |subject| [subject.subject_name, subject.id] }
+        SecondarySubject.order(:subject_name).map { |subject| [subject.subject_name, subject.id] }
       end
 
       def self.permitted_params

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -41,6 +41,36 @@ en:
           secondary_master_subject_id:
             blank: Select a subject
             same_as_subordinate_subject_id: The second subject must be different to the first subject
+      physics_specialisms:
+        caption: Add course
+        heading: Engineers Teach Physics
+        programme_description: Engineers Teach Physics is a new campaign to help engineers become physics teachers.
+        question: Is this course part of the Engineers Teach Physics programme?
+        submit: Continue
+        options:
+          engineers_teach_physics:
+            label: "Yes"
+          no_campaign:
+            label: "No"
+        errors:
+          campaign_name:
+            blank: Select if this course is part of the Engineers teach physics programme
+      modern_languages_specialisms:
+        caption: Add course
+        heading: Languages
+        hint: Select all that apply
+        submit: Continue
+        errors:
+          language_ids:
+            blank: Select at least one language
+      design_technology_specialisms:
+        caption: Add course
+        heading: Specialisms
+        hint: Select all that apply
+        submit: Continue
+        errors:
+          design_technology_ids:
+            blank: Select at least one specialism
       age_range:
         caption: Add course
         heading: Age range

--- a/spec/support/shared_contexts/add_course_wizard.rb
+++ b/spec/support/shared_contexts/add_course_wizard.rb
@@ -13,6 +13,10 @@ RSpec.shared_context "add_course_wizard" do
     end
   end
 
+  before do
+    SecondarySubject.clear_cache
+  end
+
   let(:repository) { DfE::Wizard::Repository::InMemory.new }
   let(:state_store) { CourseWizard::StateStores::CourseWizardStore.new(repository:) }
   let(:current_step) { :level }

--- a/spec/system/publish/courses/add_course_wizard/subjects_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/subjects_spec.rb
@@ -43,6 +43,88 @@ RSpec.describe "Add course wizard subjects step", type: :system do
     then_i_should_see_a_duplicate_master_and_subordinate_subject_error
   end
 
+  scenario "physics and modern languages selections show both specialism pages before age range" do
+    and_i_have_wizard_state_for_specialism_flow(master: :physics, subordinate: :modern_languages)
+    when_i_visit_the_wizard_step(:physics_specialisms)
+    then_i_am_taken_to_the_physics_specialisms_page
+
+    and_i_select_engineers_teach_physics_option
+    and_i_click_continue
+    then_i_am_taken_to_the_modern_languages_specialisms_page
+
+    and_i_select_a_modern_language
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+  end
+
+  scenario "physics only selection shows physics specialisms then age range" do
+    and_i_have_wizard_state_for_specialism_flow(master: :physics)
+    when_i_visit_the_wizard_step(:physics_specialisms)
+    then_i_am_taken_to_the_physics_specialisms_page
+
+    and_i_select_engineers_teach_physics_option
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+  end
+
+  scenario "modern languages only selection shows modern languages specialisms then age range" do
+    and_i_have_wizard_state_for_specialism_flow(master: :modern_languages)
+    when_i_visit_the_wizard_step(:modern_languages_specialisms)
+    then_i_am_taken_to_the_modern_languages_specialisms_page
+
+    and_i_select_a_modern_language
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+  end
+
+  scenario "design technology only selection shows design technology specialisms then age range" do
+    and_i_have_wizard_state_for_specialism_flow(master: :design_and_technology)
+    when_i_visit_the_wizard_step(:design_technology_specialisms)
+    then_i_am_taken_to_the_design_technology_specialisms_page
+
+    and_i_select_a_design_technology_specialism
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+  end
+
+  scenario "modern languages and design technology selections show both specialism pages before age range" do
+    and_i_have_wizard_state_for_specialism_flow(master: :modern_languages, subordinate: :design_and_technology)
+    when_i_visit_the_wizard_step(:modern_languages_specialisms)
+    then_i_am_taken_to_the_modern_languages_specialisms_page
+
+    and_i_select_a_modern_language
+    and_i_click_continue
+    then_i_am_taken_to_the_design_technology_specialisms_page
+
+    and_i_select_a_design_technology_specialism
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+  end
+
+  scenario "physics and design technology selections show both specialism pages before age range" do
+    and_i_have_wizard_state_for_specialism_flow(master: :physics, subordinate: :design_and_technology)
+    when_i_visit_the_wizard_step(:physics_specialisms)
+    then_i_am_taken_to_the_physics_specialisms_page
+
+    and_i_select_engineers_teach_physics_option
+    and_i_click_continue
+    then_i_am_taken_to_the_design_technology_specialisms_page
+
+    and_i_select_a_design_technology_specialism
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+  end
+
+  scenario "modern languages other selection shows modern languages specialisms then age range" do
+    and_i_have_wizard_state_for_specialism_flow(master: :modern_languages_other)
+    when_i_visit_the_wizard_step(:modern_languages_specialisms)
+    then_i_am_taken_to_the_modern_languages_specialisms_page
+
+    and_i_select_a_modern_language
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+  end
+
 private
 
   def given_i_am_authenticated_as_a_provider_user_with_a_school
@@ -93,12 +175,26 @@ private
     click_on "Continue"
   end
 
+  def when_i_visit_the_wizard_step(step_name)
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: step_name,
+      state_key: wizard_state_key,
+    )
+  end
+
   def and_i_choose_primary_subject
     choose primary_subject.subject_name
   end
 
   def and_i_choose_secondary_subject
     select secondary_subject.subject_name, from: "First subject"
+  end
+
+  def and_i_choose_secondary_subject_pair(first:, second:)
+    select first, from: "First subject"
+    select second, from: "Second subject (optional)"
   end
 
   def and_i_click_continue
@@ -114,6 +210,70 @@ private
         state_key: wizard_state_key,
       ),
       ignore_query: true,
+    )
+  end
+
+  def then_i_am_taken_to_the_physics_specialisms_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        step: :physics_specialisms,
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_am_taken_to_the_modern_languages_specialisms_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        step: :modern_languages_specialisms,
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_am_taken_to_the_design_technology_specialisms_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        step: :design_technology_specialisms,
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def and_i_select_engineers_teach_physics_option
+    choose "Yes"
+  end
+
+  def and_i_select_a_modern_language
+    page.find(".govuk-checkboxes__input", visible: :all, match: :first).set(true)
+  end
+
+  def and_i_select_a_design_technology_specialism
+    page.find(".govuk-checkboxes__input", visible: :all, match: :first).set(true)
+  end
+
+  def and_i_have_wizard_state_for_specialism_flow(master:, subordinate: nil)
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
+    state_store.write(
+      level: "secondary",
+      secondary_master_subject_id: course_subject(master).id.to_s,
+      subordinate_subject_id: subordinate.present? ? course_subject(subordinate).id.to_s : nil,
     )
   end
 
@@ -133,6 +293,21 @@ private
 
   def secondary_subject
     @secondary_subject ||= find_or_create(:secondary_subject, :business_studies)
+  end
+
+  def course_subject(subject_key)
+    case subject_key
+    when :physics
+      find_or_create(:secondary_subject, :physics)
+    when :modern_languages
+      find_or_create(:secondary_subject, :modern_languages)
+    when :modern_languages_other
+      find_or_create(:modern_languages_subject, :modern_languages_other)
+    when :design_and_technology
+      find_or_create(:secondary_subject, :design_and_technology)
+    else
+      raise "Unknown subject key: #{subject_key}"
+    end
   end
 
   def provider

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "can_sponsor_skilled_worker_visa" => true })
       repository.write({ "visa_sponsorship_application_deadline_required" => true })
       repository.write({ "visa_sponsorship_application_deadline_at" => visa_deadline_payload })
+      repository.write({ "design_technology_ids" => %w[1 2] })
+      repository.write({ "campaign_name" => "engineers_teach_physics" })
+      repository.write({ "language_ids" => %w[5 6] })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -55,6 +58,9 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:can_sponsor_skilled_worker_visa]).to be(true)
       expect(data[:visa_sponsorship_application_deadline_required]).to be(true)
       expect(data[:visa_sponsorship_application_deadline_at]).to eq(visa_deadline_payload)
+      expect(data[:design_technology_ids]).to eq(%w[1 2])
+      expect(data[:campaign_name]).to eq("engineers_teach_physics")
+      expect(data[:language_ids]).to eq(%w[5 6])
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/steps/design_technology_specialisms_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/design_technology_specialisms_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::DesignTechnologySpecialisms do
+  subject(:wizard_step) { described_class.new }
+
+  describe "#valid?" do
+    context "when at least one specialism is selected" do
+      it "is valid" do
+        wizard_step.design_technology_ids = %w[1]
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context "when no specialism is selected" do
+      it "is not valid" do
+        wizard_step.design_technology_ids = []
+        expect(wizard_step).not_to be_valid
+      end
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq([{ design_technology_ids: [] }])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/modern_languages_specialisms_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/modern_languages_specialisms_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::ModernLanguagesSpecialisms do
+  subject(:wizard_step) { described_class.new }
+
+  describe "#valid?" do
+    context "when at least one language is selected" do
+      it "is valid" do
+        wizard_step.language_ids = %w[1]
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context "when no language is selected" do
+      it "is not valid" do
+        wizard_step.language_ids = []
+        expect(wizard_step).not_to be_valid
+      end
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq([{ language_ids: [] }])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/physics_specialisms_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/physics_specialisms_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::PhysicsSpecialisms do
+  subject(:wizard_step) { described_class.new }
+
+  describe "#valid?" do
+    context "when campaign_name is selected as engineers teach physics" do
+      it "is valid" do
+        wizard_step.campaign_name = "engineers_teach_physics"
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context "when campaign_name is selected as no campaign" do
+      it "is valid" do
+        wizard_step.campaign_name = "no_campaign"
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context "when campaign_name is blank" do
+      it "is not valid" do
+        wizard_step.campaign_name = nil
+        expect(wizard_step).not_to be_valid
+      end
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq([:campaign_name])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -50,6 +50,155 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
   context "from secondary subjects" do
     let(:current_step) { :secondary_subjects }
 
+    before do
+      state_store.write(level: "secondary", is_send: false)
+    end
+
+    it "proceeds to age range page" do
+      expect(wizard).to have_next_step(:age_range)
+    end
+
+    context "when physics is selected as first subject" do
+      before do
+        state_store.write(secondary_master_subject_id: find_or_create(:secondary_subject, :physics).id.to_s)
+      end
+
+      it "proceeds to physics specialisms page" do
+        expect(wizard).to have_next_step(:physics_specialisms)
+      end
+    end
+
+    context "when modern languages is selected as second subject" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :business_studies).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s,
+        )
+      end
+
+      it "proceeds to modern languages specialisms page" do
+        expect(wizard).to have_next_step(:modern_languages_specialisms)
+      end
+    end
+
+    context "when design and technology is selected as second subject" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :business_studies).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :design_and_technology).id.to_s,
+        )
+      end
+
+      it "proceeds to design technology specialisms page" do
+        expect(wizard).to have_next_step(:design_technology_specialisms)
+      end
+    end
+
+    context "when physics and modern languages are both selected" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :physics).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s,
+        )
+      end
+
+      it "proceeds to physics specialisms first" do
+        expect(wizard).to have_next_step(:physics_specialisms)
+      end
+    end
+
+    context "when modern languages and design and technology are both selected" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :design_and_technology).id.to_s,
+        )
+      end
+
+      it "proceeds to modern languages specialisms first" do
+        expect(wizard).to have_next_step(:modern_languages_specialisms)
+      end
+    end
+  end
+
+  context "from physics specialisms" do
+    let(:current_step) { :physics_specialisms }
+
+    before do
+      state_store.write(level: "secondary", is_send: false)
+    end
+
+    context "when modern languages is selected" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :physics).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s,
+        )
+      end
+
+      it "proceeds to modern languages specialisms page" do
+        expect(wizard).to have_next_step(:modern_languages_specialisms)
+      end
+    end
+
+    context "when design and technology is selected without modern languages" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :physics).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :design_and_technology).id.to_s,
+        )
+      end
+
+      it "proceeds to design technology specialisms page" do
+        expect(wizard).to have_next_step(:design_technology_specialisms)
+      end
+    end
+
+    context "when no further specialism pages apply" do
+      before do
+        state_store.write(secondary_master_subject_id: find_or_create(:secondary_subject, :physics).id.to_s)
+      end
+
+      it "proceeds to age range page" do
+        expect(wizard).to have_next_step(:age_range)
+      end
+    end
+  end
+
+  context "from modern languages specialisms" do
+    let(:current_step) { :modern_languages_specialisms }
+
+    before do
+      state_store.write(level: "secondary", is_send: false)
+    end
+
+    context "when design and technology is selected" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :design_and_technology).id.to_s,
+        )
+      end
+
+      it "proceeds to design technology specialisms page" do
+        expect(wizard).to have_next_step(:design_technology_specialisms)
+      end
+    end
+
+    context "when no further specialism pages apply" do
+      before do
+        state_store.write(secondary_master_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s)
+      end
+
+      it "proceeds to age range page" do
+        expect(wizard).to have_next_step(:age_range)
+      end
+    end
+  end
+
+  context "from design technology specialisms" do
+    let(:current_step) { :design_technology_specialisms }
+
     it "proceeds to age range page" do
       expect(wizard).to have_next_step(:age_range)
     end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -33,6 +33,94 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
     end
   end
 
+  context "from physics specialisms" do
+    let(:current_step) { :physics_specialisms }
+
+    before do
+      state_store.write(level: "secondary", is_send: false)
+      state_store.write(secondary_master_subject_id: find_or_create(:secondary_subject, :physics).id.to_s)
+    end
+
+    it "goes back to secondary subjects" do
+      expect(wizard).to have_previous_step(:secondary_subjects)
+    end
+  end
+
+  context "from modern languages specialisms" do
+    let(:current_step) { :modern_languages_specialisms }
+
+    before do
+      state_store.write(level: "secondary", is_send: false)
+    end
+
+    context "when physics is also selected" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :physics).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s,
+        )
+      end
+
+      it "goes back to physics specialisms" do
+        expect(wizard).to have_previous_step(:physics_specialisms)
+      end
+    end
+
+    context "when physics is not selected" do
+      before do
+        state_store.write(secondary_master_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s)
+      end
+
+      it "goes back to secondary subjects" do
+        expect(wizard).to have_previous_step(:secondary_subjects)
+      end
+    end
+  end
+
+  context "from design technology specialisms" do
+    let(:current_step) { :design_technology_specialisms }
+
+    before do
+      state_store.write(level: "secondary", is_send: false)
+    end
+
+    context "when modern languages is also selected" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :modern_languages).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :design_and_technology).id.to_s,
+        )
+      end
+
+      it "goes back to modern languages specialisms" do
+        expect(wizard).to have_previous_step(:modern_languages_specialisms)
+      end
+    end
+
+    context "when physics is also selected and modern languages is not selected" do
+      before do
+        state_store.write(
+          secondary_master_subject_id: find_or_create(:secondary_subject, :physics).id.to_s,
+          subordinate_subject_id: find_or_create(:secondary_subject, :design_and_technology).id.to_s,
+        )
+      end
+
+      it "goes back to physics specialisms" do
+        expect(wizard).to have_previous_step(:physics_specialisms)
+      end
+    end
+
+    context "when design technology is selected on its own" do
+      before do
+        state_store.write(secondary_master_subject_id: find_or_create(:secondary_subject, :design_and_technology).id.to_s)
+      end
+
+      it "goes back to secondary subjects" do
+        expect(wizard).to have_previous_step(:secondary_subjects)
+      end
+    end
+  end
+
   context "from age range with primary level" do
     let(:current_step) { :age_range }
 


### PR DESCRIPTION
## Context

The latest change (`Implement Special Secondary Subjects steps`) adds specialist-subject routing to the new course wizard so it behaves like the legacy add-course flow.

The main behavior change is that secondary subject choices can now trigger one or more intermediate specialist pages before reaching age range, including combinations (for example Physics + Modern Languages). It also handles Modern Languages variants such as `Modern languages (other)` so that branch is not skipped.

## Changes proposed in this pull request

- Added specialist branching in `CourseWizard` after `secondary_subjects` for:
  - `physics_specialisms`
  - `modern_languages_specialisms`
  - `design_technology_specialisms`
- Added multi-step sequencing so applicable specialist pages are shown in order before `age_range`.
- Implemented missing specialist wizard steps:
  - `CourseWizard::Steps::PhysicsSpecialisms`
  - `CourseWizard::Steps::ModernLanguagesSpecialisms`
  - `CourseWizard::Steps::DesignTechnologySpecialisms`
- Added new specialist step partials for the wizard UI.
- Added/updated locale entries for specialist headings, hints, options, and errors.
- Updated state-store specialist predicates to correctly detect:
  - master/subordinate secondary subject selections
  - Modern Languages specialist variants (including `Modern languages (other)`).
- Added regression coverage:
  - wizard `next_step` and `previous_step` specs for single/combined specialist flows
  - system specs covering individual specialist pages and combinations.

## Guidance to review

- Review `CourseWizard` graph transitions first to confirm intended navigation order.
- Validate state-store predicate logic for secondary subject IDs and Modern Languages variants.
- Run and review key specs:
  - `bundle exec rspec spec/wizards/add_course_wizard/wizard/next_step_spec.rb`
  - `bundle exec rspec spec/wizards/add_course_wizard/wizard/previous_step_spec.rb`
  - `bundle exec rspec spec/system/publish/courses/add_course_wizard/subjects_spec.rb`

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.