### PR TITLE
Add School experience to find and add dynamic preview in publish

### DIFF
--- a/app/components/accredited_provider_component.rb
+++ b/app/components/accredited_provider_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AccreditedProviderComponent < ViewComponent::Base
-  include PublishHelper
+  include MarkdownHelper
 
   attr_reader :provider, :remove_path
 

--- a/app/components/courses/summary_card_component.html.erb
+++ b/app/components/courses/summary_card_component.html.erb
@@ -41,6 +41,13 @@
         <% row.with_value(text: qualification_value) %>
       <% end %>
 
+      <% if course.show_school_experience? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: experience_key) %>
+          <% row.with_value(text: experience_value) %>
+        <% end %>
+      <% end %>
+
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: degree_requirements_key) %>
         <% row.with_value do %>

--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -113,6 +113,14 @@ module Courses
       t(".qualification_key")
     end
 
+    def experience_key
+      t(".experience_key")
+    end
+
+    def experience_value
+      t(".experience_value")
+    end
+
     def qualification_value
       t(".qualification_value.#{course.qualification}_html")
     end

--- a/app/components/degree_row_content.rb
+++ b/app/components/degree_row_content.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DegreeRowContent < ViewComponent::Base
-  include PublishHelper
+  include MarkdownHelper
   attr_reader :course, :errors
 
   DEGREE_GRADE_MAPPING = {

--- a/app/components/find/courses/apply_component/view.rb
+++ b/app/components/find/courses/apply_component/view.rb
@@ -38,7 +38,7 @@ module Find
         end
 
         def school_experience_interstitial_path?
-          course.school_experience_interruption_required?
+          course.show_school_experience?
         end
 
         def find_apply_destination_path

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -3,6 +3,15 @@
   <div data-qa="course__required_qualifications">
 
     <%= govuk_summary_list(actions: false) do |summary_list| %>
+      <% if course.show_school_experience? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: school_experience_title) %>
+          <% row.with_value do %>
+            <%= govuk_details(summary_text: t(".yes_school_experience")) { markdown(course.school_experience_required_content) } %>
+          <% end %>
+        <% end %>
+      <% end %>
+
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: qualification_required) %>
         <% row.with_value do %>

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -5,6 +5,7 @@ module Find
     module EntryRequirementsComponent
       class View < ViewComponent::Base
         include PreviewHelper
+        include MarkdownHelper
 
         attr_accessor :course
 
@@ -27,6 +28,10 @@ module Find
         end
 
       private
+
+        def school_experience_title
+          t(".school_experience")
+        end
 
         def degree_requirements_title
           if course.subjects.map(&:subject_code).intersect?(NON_SKE_SUBJECT_CODES)

--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -4,7 +4,7 @@ module Find
   module Courses
     module TrainingLocations
       class View < ViewComponent::Base
-        include PublishHelper
+        include MarkdownHelper
         include PreviewHelper
 
         attr_reader :course, :address, :distance_from_location, :preview

--- a/app/components/gcse_row_content.rb
+++ b/app/components/gcse_row_content.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class GcseRowContent < GcseRequirements
-  include PublishHelper
+  include MarkdownHelper
 end

--- a/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.rb
+++ b/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.rb
@@ -5,7 +5,7 @@ module Shared
     module FinancialSupport
       module FeesAndFinancialSupportComponent
         class View < ViewComponent::Base
-          include PublishHelper
+          include MarkdownHelper
 
           attr_reader :course, :enrichment
 

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -26,7 +26,7 @@ module Find
     def confirm_apply; end
 
     def school_experience_interstitial
-      redirect_to find_confirm_apply_path(provider_code: @course.provider_code, course_code: @course.course_code) unless @course.school_experience_interruption_required?
+      redirect_to find_confirm_apply_path(provider_code: @course.provider_code, course_code: @course.course_code) unless @course.show_school_experience?
     end
 
     def location_params

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -449,8 +449,6 @@ class CourseDecorator < ApplicationDecorator
     !teacher_degree_apprenticeship?
   end
 
-  delegate :show_school_experience?, to: :object
-
   def visa_sponsorship_deadline_required
     visa_sponsorship_application_deadline_at.respond_to?(:to_fs) ? "Yes" : "No"
   end

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SiteDecorator < Draper::Decorator
-  include PublishHelper
+  include MarkdownHelper
   delegate_all
 
   def full_address(join_on_separator = ", ")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,7 @@
 module ApplicationHelper
   include Pagy::Frontend
   include DfE::Autocomplete::ApplicationHelper
+  include MarkdownHelper
 
   def pagy_govuk_nav(pagy)
     render "pagy/paginator", pagy:

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module PublishHelper
+module MarkdownHelper
   def markdown(source)
     return "".html_safe if source.blank?
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -932,12 +932,8 @@ class Course < ApplicationRecord
       Courses::PublishRules::SchoolPresence.none?(self)
   end
 
-  def school_experience_interruption_required?
-    show_school_experience? && school_experience_required?
-  end
-
   def show_school_experience?
-    recruitment_cycle_after?(2026)
+    recruitment_cycle_after?(2026) && school_experience_required?
   end
 
 private

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -55,7 +55,7 @@
 
 <%= govuk_summary_list do |summary_list| %>
 
-  <% if course.show_school_experience? %>
+  <% if course.recruitment_cycle_after?(2026) %>
     <% if course.salaried? %>
       <% summary_list.with_row do |row|
         row.with_key { t("publish.providers.courses.description_content.experience_required_key") }

--- a/app/views/publish/courses/school_experience/experience_details/new.html.erb
+++ b/app/views/publish/courses/school_experience/experience_details/new.html.erb
@@ -22,12 +22,20 @@
 
       <%= render partial: "publish/courses/markdown_formatting" %>
 
-      <%= form.govuk_text_area :experience_details,
+      <div data-controller="input-preview">
+        <%= form.govuk_text_area :experience_details,
+          data: {
+            input_preview_target: "input",
+            action: "input-preview#updatePreview",
+            preview_output_target: "shared",
+          },
           label: { text: t("publish.courses.#{current_step.model_name.i18n_key}.subtitle"), size: "s" },
           hint: { text: t("publish.courses.#{current_step.model_name.i18n_key}.hint_html") },
-          rows: 8,
-          max_words: 250,
-          value: "" %>
+          rows: 10,
+          max_words: 250 %>
+
+        <%= render "publish/courses/fields/dynamic_preview", preview_heading: t(".preview_heading") %>
+      </div>
 
       <%= form.submit t("publish.courses.#{current_step.model_name.i18n_key}.submit"), class: "govuk-button" %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,6 +328,8 @@ en:
         ThreeYears: 3 years
         FourYears: 4 years
       age_group_key: Age group
+      experience_key: School experience
+      experience_value: Required or strongly recommended
       qualification_key: Qualification awarded
       qualification_value:
         qts_html: <abbr title='Qualified teacher status'>QTS</abbr> only

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -48,6 +48,8 @@ en:
           degree: Degree required
           or_equivalent_qualification: or equivalent qualification
           equivalency_tests: Equivalency tests
+          school_experience: School experience
+          yes_school_experience: Yes, school experience is required or strongly recommended
           degree_subject_requirements: Degree subject requirements
           degree_requirements: Degree requirements
           a_levels: A levels

--- a/config/locales/en/publish/courses/school_experience.yml
+++ b/config/locales/en/publish/courses/school_experience.yml
@@ -6,5 +6,7 @@ en:
           create:
             flash_success: School experience updated
         experience_details:
+          new:
+            preview_heading: School experience
           create:
             flash_success: School experience updated

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -625,6 +625,42 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     it_behaves_like "course qualification row", :undergraduate_degree_with_qts, "Teacher degree apprenticeship with QTS"
   end
 
+  describe "when displaying school experience" do
+    let(:cycle_year) { 2027 }
+    let(:course) do
+      create(
+        :course,
+        school_experience_required:,
+        provider: build(:provider, recruitment_cycle: find_or_create(:recruitment_cycle, year: cycle_year)),
+      )
+    end
+
+    context "when the course is in the 2027 cycle or later and school experience is required" do
+      let(:school_experience_required) { true }
+
+      it "displays the school experience row" do
+        expect(summary_card_content).to include("School experienceRequired or strongly recommended")
+      end
+    end
+
+    context "when school experience is not required" do
+      let(:school_experience_required) { false }
+
+      it "does not display the school experience row" do
+        expect(summary_card_content).not_to include("School experience")
+      end
+    end
+
+    context "when the course is in a cycle before 2027" do
+      let(:cycle_year) { 2026 }
+      let(:school_experience_required) { true }
+
+      it "does not display the school experience row" do
+        expect(summary_card_content).not_to include("School experience")
+      end
+    end
+  end
+
   shared_examples "course degree requirements row" do |course_degree_type, course_degree_grade_required, expected_output|
     let(:course) { create(:course, degree_type:, degree_grade:) }
     let(:degree_type) { course_degree_type }

--- a/spec/components/find/courses/apply_component/view_spec.rb
+++ b/spec/components/find/courses/apply_component/view_spec.rb
@@ -123,7 +123,7 @@ describe Find::Courses::ApplyComponent::View, type: :component do
         let(:course) { build(:course, :open, :salary, provider:) }
 
         it "returns the school experience interstitial path" do
-          allow(course).to receive(:school_experience_interruption_required?).and_return(true)
+          allow(course).to receive(:show_school_experience?).and_return(true)
 
           render_component
 
@@ -135,7 +135,7 @@ describe Find::Courses::ApplyComponent::View, type: :component do
         let(:course) { build(:course, :open, provider:) }
 
         it "returns the confirm apply path" do
-          allow(course).to receive(:school_experience_interruption_required?).and_return(false)
+          allow(course).to receive(:show_school_experience?).and_return(false)
           allow(FeatureFlag).to receive(:active?).with(:candidate_accounts).and_return(true)
 
           render_component
@@ -148,7 +148,7 @@ describe Find::Courses::ApplyComponent::View, type: :component do
         let(:course) { build(:course, :open, provider:) }
 
         it "returns the apply path" do
-          allow(course).to receive(:school_experience_interruption_required?).and_return(false)
+          allow(course).to receive(:show_school_experience?).and_return(false)
           allow(FeatureFlag).to receive(:active?).with(:candidate_accounts).and_return(false)
 
           render_component

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -488,6 +488,60 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     end
   end
 
+  describe "school experience row" do
+    let(:subjects) { [build(:secondary_subject, :mathematics)] }
+
+    context "when the recruitment cycle is after 2026 and school experience is required" do
+      let(:course) do
+        build(
+          :course,
+          subjects:,
+          school_experience_required: true,
+          school_experience_required_content: "You must complete two weeks in a school.",
+          provider: build(:provider, recruitment_cycle: build(:recruitment_cycle, year: 2027)),
+        )
+      end
+
+      it "renders the school experience row" do
+        expect(result.text).to include("School experience")
+        expect(result.text).to include("Yes, school experience is required or strongly recommended")
+        expect(result.text).to include("You must complete two weeks in a school.")
+      end
+    end
+
+    context "when the recruitment cycle is after 2026 but school experience is not required" do
+      let(:course) do
+        build(
+          :course,
+          subjects:,
+          school_experience_required: false,
+          provider: build(:provider, recruitment_cycle: build(:recruitment_cycle, year: 2027)),
+        )
+      end
+
+      it "does not render the school experience row" do
+        expect(result.text).not_to include("School experience")
+      end
+    end
+
+    context "when the recruitment cycle is 2026 or earlier and school experience is required" do
+      let(:course) do
+        build(
+          :course,
+          subjects:,
+          school_experience_required: true,
+          school_experience_required_content: "You must complete two weeks in a school.",
+          provider: build(:provider, recruitment_cycle: build(:recruitment_cycle, year: 2026)),
+        )
+      end
+
+      it "does not render the school experience row" do
+        expect(result.text).not_to include("School experience")
+        expect(result.text).not_to include("You must complete two weeks in a school.")
+      end
+    end
+  end
+
   describe "#qualification_required" do
     let(:course) { build(:course) }
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -627,27 +627,6 @@ describe CourseDecorator do
     end
   end
 
-  describe "#show_school_experience?" do
-    let(:cycle_year) { 2027 }
-    let(:provider) { build_stubbed(:provider, recruitment_cycle: build_stubbed(:recruitment_cycle, year: cycle_year)) }
-
-    context "and the course is in the 2027 cycle or later" do
-      let(:cycle_year) { 2027 }
-
-      it "returns true" do
-        expect(decorated_course.show_school_experience?).to be true
-      end
-    end
-
-    context "and the course is in a cycle before 2027" do
-      let(:cycle_year) { 2026 }
-
-      it "returns false" do
-        expect(decorated_course.show_school_experience?).to be false
-      end
-    end
-  end
-
   describe "#a_level_change_path" do
     subject(:a_level_change_path) { course.decorate.a_level_change_path }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -96,39 +96,6 @@ describe Course do
     end
   end
 
-  describe "#school_experience_interruption_required?" do
-    it "returns true when school experience is required on a salaried course" do
-      course.school_experience_required = true
-      course.funding = "salary"
-      allow(course).to receive(:show_school_experience?).and_return(true)
-
-      expect(course.school_experience_interruption_required?).to be(true)
-    end
-
-    it "returns true when school experience is required on an apprenticeship course" do
-      course.school_experience_required = true
-      course.funding = "apprenticeship"
-      allow(course).to receive(:show_school_experience?).and_return(true)
-
-      expect(course.school_experience_interruption_required?).to be(true)
-    end
-
-    it "returns false when school experience is not required on a salaried course" do
-      course.school_experience_required = false
-      course.funding = "salary"
-
-      expect(course.school_experience_interruption_required?).to be(false)
-    end
-
-    it "returns false when school experience is not shown for the course cycle" do
-      course.school_experience_required = true
-      course.funding = "salary"
-      allow(course).to receive(:show_school_experience?).and_return(false)
-
-      expect(course.school_experience_interruption_required?).to be(false)
-    end
-  end
-
   describe "#in_previous_cycle" do
     let(:previous_cycle) { create(:recruitment_cycle, year: "2026") }
     let(:current_cycle) { create(:recruitment_cycle, year: "2027") }
@@ -152,6 +119,37 @@ describe Course do
       create(:course, course_code: "B123", provider: previous_provider).discard!
 
       expect(course.in_previous_cycle).to be_nil
+    end
+  end
+
+  describe "#show_school_experience?" do
+    let(:cycle_year) { 2027 }
+    let(:provider) { build_stubbed(:provider, recruitment_cycle: build_stubbed(:recruitment_cycle, year: cycle_year)) }
+    let(:course) { build_stubbed(:course, school_experience_required: true, provider:) }
+
+    context "and the course is in the 2027 cycle or later" do
+      let(:cycle_year) { 2027 }
+
+      it "returns true" do
+        expect(course.show_school_experience?).to be true
+      end
+    end
+
+    context "and the course is in a cycle before 2027" do
+      let(:cycle_year) { 2026 }
+
+      it "returns false" do
+        expect(course.show_school_experience?).to be false
+      end
+    end
+
+    context "and school experience is not required" do
+      let(:cycle_year) { 2027 }
+      let(:course) { build_stubbed(:course, school_experience_required: false, provider:) }
+
+      it "returns false" do
+        expect(course.show_school_experience?).to be false
+      end
     end
   end
 

--- a/spec/system/find/course/viewing_a_course_spec.rb
+++ b/spec/system/find/course/viewing_a_course_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Viewing a findable course" do
-  include PublishHelper
+  include MarkdownHelper
   include Rails.application.routes.url_helpers
 
   before do

--- a/spec/system/find/course/viewing_a_further_education_course_spec.rb
+++ b/spec/system/find/course/viewing_a_further_education_course_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Viewing a findable course" do
-  include PublishHelper
+  include MarkdownHelper
   include Rails.application.routes.url_helpers
 
   before do

--- a/spec/system/find/course/viewing_school_experience_spec.rb
+++ b/spec/system/find/course/viewing_school_experience_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Viewing school experience on a course", service: :find do
+  scenario "a course after the 2026 cycle that requires school experience shows the row", travel: mid_cycle(2027) do
+    given_a_course_exists(
+      school_experience_required: true,
+      school_experience_required_content: "Spend two weeks in a UK school before applying.",
+    )
+    when_i_visit_the_course_page
+    then_i_see_the_school_experience_row
+    then_i_see("Spend two weeks in a UK school before applying.")
+  end
+
+  scenario "a course after the 2026 cycle that does not require school experience hides the row", travel: mid_cycle(2027) do
+    given_a_course_exists(school_experience_required: false, school_experience_required_content: nil)
+    when_i_visit_the_course_page
+    then_i_do_not_see_the_school_experience_row
+  end
+
+  scenario "a course up to the 2026 cycle does not show the row", travel: mid_cycle(2026) do
+    given_a_course_exists(
+      school_experience_required: true,
+      school_experience_required_content: "Spend two weeks in a UK school before applying.",
+    )
+    when_i_visit_the_course_page
+    then_i_do_not_see_the_school_experience_row
+  end
+
+  def given_a_course_exists(school_experience_required:, school_experience_required_content:)
+    @course = create(
+      :course,
+      :salary_type_based,
+      :published,
+      :open,
+      school_experience_required:,
+      school_experience_required_content:,
+      enrichments: [build(:course_enrichment, :published)],
+    )
+  end
+
+  def when_i_visit_the_course_page
+    visit find_course_path(@course.provider.provider_code, @course.course_code)
+  end
+
+  def then_i_see_the_school_experience_row
+    expect(page).to have_content("School experience")
+    expect(page).to have_content("Yes, school experience is required or strongly recommended")
+  end
+
+  def then_i_do_not_see_the_school_experience_row
+    expect(page).to have_no_content("Yes, school experience is required or strongly recommended")
+  end
+
+  def then_i_see(content)
+    expect(page).to have_content(content)
+  end
+end


### PR DESCRIPTION
## Context

Add the dynamic preview to the publish step for adding school experience.
Render the value in Find for courses in recruitment cycles 2027 and beyond.
The whole row should be hidden in the course summary on results page if the school experience is not required.

Extra: guard the /salary endpoint for salary fees feature

## Changes proposed in this pull request

* Rename `PublishHelper` to `MarkdownHelper` - "`PublishHelper`" is confusing
* Render the school experience information on the Find course page
* Reduce input rows from 8 to 5
* Add dynamic preview to School experience input in Publish


## Guidance to review

## Add to Find

|course summary|course show|
|---|---|
|<img width="738" height="658" alt="image" src="https://github.com/user-attachments/assets/54f41ee6-6e12-4741-834b-6d3469d663ef" />|<img width="806" height="909" alt="image" src="https://github.com/user-attachments/assets/87926548-22ed-49b3-b712-66e4b2066f25" />|

## Dynamic preview in Publish
<img width="887" height="960" alt="image" src="https://github.com/user-attachments/assets/c7da213c-658e-4c27-9b9f-481c78b51bd8" />


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
