### PR TITLE
Audit add course anchor error links

### DIFF
--- a/app/views/publish/course_wizards/steps/_accredited_provider.html.erb
+++ b/app/views/publish/course_wizards/steps/_accredited_provider.html.erb
@@ -9,7 +9,7 @@
   <% current_step.accredited_partners.each do |accredited_partner| %>
     <%= form.govuk_radio_button :accredited_provider_code,
       accredited_partner.provider_code,
-      label: { text: accredited_partner.provider_name } %>
+      label: { text: accredited_partner.provider_name }, link_errors: true %>
   <% end %>
 <% end %>
 

--- a/app/views/publish/course_wizards/steps/_level.html.erb
+++ b/app/views/publish/course_wizards/steps/_level.html.erb
@@ -6,13 +6,13 @@
 </h1>
 
 <%= form.govuk_radio_buttons_fieldset :level, legend: { text: t("course_wizard.steps.level.level_label"), size: "m" } do %>
-  <%= form.govuk_radio_button :level, t("course_wizard.steps.level.options.primary").downcase, label: { text: t("course_wizard.steps.level.options.primary") } %>
+  <%= form.govuk_radio_button :level, t("course_wizard.steps.level.options.primary").downcase, label: { text: t("course_wizard.steps.level.options.primary") }, link_errors: true %>
   <%= form.govuk_radio_button :level, t("course_wizard.steps.level.options.secondary").downcase, label: { text: t("course_wizard.steps.level.options.secondary") } %>
   <%= form.govuk_radio_button :level, t("course_wizard.steps.level.options.further_education_value"), label: { text: t("course_wizard.steps.level.options.further_education") } %>
 <% end %>
 
 <%= form.govuk_radio_buttons_fieldset :is_send, legend: { text: t("course_wizard.steps.level.send_label"), size: "m" } do %>
-  <%= form.govuk_radio_button :is_send, "true", label: { text: t("course_wizard.steps.level.options.yes_send") } %>
+  <%= form.govuk_radio_button :is_send, "true", label: { text: t("course_wizard.steps.level.options.yes_send") }, link_errors: true %>
   <%= form.govuk_radio_button :is_send, "false", label: { text: t("course_wizard.steps.level.options.no_send") } %>
 <% end %>
 

--- a/app/views/publish/course_wizards/steps/_physics_specialisms.html.erb
+++ b/app/views/publish/course_wizards/steps/_physics_specialisms.html.erb
@@ -8,7 +8,7 @@
 <p class="govuk-body"><%= t("course_wizard.steps.physics_specialisms.programme_description") %></p>
 
 <%= form.govuk_radio_buttons_fieldset :campaign_name, legend: { text: t("course_wizard.steps.physics_specialisms.question") } do %>
-  <%= form.govuk_radio_button :campaign_name, "engineers_teach_physics", label: { text: t("course_wizard.steps.physics_specialisms.options.engineers_teach_physics.label") } %>
+  <%= form.govuk_radio_button :campaign_name, "engineers_teach_physics", label: { text: t("course_wizard.steps.physics_specialisms.options.engineers_teach_physics.label") }, link_errors: true %>
   <%= form.govuk_radio_button :campaign_name, "no_campaign", label: { text: t("course_wizard.steps.physics_specialisms.options.no_campaign.label") } %>
 <% end %>
 

--- a/app/views/publish/course_wizards/steps/_skilled_worker_visa.html.erb
+++ b/app/views/publish/course_wizards/steps/_skilled_worker_visa.html.erb
@@ -6,7 +6,7 @@
 </h1>
 
 <%= form.govuk_radio_buttons_fieldset :can_sponsor_skilled_worker_visa, legend: { text: t("course_wizard.steps.skilled_worker_visa.question") } do %>
-  <%= form.govuk_radio_button :can_sponsor_skilled_worker_visa, true, label: { text: t("course_wizard.steps.skilled_worker_visa.options.can_sponsor_skilled_worker_visa.label") } %>
+  <%= form.govuk_radio_button :can_sponsor_skilled_worker_visa, true, label: { text: t("course_wizard.steps.skilled_worker_visa.options.can_sponsor_skilled_worker_visa.label") }, link_errors: true %>
   <%= form.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: t("course_wizard.steps.skilled_worker_visa.options.cannot_sponsor_skilled_worker_visa.label") } %>
 <% end %>
 

--- a/app/views/publish/course_wizards/steps/_start_date.html.erb
+++ b/app/views/publish/course_wizards/steps/_start_date.html.erb
@@ -6,8 +6,8 @@
 </h1>
 
 <%= form.govuk_radio_buttons_fieldset :start_date, legend: { hidden: true, text: t("course_wizard.steps.start_date.heading") } do %>
-  <% current_step.start_date_options.each do |option| %>
-    <%= form.govuk_radio_button :start_date, option, label: { text: option } %>
+  <% current_step.start_date_options.each_with_index do |option, index| %>
+    <%= form.govuk_radio_button :start_date, option, label: { text: option }, link_errors: index.zero? %>
   <% end %>
 <% end %>
 

--- a/app/views/publish/course_wizards/steps/_visa_sponsorship.html.erb
+++ b/app/views/publish/course_wizards/steps/_visa_sponsorship.html.erb
@@ -28,7 +28,7 @@
 <% end %>
 
 <%= form.govuk_radio_buttons_fieldset :can_sponsor_student_visa, legend: { hidden: true } do %>
-  <%= form.govuk_radio_button :can_sponsor_student_visa, true, label: { text: t("course_wizard.steps.visa_sponsorship.options.can_sponsor_student_visa.label") } %>
+  <%= form.govuk_radio_button :can_sponsor_student_visa, true, label: { text: t("course_wizard.steps.visa_sponsorship.options.can_sponsor_student_visa.label") }, link_errors: true %>
   <%= form.govuk_radio_button :can_sponsor_student_visa, false, label: { text: t("course_wizard.steps.visa_sponsorship.options.cannot_sponsor_student_visa.label") } %>
 <% end %>
 

--- a/app/views/publish/course_wizards/steps/_visa_sponsorship_application_deadline_required.html.erb
+++ b/app/views/publish/course_wizards/steps/_visa_sponsorship_application_deadline_required.html.erb
@@ -8,7 +8,7 @@
 <p class="govuk-inset-text"><%= t("course_wizard.steps.visa_sponsorship_application_deadline_required.hint") %></p>
 
 <%= form.govuk_radio_buttons_fieldset :visa_sponsorship_application_deadline_required, legend: { hidden: true } do %>
-  <%= form.govuk_radio_button :visa_sponsorship_application_deadline_required, true, label: { text: t("course_wizard.steps.visa_sponsorship_application_deadline_required.options.visa_sponsorship_application_deadline_required.label") } %>
+  <%= form.govuk_radio_button :visa_sponsorship_application_deadline_required, true, label: { text: t("course_wizard.steps.visa_sponsorship_application_deadline_required.options.visa_sponsorship_application_deadline_required.label") }, link_errors: true %>
   <%= form.govuk_radio_button :visa_sponsorship_application_deadline_required, false, label: { text: t("course_wizard.steps.visa_sponsorship_application_deadline_required.options.visa_sponsorship_application_deadline_not_required.label") } %>
 <% end %>
 


### PR DESCRIPTION
## Context

On several add-course wizard steps, the GOV.UK error summary rendered correctly but its links did not jump to the relevant field. 

Several wizard steps already had this wired up (for example qualifications, funding type, and schools). This change brings the remaining radio-based steps into line so validation errors are accessible and match GOV.UK Design System behaviour.

## Changes proposed in this pull request

- Add `link_errors: true` to the first radio option on wizard steps that were missing it:
  - Level (`level` and `is_send`)
  - Physics specialisms
  - Skilled Worker visa
  - Student visa sponsorship
  - Visa sponsorship deadline required
  - Accredited provider
- Update the start date step to set `link_errors: index.zero?` on the first start-date option only, rather than leaving all options unlinked.

## Guidance to review

- Trigger validation errors on each updated step and confirm the error summary links scroll/focus to the correct field:
  - Level: submit with no selections
  - Physics specialisms: continue without choosing Engineers Teach Physics
  - Skilled Worker visa / Student visa sponsorship: continue without a selection
  - Visa sponsorship deadline required: continue without a selection
  - Accredited provider: continue without choosing a provider
  - Start date: continue without choosing a date
- Compare with an already-working step such as qualifications to confirm behaviour is consistent.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.