### PR TITLE
Adding primary key to subject_area

### DIFF
--- a/db/migrate/20260701194000_add_primary_key_to_subject_area.rb
+++ b/db/migrate/20260701194000_add_primary_key_to_subject_area.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AddPrimaryKeyToSubjectArea < ActiveRecord::Migration[8.1]
+  def up
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE subject_area
+        ADD CONSTRAINT subject_area_pkey
+        PRIMARY KEY USING INDEX index_subject_area_on_typename
+      SQL
+    end
+  end
+
+  def down
+    remove_foreign_key :subject, name: "fk_subject__subject_area", if_exists: true
+
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE subject_area
+        DROP CONSTRAINT subject_area_pkey
+      SQL
+    end
+
+    add_index :subject_area, :typename, unique: true, name: "index_subject_area_on_typename"
+    add_subject_area_foreign_key
+  end
+
+private
+
+  def add_subject_area_foreign_key
+    safety_assured do
+      add_foreign_key :subject,
+                      :subject_area,
+                      column: :type,
+                      primary_key: :typename,
+                      name: "fk_subject__subject_area"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_16_110551) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_194000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -602,12 +602,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_110551) do
     t.index ["type"], name: "index_subject_on_type"
   end
 
-  create_table "subject_area", id: false, force: :cascade do |t|
+  create_table "subject_area", primary_key: "typename", id: :text, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "name"
-    t.text "typename", null: false
     t.datetime "updated_at", null: false
-    t.index ["typename"], name: "index_subject_area_on_typename", unique: true
   end
 
   create_table "subject_group", force: :cascade do |t|

--- a/docs/database-diagram.mmd
+++ b/docs/database-diagram.mmd
@@ -136,6 +136,7 @@ erDiagram
 		text profpost_flag
 		text program_type
 		integer provider_id FK
+		boolean publish_without_schools_allowed
 		integer qualification
 		boolean school_experience_required
 		text school_experience_required_content


### PR DESCRIPTION
## Context

Airbyte sync is failing as our subject_are table does not have a primary key.

## Changes proposed in this pull request

- Creating a primary key on the existing text field

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
