### PR TITLE
Add confirm production env var in maintenence github workflows

### DIFF
--- a/.github/workflows/disable-maintenance.yml
+++ b/.github/workflows/disable-maintenance.yml
@@ -11,6 +11,11 @@ on:
         - production
         - sandbox
         - staging
+      confirm_production:
+        description: Confirm production deployment
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -38,6 +43,12 @@ jobs:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+
+    - name: Confirm production
+      if: ${{ inputs.environment == 'production' && !inputs.confirm_production }}
+      run: |
+        echo "Production maintenance requires confirm_production to be selected."
+        exit 1
 
     - name: Disable maintenance app
       run: make ${{ inputs.environment }} disable-maintenance

--- a/.github/workflows/enable-maintenance.yml
+++ b/.github/workflows/enable-maintenance.yml
@@ -11,6 +11,12 @@ on:
         - production
         - sandbox
         - staging
+      confirm_production:
+        description: Confirm production deployment
+        required: false
+        type: boolean
+        default: false
+
 
 permissions:
   id-token: write
@@ -48,7 +54,14 @@ jobs:
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
 
+    - name: Confirm production
+      if: ${{ inputs.environment == 'production' && !inputs.confirm_production }}
+      run: |
+        echo "Production maintenance requires confirm_production to be selected."
+        exit 1
+
     - name: Deploy maintenance app
       run: make ${{ inputs.environment }} maintenance-fail-over
       env:
         MAINTENANCE_IMAGE_TAG: ${{steps.build-image.outputs.tag}}
+        CONFIRM_PRODUCTION: ${{ inputs.confirm_production && 'yes' || '' }}


### PR DESCRIPTION
## Context

  - In order to run enable/disable maintenence workflows in production the environment needs the CONFIRM_PRODUCTION variable set to true

 Co-authored-by: Simon L <simon.lange@education.gov.uk>


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
