### PR TITLE
Add SalaryFees json column to the course enrichment

### DIFF
--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -41,6 +41,7 @@ module CoursePreview
     def financial_support_link = fields_fees_and_financial_support_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
     def where_you_will_train_link = fields_where_you_will_train_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
     def provider_train_with_disability_link = edit_publish_provider_recruitment_cycle_disability_support_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true)
+    def salary_fee_details_link = salary_fees_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)
     def train_with_us_link = edit_publish_provider_recruitment_cycle_why_train_with_us_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true)
     def train_with_disability_link = edit_publish_provider_recruitment_cycle_disability_support_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true)
   end

--- a/app/controllers/publish/courses/salary_fees_controller.rb
+++ b/app/controllers/publish/courses/salary_fees_controller.rb
@@ -49,7 +49,7 @@ module Publish
         @previous_cycle_enrichment ||= course.recruitment_cycle.previous&.providers&.find_by(
           provider_code: @provider.provider_code,
         )&.courses&.find_by(
-          course_code: course_enrichment.course.course_code,
+          course_code: course.course_code,
         )&.enrichments&.where(
           status: "published",
         )&.last

--- a/app/controllers/publish/courses/salary_fees_controller.rb
+++ b/app/controllers/publish/courses/salary_fees_controller.rb
@@ -14,7 +14,7 @@ module Publish
         @course_salary_fees_form = ::Publish::CourseSalaryFeesForm.new(course_enrichment, params: form_params)
 
         if @course_salary_fees_form.save!
-          course_updated_message I18n.t("publish.providers.course_salary_fees.edit.course_salary_fee")
+          course_updated_message t(".course_salary_fee")
 
           redirect_to publish_provider_recruitment_cycle_course_path(
             provider.provider_code,

--- a/app/controllers/publish/courses/salary_fees_controller.rb
+++ b/app/controllers/publish/courses/salary_fees_controller.rb
@@ -3,11 +3,15 @@
 module Publish
   module Courses
     class SalaryFeesController < ApplicationController
+      include CopyCourseContent
+
       before_action :previous_cycle_enrichment, only: :edit
 
       def edit
         @course_salary_fees_form = ::Publish::CourseSalaryFeesForm.new(course_enrichment)
         @course_salary_fees_form.valid? if show_errors_on_publish?
+        @copied_fields = copy_content_check(::Courses::Copy::SALARY_FEES_FIELDS)
+        @copied_fields_values = copied_fields_values if @copied_fields.present?
       end
 
       def update
@@ -22,6 +26,7 @@ module Publish
             course.course_code,
           )
         else
+          fetch_course_list_to_copy_from
           render :edit
         end
       end

--- a/app/controllers/publish/courses/salary_fees_controller.rb
+++ b/app/controllers/publish/courses/salary_fees_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    class SalaryFeesController < ApplicationController
+      before_action :previous_cycle_enrichment, only: :edit
+
+      def edit
+        @course_salary_fees_form = ::Publish::CourseSalaryFeesForm.new(course_enrichment)
+        @course_salary_fees_form.valid? if show_errors_on_publish?
+      end
+
+      def update
+        @course_salary_fees_form = ::Publish::CourseSalaryFeesForm.new(course_enrichment, params: form_params)
+
+        if @course_salary_fees_form.save!
+          course_updated_message I18n.t("publish.providers.course_salary_fees.edit.course_salary_fee")
+
+          redirect_to publish_provider_recruitment_cycle_course_path(
+            provider.provider_code,
+            recruitment_cycle.year,
+            course.course_code,
+          )
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def form_params
+        params.require(:publish_course_salary_fees_form).permit(:salary_fee_details)
+      end
+
+      def course
+        @course ||= provider.courses.find_by!(course_code: params[:code])
+      end
+
+      def course_enrichment
+        @course_enrichment ||= course.enrichments.find_or_initialize_draft
+      end
+
+      def previous_cycle_enrichment
+        @previous_cycle_enrichment ||= course.recruitment_cycle.previous&.providers&.find_by(
+          provider_code: @provider.provider_code,
+        )&.courses&.find_by(
+          course_code: course_enrichment.course.course_code,
+        )&.enrichments&.where(
+          status: "published",
+        )&.last
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/salary_fees_controller.rb
+++ b/app/controllers/publish/courses/salary_fees_controller.rb
@@ -4,6 +4,7 @@ module Publish
   module Courses
     class SalaryFeesController < ApplicationController
       include CopyCourseContent
+      include GotoPreview
 
       before_action :previous_cycle_enrichment, only: :edit
 
@@ -20,11 +21,19 @@ module Publish
         if @course_salary_fees_form.save!
           course_updated_message t(".course_salary_fee")
 
-          redirect_to publish_provider_recruitment_cycle_course_path(
-            provider.provider_code,
-            recruitment_cycle.year,
-            course.course_code,
-          )
+          if goto_preview?
+            redirect_to preview_publish_provider_recruitment_cycle_course_path(
+              provider.provider_code,
+              recruitment_cycle.year,
+              course.course_code,
+            )
+          else
+            redirect_to publish_provider_recruitment_cycle_course_path(
+              provider.provider_code,
+              recruitment_cycle.year,
+              course.course_code,
+            )
+          end
         else
           fetch_course_list_to_copy_from
           render :edit
@@ -53,6 +62,10 @@ module Publish
         )&.enrichments&.where(
           status: "published",
         )&.last
+      end
+
+      def param_form_key
+        :publish_course_salary_fees_form
       end
     end
   end

--- a/app/controllers/publish/providers/course_fields/disability_support_controller.rb
+++ b/app/controllers/publish/providers/course_fields/disability_support_controller.rb
@@ -36,7 +36,7 @@ module Publish
       private
 
         def last_cycle_provider
-          @last_cycle_provider ||= RecruitmentCycle.current.previous&.providers&.find_by(provider_code: @provider.provider_code)
+          @last_cycle_provider ||= @provider.recruitment_cycle.previous&.providers&.find_by(provider_code: @provider.provider_code)
         end
 
         def redirect_params

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -237,6 +237,7 @@ class CourseDecorator < ApplicationDecorator
     placement_school_activities
     support_and_mentorship
     salary_details
+    salary_fee_details
     interview_process
     duration_per_school
     how_school_placements_work

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -436,7 +436,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def show_school_experience?
-    recruitment_cycle_after_2026?
+    recruitment_cycle_after?(2026)
   end
 
   def visa_sponsorship_deadline_required

--- a/app/forms/publish/course_salary_fees_form.rb
+++ b/app/forms/publish/course_salary_fees_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Publish
+  class CourseSalaryFeesForm < BaseModelForm
+    alias_method :course_enrichment, :model
+
+    FIELDS = %i[salary_fee_details].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :salary_fee_details, words_count: { maximum: 250, message: :too_long }
+
+  private
+
+    def declared_fields
+      FIELDS
+    end
+
+    def compute_fields
+      model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -128,7 +128,7 @@ class Course < ApplicationRecord
   has_many :gias_schools, through: :schools
 
   delegate :recruitment_cycle, :provider_name, :provider_code, to: :provider, allow_nil: true
-  delegate :after_2021?, :after_2026?, :year, :rollover_period_2026?, to: :recruitment_cycle, allow_nil: true, prefix: :recruitment_cycle
+  delegate :after?, :after_2021?, :year, :rollover_period_2026?, to: :recruitment_cycle, allow_nil: true, prefix: :recruitment_cycle
 
   def set_subject_position(course_subject)
     return if course_subject.position.present?

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -23,6 +23,7 @@ class CourseEnrichment < ApplicationRecord
                  personal_qualities: [:string, { store_key: "PersonalQualities" }],
                  required_qualifications: [:string, { store_key: "Qualifications" }],
                  salary_details: [:string, { store_key: "SalaryDetails" }],
+                 salary_fee_details: [:string, { store_key: "SalaryFeeDetails" }],
                  placement_selection_criteria: [:string, { store_key: "PlacementSelectionCriteria" }],
                  duration_per_school: [:string, { store_key: "DurationPerSchool" }],
                  theoretical_training_location: [:string, { store_key: "TheoreticalTrainingLocation" }],

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -144,7 +144,7 @@ class RecruitmentCycle < ApplicationRecord
     year.to_i > 2025
   end
 
-  def after_2026?
-    year.to_i > 2026
+  def after?(target_year)
+    year.to_i > target_year
   end
 end

--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -52,6 +52,10 @@ module Courses
       ["Salary details", "salary_details"],
     ].freeze
 
+    SALARY_FEES_FIELDS = [
+      %w[Fees salary_fee_details],
+    ].freeze
+
     WHAT_YOU_WILL_STUDY_FIELDS = [
       ["What will trainees do during their theoretical training?", "theoretical_training_activities"],
       ["How will they be assessed?", "assessment_methods"],

--- a/app/views/find/courses/_components.html.erb
+++ b/app/views/find/courses/_components.html.erb
@@ -35,7 +35,7 @@
 
 <%# Where you will train %>
 <% if published_where_you_will_train_present?(course) || preview?(params) %>
-    <%= render partial: "find/courses/where_you_will_train", locals: { course: course, enrichment: @enrichment } %>
+  <%= render partial: "find/courses/where_you_will_train", locals: { course: course, enrichment: @enrichment } %>
 <% end %>
 
 <%# What you will do on school placements %>
@@ -62,9 +62,10 @@
     <%= t("find.courses.show.training_with_disabilities") %>
   </h2>
 
-  <% if preview?(params) %>
-    <p class="govuk-body govuk-!-margin-bottom-8">
-    <%= govuk_link_to(
+  <p class="govuk-body govuk-!-margin-bottom-8">
+    <% if preview?(params) %>
+
+      <%= govuk_link_to(
       t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
       training_with_disabilities_publish_provider_recruitment_cycle_course_path(
         course.provider_code,
@@ -72,16 +73,17 @@
         course.course_code,
       ),
     ) %>
-    </p>
-  <% else %>
-    <p class="govuk-body govuk-!-margin-bottom-8">
-    <%= govuk_link_to(
+
+    <% else %>
+
+      <%= govuk_link_to(
       t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
       find_track_click_path(url: find_training_with_disabilities_path(
         course.provider_code,
         course.course_code,
       )),
     ) %>
-    </p>
-  <% end %>
+
+    <% end %>
+  </p>
 <% end %>

--- a/app/views/find/courses/_salary.html.erb
+++ b/app/views/find/courses/_salary.html.erb
@@ -1,6 +1,8 @@
 <% if course.recruitment_cycle_after?(2026) %>
   <% if course.salary_fee_details.present? %>
     <%= markdown(course.salary_fee_details) %>
+  <% else %>
+    <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :salary_fee_details, is_preview: preview?(params)) %>
   <% end %>
 <% else %>
   <% if course.salary_details.present? %>

--- a/app/views/find/courses/_salary.html.erb
+++ b/app/views/find/courses/_salary.html.erb
@@ -1,3 +1,9 @@
-<% if course.salary_details.present? %>
-  <%= markdown(course.salary_details) %>
+<% if course.recruitment_cycle_after?(2026) %>
+  <% if course.salary_fee_details.present? %>
+    <%= markdown(course.salary_fee_details) %>
+  <% end %>
+<% else %>
+  <% if course.salary_details.present? %>
+    <%= markdown(course.salary_details) %>
+  <% end %>
 <% end %>

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -32,7 +32,7 @@
       summary_list,
       :course,
       t("publish.providers.courses.description_content.salary_fee_details_label"),
-      value_provided?(course.salary_fee_details),
+      value_provided?(markdown(course.salary_fee_details)),
       %w[salary_fee_details],
       action_path: salary_fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code),
     ) %>

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -27,7 +27,17 @@
   <% if course.fee_based? %>
     <%= render partial: "publish/courses/fees_and_financial_support", locals: { course: course, summary_list: summary_list } %>
   <% else %>
-    <% enrichment_summary(
+    <% if course.recruitment_cycle_after?(2026) %>
+      <% enrichment_summary(
+      summary_list,
+      :course,
+      t("publish.providers.courses.description_content.salary_fee_details_label"),
+      value_provided?(course.salary_fee_details),
+      %w[salary_fee_details],
+      action_path: salary_fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code),
+    ) %>
+    <% else %>
+      <% enrichment_summary(
       summary_list,
       :course,
       t("publish.providers.courses.description_content.salary_details_label"),
@@ -35,6 +45,7 @@
       %w[salary_details],
       action_path: salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code),
     ) %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -40,7 +40,7 @@
 
         <%= render partial: "publish/courses/fields/dynamic_preview", locals: { preview_heading: t(".preview_heading") } %>
       </div>
-      <%= f.govuk_submit @course.only_published? ? "Save and publish" : "Save" %>
+      <%= f.govuk_submit t(".update") %>
     <% end %>
   </div>
 </div>

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -1,4 +1,4 @@
-<% page_title = t("publish.providers.course_salary_fees.edit.course_salary_fees_title") %>
+<% page_title = t(".course_salary_fees_title") %>
 <% content_for :page_title, title_with_error_prefix("#{page_title} – #{@course.name_and_code}", @course_salary_fees_form.errors.any?) %>
 
 <% content_for :before_content do %>
@@ -23,19 +23,16 @@
       </h1>
 
       <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
-        texts: [["Salary fees", @previous_cycle_enrichment&.salary_details]],
+        texts: [[t(".last_cycle_title"), @previous_cycle_enrichment&.salary_details]],
       } %>
 
       <%= render partial: "publish/courses/markdown_formatting" %>
 
       <%= f.govuk_text_area(:salary_fee_details,
         form_group: { id: @course_salary_fees_form.errors.key?(:salary_fee_details) ? "salary_fee_details-error" : "salary_fee_details" },
-        label: { text: "Give details about any fees or other costs that the trainee might have to pay (optional)
-
-", size: "s" },
+        label: { text: t(".label"), size: "s" },
         rows: 15,
-        max_words: 250,
-        data: { qa: "course_salary_fees_details" }) %>
+        max_words: 250) %>
 
       <%= f.govuk_submit @course.only_published? ? "Save and publish" : "Save" %>
     <% end %>

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -1,0 +1,41 @@
+<% page_title = t("publish.providers.course_salary_fees.edit.course_salary_fees_title") %>
+<% content_for :page_title, title_with_error_prefix("#{page_title} – #{@course.name_and_code}", @course_salary_fees_form.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @course_salary_fees_form,
+      url: salary_fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code),
+      data: { qa: "enrichment-form", module: "form-check-leave" },
+      method: :patch,
+      local: true,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+        <%= page_title %>
+      </h1>
+
+      <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
+        texts: [["Salary fees", @previous_cycle_enrichment&.salary_details]],
+      } %>
+
+      <%= f.govuk_text_area(:salary_fee_details,
+        form_group: { id: @course_salary_fees_form.errors.key?(:salary_fee_details) ? "salary_fee_details-error" : "salary_fee_details" },
+        label: { text: "Give details about any fees or other costs that the trainee might have to pay (optional)
+
+", size: "s" },
+        rows: 15,
+        max_words: 250,
+        data: { qa: "course_salary_fees_details" }) %>
+
+      <%= f.govuk_submit @course.only_published? ? "Save and publish" : "Save" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -28,12 +28,18 @@
 
       <%= render partial: "publish/courses/markdown_formatting" %>
 
-      <%= f.govuk_text_area(:salary_fee_details,
+      <div data-controller="input-preview">
+        <%= f.govuk_text_area(:salary_fee_details,
         form_group: { id: @course_salary_fees_form.errors.key?(:salary_fee_details) ? "salary_fee_details-error" : "salary_fee_details" },
+        data: { input_preview_target: "input",
+                action: "input-preview#updatePreview",
+                preview_output_target: "shared" },
         label: { text: t(".label"), size: "s" },
         rows: 15,
         max_words: 250) %>
 
+        <%= render partial: "publish/courses/fields/dynamic_preview", locals: { preview_heading: t(".preview_heading") } %>
+      </div>
       <%= f.govuk_submit @course.only_published? ? "Save and publish" : "Save" %>
     <% end %>
   </div>

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -5,6 +5,14 @@
   <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
 <% end %>
 
+<% if params[:copy_from].present? %>
+  <%= render Providers::CopyCourseContentWarningComponent.new(
+    @copied_fields,
+    "publish-course-salary-fees-form",
+    @source_course,
+  ) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
@@ -31,6 +39,7 @@
       <div data-controller="input-preview">
         <%= f.govuk_text_area(:salary_fee_details,
         form_group: { id: @course_salary_fees_form.errors.key?(:salary_fee_details) ? "salary_fee_details-error" : "salary_fee_details" },
+        value: @copied_fields_values&.[]("salary_fee_details"),
         data: { input_preview_target: "input",
                 action: "input-preview#updatePreview",
                 preview_output_target: "shared" },
@@ -43,4 +52,13 @@
       <%= f.govuk_submit t(".update") %>
     <% end %>
   </div>
+  <aside class="govuk-grid-column-one-third">
+     <%= render(
+      partial: "publish/courses/related_sidebar",
+      locals: {
+        course: @course,
+        page_path: salary_fees_publish_provider_recruitment_cycle_course_path(@course.provider.provider_code, @course.recruitment_cycle_year, @course.course_code),
+      },
+    ) %>
+  </aside>
 </div>

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -26,6 +26,8 @@
         texts: [["Salary fees", @previous_cycle_enrichment&.salary_details]],
       } %>
 
+      <%= render partial: "publish/courses/markdown_formatting" %>
+
       <%= f.govuk_text_area(:salary_fee_details,
         form_group: { id: @course_salary_fees_form.errors.key?(:salary_fee_details) ? "salary_fee_details-error" : "salary_fee_details" },
         label: { text: "Give details about any fees or other costs that the trainee might have to pay (optional)

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -47,6 +47,8 @@
         rows: 15,
         max_words: 250) %>
 
+        <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>
+
         <%= render partial: "publish/courses/fields/dynamic_preview", locals: { preview_heading: t(".preview_heading") } %>
       </div>
       <%= f.govuk_submit t(".update") %>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -101,6 +101,7 @@
   - about_course
   - course_length
   - fee_details
+  - salary_fee_details
   - fee_international
   - fee_uk_eu
   - financial_support

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1210,10 +1210,6 @@ en:
           attributes:
             course_length:
               blank: Enter a course length
-        publish/course_salary_fees_form:
-          attributes:
-            salary_fee_details:
-              too_long: "Reduce the word count for fees"
         publish/course_salary_form:
           attributes:
             course_length:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1210,6 +1210,10 @@ en:
           attributes:
             course_length:
               blank: Enter a course length
+        publish/course_salary_fees_form:
+          attributes:
+            salary_fee_details:
+              too_long: "Reduce the word count for fees"
         publish/course_salary_form:
           attributes:
             course_length:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -565,6 +565,8 @@ en:
           text: "Enter details about the training provider"
         what_you_will_study:
           text: "Enter details about what you will study"
+        salary_fee_details:
+          text: "Enter details about fees"
         school_placement:
           text: "Enter details about what you will do on school placements"
         interview_process:

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -87,6 +87,10 @@ en:
       course_salary:
         edit:
           course_salary: Course salary
+      course_salary_fees:
+        edit:
+          course_salary_fees_title: Fees (optional)
+          course_salary_fee: Fees
       course_fees:
         edit:
           course_fees: Course fees

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -87,10 +87,6 @@ en:
       course_salary:
         edit:
           course_salary: Course salary
-      course_salary_fees:
-        edit:
-          course_salary_fees_title: Fees (optional)
-          course_salary_fee: Fees
       course_fees:
         edit:
           course_fees: Course fees

--- a/config/locales/en/publish/courses/salary_fees.yml
+++ b/config/locales/en/publish/courses/salary_fees.yml
@@ -1,0 +1,18 @@
+en:
+  publish:
+    courses:
+      salary_fees:
+        edit:
+          course_salary_fees_title: Fees (optional)
+          label: Give details about any fees or other costs that the trainee might have to pay (optional)
+          last_cycle_title: Salary fees
+        update:
+          course_salary_fee: Fees
+
+  activemodel:
+    errors:
+      models:
+        publish/course_salary_fees_form:
+          attributes:
+            salary_fee_details:
+              too_long: "Reduce the word count for fees"

--- a/config/locales/en/publish/courses/salary_fees.yml
+++ b/config/locales/en/publish/courses/salary_fees.yml
@@ -7,6 +7,7 @@ en:
           label: Give details about any fees or other costs that the trainee might have to pay (optional)
           last_cycle_title: Salary fees
           preview_heading: Fees
+          update: Update fees
         update:
           course_salary_fee: Fees
 

--- a/config/locales/en/publish/courses/salary_fees.yml
+++ b/config/locales/en/publish/courses/salary_fees.yml
@@ -6,6 +6,7 @@ en:
           course_salary_fees_title: Fees (optional)
           label: Give details about any fees or other costs that the trainee might have to pay (optional)
           last_cycle_title: Salary fees
+          preview_heading: Fees
         update:
           course_salary_fee: Fees
 

--- a/config/locales/en/publish/providers/courses/description_content.yml
+++ b/config/locales/en/publish/providers/courses/description_content.yml
@@ -30,6 +30,7 @@ en:
           fee_international_optional_label: Fee for non-UK citizens (optional)
           financial_incentive_details_label: Financial support from the government
           salary_details_label: Salary details
+          salary_fee_details_label: Fees (optional)
           gcse_label: GCSEs
           interview_location_label: Where will the interviews take place (optional)
           interview_process_hidden_text: details about the interview process

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -219,6 +219,9 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
         get "/fields/what-you-will-study", on: :member, to: "courses/fields/what_you_will_study#edit"
         patch "/fields/what-you-will-study", on: :member, to: "courses/fields/what_you_will_study#update"
 
+        get "/salary-fees", on: :member, to: "courses/salary_fees#edit"
+        patch "/salary-fees", on: :member, to: "courses/salary_fees#update"
+
         get "/salary", on: :member, to: "courses/salary#edit"
         patch "/salary", on: :member, to: "courses/salary#update"
 

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -219,8 +219,10 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
         get "/fields/what-you-will-study", on: :member, to: "courses/fields/what_you_will_study#edit"
         patch "/fields/what-you-will-study", on: :member, to: "courses/fields/what_you_will_study#update"
 
-        get "/salary-fees", on: :member, to: "courses/salary_fees#edit"
-        patch "/salary-fees", on: :member, to: "courses/salary_fees#update"
+        constraints ->(req) { req.params["recruitment_cycle_year"].to_i > 2026 } do
+          get "/salary-fees", on: :member, to: "courses/salary_fees#edit"
+          patch "/salary-fees", on: :member, to: "courses/salary_fees#update"
+        end
 
         get "/salary", on: :member, to: "courses/salary#edit"
         patch "/salary", on: :member, to: "courses/salary#update"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -224,8 +224,10 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
           patch "/salary-fees", on: :member, to: "courses/salary_fees#update"
         end
 
-        get "/salary", on: :member, to: "courses/salary#edit"
-        patch "/salary", on: :member, to: "courses/salary#update"
+        constraints ->(req) { req.params["recruitment_cycle_year"].to_i <= 2026 } do
+          get "/salary", on: :member, to: "courses/salary#edit"
+          patch "/salary", on: :member, to: "courses/salary#update"
+        end
 
         get "/withdraw", on: :member, to: "courses/withdrawals#edit"
         patch "/withdraw", on: :member, to: "courses/withdrawals#update"

--- a/spec/components/shared/courses/financial_support/fees_and_financial_support_component/view_spec.rb
+++ b/spec/components/shared/courses/financial_support/fees_and_financial_support_component/view_spec.rb
@@ -23,6 +23,28 @@ describe Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::Vi
     end
   end
 
+  context "Salaried course salary details" do
+    it "renders the salary fee details for cycles after 2026" do
+      recruitment_cycle = create(:recruitment_cycle, :next)
+      provider = create(:provider, recruitment_cycle:)
+      enrichment = create(:course_enrichment, salary_fee_details: "Trainees may need to pay for a DBS check")
+      course = create(:course, funding: "salary", qualification: "pgce_with_qts", provider:, enrichments: [enrichment]).decorate
+
+      result = render_inline(described_class.new(course, enrichment))
+
+      expect(result.text).to include("Trainees may need to pay for a DBS check")
+    end
+
+    it "renders the salary details for cycles up to 2026" do
+      enrichment = create(:course_enrichment, salary_details: "We pay the unqualified teacher salary", salary_fee_details: nil)
+      course = create(:course, funding: "salary", qualification: "pgce_with_qts", enrichments: [enrichment]).decorate
+
+      result = render_inline(described_class.new(course, enrichment))
+
+      expect(result.text).to include("We pay the unqualified teacher salary")
+    end
+  end
+
   context "Courses excluded from bursary" do
     it "renders the student loans section if the course is excluded from bursary" do
       enrichment = create(:course_enrichment)

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -58,6 +58,8 @@ FactoryBot.define do
       ].sample
     end
 
+    salary_fee_details { Faker::Lorem.sentence }
+
     placement_selection_criteria { Faker::Lorem.sentence }
     duration_per_school { Faker::Lorem.sentence }
     theoretical_training_location { Faker::Lorem.sentence }
@@ -113,6 +115,7 @@ FactoryBot.define do
       required_qualifications { nil }
       how_school_placements_work { nil }
       salary_details { nil }
+      salary_fee_details { nil }
       course_length { nil }
       interview_process { nil }
       placement_selection_criteria { nil }

--- a/spec/forms/publish/course_salary_fees_form_spec.rb
+++ b/spec/forms/publish/course_salary_fees_form_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  describe CourseSalaryFeesForm, type: :model do
+    subject { described_class.new(enrichment, params:) }
+
+    let(:params) { {} }
+    let(:course) { build(:course, :salary_type_based) }
+    let(:enrichment) { course.enrichments.find_or_initialize_draft }
+
+    describe "validations" do
+      context "when salary fee details are within the word limit" do
+        before do
+          enrichment.salary_fee_details = Faker::Lorem.sentence(word_count: 250)
+        end
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+
+      context "when salary fee details exceed the word limit" do
+        before do
+          enrichment.salary_fee_details = Faker::Lorem.sentence(word_count: 251)
+          subject.valid?
+        end
+
+        it "adds a too_long error" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:salary_fee_details]).to include("Reduce the word count for fees")
+        end
+      end
+
+      context "when salary fee details are blank" do
+        before do
+          enrichment.salary_fee_details = nil
+        end
+
+        it "is valid as the field is optional" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    describe "#save!" do
+      let(:params) { { salary_fee_details: "some fees text" } }
+
+      it "saves the enrichment with the new attributes" do
+        expect { subject.save! }.to change(enrichment, :salary_fee_details).to("some fees text")
+      end
+    end
+  end
+end

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -126,6 +126,22 @@ RSpec.describe CourseEnrichment do
                   word_limit: [250, 50]
 
   #
+  # Salary fee details (jsonb accessor, no validation yet)
+  #
+  describe "salary_fee_details" do
+    it "is allowed to be nil" do
+      expect(build(:course_enrichment, salary_fee_details: nil)).to be_valid
+    end
+
+    it "persists the value under the SalaryFeeDetails store key" do
+      enrichment = create(:course_enrichment, salary_fee_details: "Some fees text")
+
+      expect(enrichment.reload.salary_fee_details).to eq("Some fees text")
+      expect(enrichment.json_data).to include("SalaryFeeDetails" => "Some fees text")
+    end
+  end
+
+  #
   # Existing specs we already had
   #
   describe "#publish" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -23,6 +23,7 @@ describe Course do
 
   it { is_expected.to delegate_method(:provider_name).to(:provider).allow_nil }
   it { is_expected.to delegate_method(:provider_code).to(:provider).allow_nil }
+  it { is_expected.to delegate_method(:after?).to(:recruitment_cycle).with_prefix.with_arguments(2026).allow_nil }
 
   describe "#name_and_code" do
     it "returns the course name and code in brackets" do

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -175,4 +175,18 @@ describe RecruitmentCycle, travel: mid_cycle(2025) do
       end
     end
   end
+
+  describe "#after?" do
+    it "returns true when the cycle year is after the target year" do
+      expect(described_class.new(year: 2027).after?(2026)).to be(true)
+    end
+
+    it "returns false when the cycle year equals the target year" do
+      expect(described_class.new(year: 2026).after?(2026)).to be(false)
+    end
+
+    it "returns false when the cycle year is before the target year" do
+      expect(described_class.new(year: 2025).after?(2026)).to be(false)
+    end
+  end
 end

--- a/spec/routing/publish/salary_fees_routing_spec.rb
+++ b/spec/routing/publish/salary_fees_routing_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Salary fees routing", type: :routing do
+  let(:base) { "http://publish.localhost/publish/organisations/ABC/#{year}/courses/X123/salary-fees" }
+
+  context "when the recruitment cycle year is after 2026" do
+    let(:year) { 2027 }
+
+    it "routes GET salary-fees to the edit action" do
+      expect(get: base).to route_to(
+        "publish/courses/salary_fees#edit",
+        provider_code: "ABC",
+        recruitment_cycle_year: "2027",
+        code: "X123",
+        host: "publish.localhost",
+      )
+    end
+
+    it "routes PATCH salary-fees to the update action" do
+      expect(patch: base).to route_to(
+        "publish/courses/salary_fees#update",
+        provider_code: "ABC",
+        recruitment_cycle_year: "2027",
+        code: "X123",
+        host: "publish.localhost",
+      )
+    end
+  end
+
+  context "when the recruitment cycle year is 2026 or earlier" do
+    let(:year) { 2026 }
+
+    it "does not route GET salary-fees" do
+      expect(get: base).not_to be_routable
+    end
+
+    it "does not route PATCH salary-fees" do
+      expect(patch: base).not_to be_routable
+    end
+  end
+end

--- a/spec/routing/publish/salary_routing_spec.rb
+++ b/spec/routing/publish/salary_routing_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Salary routing", type: :routing do
+  let(:base) { "http://publish.localhost/publish/organisations/ABC/#{year}/courses/X123/salary" }
+
+  context "when the recruitment cycle year is 2026 or earlier" do
+    let(:year) { 2026 }
+
+    it "routes GET salary to the edit action" do
+      expect(get: base).to route_to(
+        "publish/courses/salary#edit",
+        provider_code: "ABC",
+        recruitment_cycle_year: "2026",
+        code: "X123",
+        host: "publish.localhost",
+      )
+    end
+
+    it "routes PATCH salary to the update action" do
+      expect(patch: base).to route_to(
+        "publish/courses/salary#update",
+        provider_code: "ABC",
+        recruitment_cycle_year: "2026",
+        code: "X123",
+        host: "publish.localhost",
+      )
+    end
+  end
+
+  context "when the recruitment cycle year is after 2026" do
+    let(:year) { 2027 }
+
+    it "does not route GET salary" do
+      expect(get: base).not_to be_routable
+    end
+
+    it "does not route PATCH salary" do
+      expect(patch: base).not_to be_routable
+    end
+  end
+end

--- a/spec/system/find/course/viewing_a_salaried_course_spec.rb
+++ b/spec/system/find/course/viewing_a_salaried_course_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Viewing a salaried course", service: :find do
+  scenario "a course after the 2026 cycle shows the salary fee details", travel: mid_cycle(2027) do
+    given_a_salaried_course_exists(salary_fee_details: "Trainees may need to pay for a DBS check")
+    when_i_visit_the_course_page
+    then_i_see_the_salary_and_financial_support_section
+    then_i_see("Trainees may need to pay for a DBS check")
+  end
+
+  scenario "a course up to the 2026 cycle shows the salary details", travel: mid_cycle(2026) do
+    given_a_salaried_course_exists(salary_details: "We pay the unqualified teacher salary", salary_fee_details: nil)
+    when_i_visit_the_course_page
+    then_i_see_the_salary_and_financial_support_section
+    then_i_see("We pay the unqualified teacher salary")
+  end
+
+  def given_a_salaried_course_exists(salary_details: nil, salary_fee_details: nil)
+    @course = create(
+      :course,
+      :salary_type_based,
+      :published,
+      :open,
+      enrichments: [
+        build(
+          :course_enrichment,
+          :published,
+          salary_details:,
+          salary_fee_details:,
+        ),
+      ],
+    )
+  end
+
+  def when_i_visit_the_course_page
+    visit find_course_path(@course.provider.provider_code, @course.course_code)
+  end
+
+  def then_i_see_the_salary_and_financial_support_section
+    expect(page).to have_content("Salary and financial support")
+  end
+
+  def then_i_see(content)
+    expect(page).to have_content(content)
+  end
+end

--- a/spec/system/publish/courses/copy_course_content/salary_fees_spec.rb
+++ b/spec/system/publish/courses/copy_course_content/salary_fees_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Copy course content - salary fees", service: :publish do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user) }
+
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle(2027))
+    find_or_create(:recruitment_cycle, year: 2027)
+    sign_in_system_test(user:)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  scenario "Copy salary fees content from one course to another" do
+    given_there_are_two_salaried_draft_courses
+    when_i_visit_the_target_course_page
+    and_i_click_the_change_link_for_fees
+
+    and_i_choose_a_course_to_copy_content_from
+    and_i_click_copy_content
+    then_i_see_the_copied_content_in_the_current_course
+  end
+
+  def when_i_visit_the_target_course_page
+    visit "/publish/organisations/#{@provider.provider_code}/#{@provider.recruitment_cycle.year}/courses/#{@target_course.course_code}"
+    expect(page).to have_content(@target_course.name)
+  end
+
+  def and_i_click_the_change_link_for_fees
+    click_link "Change fees (optional)"
+  end
+
+  def and_i_choose_a_course_to_copy_content_from
+    find_field("Copy from").select @source_course.name_and_code
+  end
+
+  def and_i_click_copy_content
+    click_button "Copy content"
+  end
+
+  def then_i_see_the_copied_content_in_the_current_course
+    expect(find_field("Give details about any fees or other costs that the trainee might have to pay (optional)").value).to eq "Trainees may need to pay for a DBS check"
+  end
+
+  def given_there_are_two_salaried_draft_courses
+    @provider = create(:accredited_provider, recruitment_cycle: RecruitmentCycle.current)
+    @source_course = create(
+      :course,
+      :salary_type_based,
+      provider: @provider,
+      enrichments: [build(:course_enrichment, :initial_draft, salary_fee_details: "Trainees may need to pay for a DBS check")],
+    )
+
+    @target_course = create(
+      :course,
+      :salary_type_based,
+      provider: @provider,
+      enrichments: [build(:course_enrichment, :initial_draft, version: 2)],
+    )
+
+    user.providers << @provider
+  end
+end

--- a/spec/system/publish/courses/editing_course_salary_fees_spec.rb
+++ b/spec/system/publish/courses/editing_course_salary_fees_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Editing course salary fees", travel: mid_cycle(2027) do
+  scenario "i can update the salary fees" do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_salaried_course_i_want_to_edit
+    when_i_visit_the_salary_fees_page
+    and_i_fill_in_the_salary_fees
+    and_i_submit
+    then_i_see_a_success_message
+    and_the_salary_fees_are_updated
+    and_i_am_on_the_course_details_page
+  end
+
+  scenario "i see a validation error when the salary fees exceed the word limit" do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_salaried_course_i_want_to_edit
+    when_i_visit_the_salary_fees_page
+    and_i_fill_in_the_salary_fees_with_too_many_words
+    and_i_submit
+    then_i_see_a_word_limit_error
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_salaried_course_i_want_to_edit
+    given_a_course_exists(:salary_type_based, :draft_enrichment)
+  end
+
+  def when_i_visit_the_salary_fees_page
+    visit salary_fees_publish_provider_recruitment_cycle_course_path(
+      provider.provider_code, recruitment_cycle_year, course.course_code
+    )
+  end
+
+  def and_i_fill_in_the_salary_fees
+    fill_in salary_fees_label, with: "Trainees may need to pay for a DBS check"
+  end
+
+  def and_i_fill_in_the_salary_fees_with_too_many_words
+    @too_many_words = Faker::Lorem.sentence(word_count: 251)
+    fill_in salary_fees_label, with: @too_many_words
+  end
+
+  def salary_fees_label
+    "Give details about any fees or other costs that the trainee might have to pay (optional)"
+  end
+
+  def and_i_submit
+    click_on "Update fees"
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_content("Fees updated")
+  end
+
+  def and_the_salary_fees_are_updated
+    expect(course.enrichments.draft.last.salary_fee_details).to eq("Trainees may need to pay for a DBS check")
+  end
+
+  def then_i_see_a_word_limit_error
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_current_path(
+      salary_fees_publish_provider_recruitment_cycle_course_path(
+        provider.provider_code, recruitment_cycle_year, course.course_code
+      ),
+    )
+    expect(course.reload.enrichments.draft.last.salary_fee_details).not_to eq(@too_many_words)
+  end
+
+  def and_i_am_on_the_course_details_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_path(
+        provider.provider_code, recruitment_cycle_year, course.course_code
+      ),
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def recruitment_cycle_year
+    RecruitmentCycle.current.year
+  end
+end

--- a/spec/system/publish/courses/last_cycle_salary_fees_spec.rb
+++ b/spec/system/publish/courses/last_cycle_salary_fees_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Salary fees last cycle recap", travel: mid_cycle(2026) do
+  scenario "editing a next cycle course shows salary content from that course's previous cycle" do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_salaried_course_in_the_next_cycle
+    and_the_same_course_existed_this_cycle_with_salary_details
+
+    when_i_visit_the_next_cycle_salary_fees_page
+    then_i_see_last_cycles_salary_details
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user))
+  end
+
+  def and_there_is_a_salaried_course_in_the_next_cycle
+    @next_cycle = find_or_create(:recruitment_cycle, :next)
+    next_cycle_provider = create(:provider, recruitment_cycle: @next_cycle)
+    @course = create(
+      :course,
+      :salary_type_based,
+      provider: next_cycle_provider,
+      enrichments: [build(:course_enrichment, :initial_draft, version: 2)],
+    )
+    @current_user.providers << next_cycle_provider
+  end
+
+  def and_the_same_course_existed_this_cycle_with_salary_details
+    current_cycle_provider = create(
+      :provider,
+      recruitment_cycle: RecruitmentCycle.current,
+      provider_code: @course.provider.provider_code,
+    )
+    create(
+      :course,
+      :salary_type_based,
+      provider: current_cycle_provider,
+      course_code: @course.course_code,
+      enrichments: [build(:course_enrichment, :published, salary_details: "We pay the unqualified teacher salary")],
+    )
+    @current_user.providers << current_cycle_provider
+  end
+
+  def when_i_visit_the_next_cycle_salary_fees_page
+    visit salary_fees_publish_provider_recruitment_cycle_course_path(
+      @course.provider.provider_code, @next_cycle.year, @course.course_code
+    )
+  end
+
+  def then_i_see_last_cycles_salary_details
+    expect(page).to have_content("See what you wrote last cycle")
+    expect(page).to have_content("We pay the unqualified teacher salary")
+  end
+end

--- a/spec/system/publish/courses/previews/course_preview_salary_fees_spec.rb
+++ b/spec/system/publish/courses/previews/course_preview_salary_fees_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Course preview", service: :publish, travel: mid_cycle(2027) do
+  include Rails.application.routes.url_helpers
+
+  scenario "Adding missing salary fee details from course preview" do
+    given_i_am_authenticated(user: user_with_a_salaried_course)
+    when_i_visit_the_publish_course_preview_page
+    and_i_click_link_or_button("Enter details about fees")
+    and_i_fill_in_the_salary_fee_details
+    and_i_submit_the_form
+    then_i_am_redirected_back_to_the_preview_page
+    and_i_see_the_salary_fee_details_content
+  end
+
+private
+
+  def user_with_a_salaried_course
+    @provider = create(:provider, recruitment_cycle:)
+    @course = create(
+      :course,
+      :salary_type_based,
+      provider:,
+      enrichments: [build(:course_enrichment, :initial_draft, salary_fee_details: nil)],
+    )
+    create(:user, providers: [@provider])
+  end
+
+  def when_i_visit_the_publish_course_preview_page
+    visit preview_publish_provider_recruitment_cycle_course_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      code: course.course_code,
+    )
+  end
+
+  def and_i_fill_in_the_salary_fee_details
+    fill_in "Give details about any fees or other costs that the trainee might have to pay (optional)", with: "Trainees may need to pay for a DBS check"
+  end
+
+  def and_i_submit_the_form
+    click_button "Update fees"
+  end
+
+  def then_i_am_redirected_back_to_the_preview_page
+    expect(page).to have_current_path("/publish/organisations/#{@provider.provider_code}/#{@provider.recruitment_cycle_year}/courses/#{@course.course_code}/preview")
+  end
+
+  def and_i_see_the_salary_fee_details_content
+    expect(page).to have_content("Trainees may need to pay for a DBS check")
+  end
+
+  alias_method :and_i_click_link_or_button, :click_link_or_button
+
+  def provider
+    @provider ||= @current_user.providers.first
+  end
+
+  def recruitment_cycle
+    @recruitment_cycle ||= Current.recruitment_cycle
+  end
+
+  def course
+    @course ||= provider.courses.first
+  end
+end

--- a/spec/system/publish/courses/viewing_salary_course_fees_row_spec.rb
+++ b/spec/system/publish/courses/viewing_salary_course_fees_row_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Viewing the financial details row for a salary course" do
+  context "when the recruitment cycle is after 2026", travel: mid_cycle(2027) do
+    scenario "i see the fees row instead of the salary details row" do
+      given_i_am_authenticated_as_a_provider_user
+      and_there_is_a_salaried_course
+      when_i_visit_the_course_page
+      then_i_see_the_fees_row
+      and_i_do_not_see_the_salary_details_row
+    end
+  end
+
+  context "when the recruitment cycle is 2026 or earlier", travel: mid_cycle(2026) do
+    scenario "i see the salary details row instead of the fees row" do
+      given_i_am_authenticated_as_a_provider_user
+      and_there_is_a_salaried_course
+      when_i_visit_the_course_page
+      then_i_see_the_salary_details_row
+      and_i_do_not_see_the_fees_row
+    end
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_salaried_course
+    given_a_course_exists(:salary_type_based, :draft_enrichment)
+  end
+
+  def when_i_visit_the_course_page
+    visit publish_provider_recruitment_cycle_course_path(
+      provider.provider_code, recruitment_cycle_year, course.course_code
+    )
+  end
+
+  def then_i_see_the_fees_row
+    expect(page).to have_content("Fees (optional)")
+  end
+
+  def and_i_do_not_see_the_salary_details_row
+    expect(page).to have_no_content("Salary details")
+  end
+
+  def then_i_see_the_salary_details_row
+    expect(page).to have_content("Salary details")
+  end
+
+  def and_i_do_not_see_the_fees_row
+    expect(page).to have_no_content("Fees (optional)")
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def recruitment_cycle_year
+    provider.recruitment_cycle_year
+  end
+end

--- a/spec/system/publish/providers/last_cycle_training_with_diabilities_spec.rb
+++ b/spec/system/publish/providers/last_cycle_training_with_diabilities_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe "Editing a courses interview process with long form content", ser
     expect(page).not_to have_content("See what you wrote last cycle")
   end
 
+  scenario "A user editing a next cycle provider sees content from that provider's previous cycle" do
+    given_there_is_a_provider_in_the_next_cycle
+    and_the_same_provider_existed_this_cycle_with_disability_filled_in
+
+    when_i_visit_the_next_cycle_disability_support_page
+    expect(page).to have_content("Training with disabilities and other needs")
+    expect(page).to have_content("See what you wrote last cycle")
+    expect(page).to have_content(@current_cycle_provider.train_with_disability)
+  end
+
   def when_i_visit_the_organisation_page
     visit "/publish/organisations/#{@provider.provider_code}/#{RecruitmentCycle.current.year}/details"
     expect(page).to have_content("Organisation details")
@@ -44,6 +54,26 @@ RSpec.describe "Editing a courses interview process with long form content", ser
     @provider = create(:provider, recruitment_cycle: @current_cycle)
     user.providers << @provider
     expect(user.providers.count).to eq(1)
+  end
+
+  def given_there_is_a_provider_in_the_next_cycle
+    @next_cycle = create(:recruitment_cycle, :next)
+    @next_cycle_provider = create(:provider, recruitment_cycle: @next_cycle)
+    user.providers << @next_cycle_provider
+  end
+
+  def and_the_same_provider_existed_this_cycle_with_disability_filled_in
+    @current_cycle_provider = create(
+      :provider,
+      recruitment_cycle: RecruitmentCycle.current,
+      provider_code: @next_cycle_provider.provider_code,
+      train_with_disability: generate_text(50),
+    )
+    user.providers << @current_cycle_provider
+  end
+
+  def when_i_visit_the_next_cycle_disability_support_page
+    visit "/publish/organisations/#{@next_cycle_provider.provider_code}/#{@next_cycle.year}/training-with-disabilities/edit"
   end
 
   def and_this_provider_existed_last_cycle_with_disability_filled_in


### PR DESCRIPTION
## Context


## Changes proposed in this pull request

For the 2027 recruitment cycle, we are changing the provider course inputs for describing the fees associated with their salaried courses. Until 2026, the course attribute was titled "Salary" but we are renaming it to "Fees".


## Guidance to review

1. This change is only happening for 2027+ courses so I've run rollover in the review app
2. This is a provider in 2027 with salaried courses
3. https://publish-review-6199.test.teacherservices.cloud/publish/organisations/1CN/2027/courses

|2026|2027|
|---|---|
|<img width="1222" height="838" alt="image" src="https://github.com/user-attachments/assets/e1616921-f80b-4fb4-a6e1-322d43f1fd9a" />|<img width="1245" height="812" alt="image" src="https://github.com/user-attachments/assets/80905e01-2923-4b3d-98ab-9da70a6a5ee8" />|


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
