### PR TITLE
Add link tracking in email digest

### DIFF
--- a/app/helpers/utm_helper.rb
+++ b/app/helpers/utm_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module UtmHelper
+  # Appends UTM tracking parameters to a URL, preserving any existing query
+  # string. Works for both internally generated route URLs and external links.
+  def with_utm(url, params:, content:)
+    uri = URI.parse(url)
+    utm = params.merge(utm_content: content).to_query
+    uri.query = [uri.query.presence, utm].compact.join("&")
+    uri.to_s
+  end
+end

--- a/app/mailers/email_alert_mailer.rb
+++ b/app/mailers/email_alert_mailer.rb
@@ -7,7 +7,7 @@ class EmailAlertMailer < GovukNotifyRails::Mailer
   MAX_USER_INPUT_LENGTH = 200
   COURSE_LIMIT = 10
   UTM_PARAMS = {
-    utm_source: "email",
+    utm_source: "email_alerts",
     utm_medium: "email",
     utm_campaign: "weekly_digest",
   }.freeze

--- a/app/mailers/email_alert_mailer.rb
+++ b/app/mailers/email_alert_mailer.rb
@@ -2,9 +2,15 @@
 
 class EmailAlertMailer < GovukNotifyRails::Mailer
   include ::Courses::ActiveFilters::SummaryRowBuilder
+  helper UtmHelper
 
   MAX_USER_INPUT_LENGTH = 200
   COURSE_LIMIT = 10
+  UTM_PARAMS = {
+    utm_source: "email",
+    utm_medium: "email",
+    utm_campaign: "weekly_digest",
+  }.freeze
 
   def weekly_digest(email_alert, courses)
     set_template(Settings.govuk_notify.email_alert_weekly_digest_template_id)
@@ -17,6 +23,7 @@ class EmailAlertMailer < GovukNotifyRails::Mailer
     @title = email_subject
     @body_intro = body_intro
     @unsubscribe_url = unsubscribe_url(email_alert)
+    @utm_params = UTM_PARAMS
 
     search_params = email_alert.search_params
     search_params[:order] = "newest_course" if @remaining_count.positive?

--- a/app/views/email_alert_mailer/weekly_digest.text.erb
+++ b/app/views/email_alert_mailer/weekly_digest.text.erb
@@ -25,9 +25,9 @@
 
 # Not sure which course is right for you?
 
-[Find out how to choose a course](<%= with_utm(I18n.t("find.get_into_teaching.url_choose_course"), params: @utm_params, content: "choose_course") %>).
+[Find out how to choose a course](<%= find_track_click_url(**@utm_params, utm_content: "choose_course", url: I18n.t("find.get_into_teaching.url_choose_course")) %>).
 
-[Get a free teacher training adviser](<%= with_utm(I18n.t("find.get_into_teaching.url_training_adviser"), params: @utm_params, content: "training_adviser") %>).
+[Get a free teacher training adviser](<%= find_track_click_url(**@utm_params, utm_content: "training_adviser", url: I18n.t("find.get_into_teaching.url_training_adviser")) %>).
 
 ---
 

--- a/app/views/email_alert_mailer/weekly_digest.text.erb
+++ b/app/views/email_alert_mailer/weekly_digest.text.erb
@@ -4,11 +4,11 @@
 
 <% @courses.each do |course| -%>
 <%= course.provider.provider_name %>
-[<%= course.name %> (<%= course.course_code %>)](<%= find_course_url(course.provider.provider_code, course.course_code) %>)
+[<%= course.name %> (<%= course.course_code %>)](<%= with_utm(find_course_url(course.provider.provider_code, course.course_code), params: @utm_params, content: "course_link") %>)
 
 <% end -%>
 <% if @remaining_count > 0 -%>
-[View more courses that meet your criteria on Find teacher training courses.](<%= @search_url %>)
+[View more courses that meet your criteria on Find teacher training courses.](<%= with_utm(@search_url, params: @utm_params, content: "view_more_courses") %>)
 
 <% end -%>
 ---
@@ -19,16 +19,16 @@
 <%= row[:label] %>: <%= row[:value] %>
 <% end -%>
 
-[Search for a course](<%= @search_url %>) to set up a new email alert for similar courses.
+[Search for a course](<%= with_utm(@search_url, params: @utm_params, content: "search_for_a_course") %>) to set up a new email alert for similar courses.
 
 ---
 
 # Not sure which course is right for you?
 
-[Find out how to choose a course](<%= I18n.t("find.get_into_teaching.url_choose_course") %>).
+[Find out how to choose a course](<%= with_utm(I18n.t("find.get_into_teaching.url_choose_course"), params: @utm_params, content: "choose_course") %>).
 
-[Get a free teacher training adviser](<%= I18n.t("find.get_into_teaching.url_training_adviser") %>).
+[Get a free teacher training adviser](<%= with_utm(I18n.t("find.get_into_teaching.url_training_adviser"), params: @utm_params, content: "training_adviser") %>).
 
 ---
 
-Don't want to receive these email alerts? [Unsubscribe here](<%= @unsubscribe_url %>).
+Don't want to receive these email alerts? [Unsubscribe here](<%= with_utm(@unsubscribe_url, params: @utm_params, content: "unsubscribe") %>).

--- a/spec/helpers/utm_helper_spec.rb
+++ b/spec/helpers/utm_helper_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UtmHelper do
+  let(:params) do
+    { utm_source: "email", utm_medium: "email", utm_campaign: "weekly_digest" }
+  end
+
+  describe "#with_utm" do
+    it "appends utm params to a url without an existing query string" do
+      result = helper.with_utm("https://example.com/page", params:, content: "course_link")
+
+      expect(result).to eq(
+        "https://example.com/page?utm_campaign=weekly_digest&utm_content=course_link&utm_medium=email&utm_source=email",
+      )
+    end
+
+    it "preserves an existing query string" do
+      result = helper.with_utm("https://example.com/results?order=newest_course", params:, content: "view_more_courses")
+
+      expect(result).to start_with("https://example.com/results?order=newest_course&")
+      expect(result).to include("utm_content=view_more_courses")
+    end
+  end
+end

--- a/spec/mailers/email_alert_mailer_spec.rb
+++ b/spec/mailers/email_alert_mailer_spec.rb
@@ -63,7 +63,7 @@ describe EmailAlertMailer do
 
   it "adds utm tracking params to the internal links in the body" do
     body = mail.govuk_notify_personalisation[:body]
-    expect(body).to include("utm_source=email")
+    expect(body).to include("utm_source=email_alerts")
     expect(body).to include("utm_medium=email")
     expect(body).to include("utm_campaign=weekly_digest")
     expect(body).to include("utm_content=course_link")
@@ -76,7 +76,7 @@ describe EmailAlertMailer do
     track_click_links = body.scan(%r{\S*/track_click\?\S+})
 
     expect(track_click_links.size).to eq(2)
-    expect(track_click_links).to all(include("utm_source=email"))
+    expect(track_click_links).to all(include("utm_source=email_alerts"))
     expect(track_click_links).to all(include("utm_medium=email"))
     expect(track_click_links).to all(include("utm_campaign=weekly_digest"))
     expect(track_click_links).to all(include(CGI.escape("getintoteaching.education.gov.uk")))

--- a/spec/mailers/email_alert_mailer_spec.rb
+++ b/spec/mailers/email_alert_mailer_spec.rb
@@ -61,6 +61,18 @@ describe EmailAlertMailer do
     expect(body).to include("Get a free teacher training adviser")
   end
 
+  it "adds utm tracking params to the links in the body" do
+    body = mail.govuk_notify_personalisation[:body]
+    expect(body).to include("utm_source=email")
+    expect(body).to include("utm_medium=email")
+    expect(body).to include("utm_campaign=weekly_digest")
+    expect(body).to include("utm_content=course_link")
+    expect(body).to include("utm_content=search_for_a_course")
+    expect(body).to include("utm_content=choose_course")
+    expect(body).to include("utm_content=training_adviser")
+    expect(body).to include("utm_content=unsubscribe")
+  end
+
   context "with course limit stubbed" do
     before { stub_const("EmailAlertMailer::COURSE_LIMIT", 2) }
 

--- a/spec/mailers/email_alert_mailer_spec.rb
+++ b/spec/mailers/email_alert_mailer_spec.rb
@@ -61,16 +61,27 @@ describe EmailAlertMailer do
     expect(body).to include("Get a free teacher training adviser")
   end
 
-  it "adds utm tracking params to the links in the body" do
+  it "adds utm tracking params to the internal links in the body" do
     body = mail.govuk_notify_personalisation[:body]
     expect(body).to include("utm_source=email")
     expect(body).to include("utm_medium=email")
     expect(body).to include("utm_campaign=weekly_digest")
     expect(body).to include("utm_content=course_link")
     expect(body).to include("utm_content=search_for_a_course")
+    expect(body).to include("utm_content=unsubscribe")
+  end
+
+  it "routes external Get Into Teaching links through the track_click redirect with the same utm params" do
+    body = mail.govuk_notify_personalisation[:body]
+    track_click_links = body.scan(%r{\S*/track_click\?\S+})
+
+    expect(track_click_links.size).to eq(2)
+    expect(track_click_links).to all(include("utm_source=email"))
+    expect(track_click_links).to all(include("utm_medium=email"))
+    expect(track_click_links).to all(include("utm_campaign=weekly_digest"))
+    expect(track_click_links).to all(include(CGI.escape("getintoteaching.education.gov.uk")))
     expect(body).to include("utm_content=choose_course")
     expect(body).to include("utm_content=training_adviser")
-    expect(body).to include("utm_content=unsubscribe")
   end
 
   context "with course limit stubbed" do


### PR DESCRIPTION
## Context

We send weekly digest emails to candidates listing new courses that match their criteria. We present links to the top 10 relevant courses in the email as well as links to other resources.

We want to be able to monitor how often these links are being used to help us decided if the feature is effective or not.

## Changes proposed in this pull request

- Add UtmHelper to append utm params to urls in the application.
- Apply Email alert utm params to the weekly digest email body.
- Use TrackClick to track links to external service Get into teaching in the email 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
