### PR TITLE
2825 - Enable Postgres WAL in Sandbox

### DIFF
--- a/terraform/aks/workspace_variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox.tfvars.json
@@ -25,5 +25,8 @@
   ],
   "enable_monitoring": true,
   "enable_logit": true,
-  "statuscake_contact_groups": [324594]
+  "statuscake_contact_groups": [
+    324594
+  ],
+  "pg_airbyte_enabled": true
 }


### PR DESCRIPTION
### Context

Add Postgres logical replication to Sandbox Postgres, which is a pre-requisite for Airbyte.
Note that this will trigger several restarts of the Sandbox Postgres server.

### Changes proposed in this pull request

Add pg_airbyte_enabled: true to for the sandbox environment.

### Guidance to review

make sandbox deploy-plan
make staging deploy-plan (no change) 

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
