### PR TITLE
Double the number of web pods in production from 6 to 12

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -8,7 +8,7 @@
   "resource_group_name": "s189p01-ptt-pd-rg",
   "main_app": {
     "main": {
-      "replicas": 6,
+      "replicas": 12,
       "max_memory": "4Gi"
     }
   },


### PR DESCRIPTION
## Context

Increase number of pods from 6 to 12.

50 max connections per pod in our current configuration.

(12 web and 2 workers)
14 * 50 = 700 threads



## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
