### PR TITLE
Add migration to add UUID to provider_school table

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -25,6 +25,7 @@
   - provider_id
   - gias_school_id
   - site_code
+  - uuid
   - created_at
   - updated_at
   :data_hub_process_summary:

--- a/db/data/20260706120000_backfill_provider_school_uuids.rb
+++ b/db/data/20260706120000_backfill_provider_school_uuids.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class BackfillProviderSchoolUuids < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  TAG = "[BackfillProviderSchoolUuids]"
+
+  def up
+    total = 0
+
+    Provider::School.unscoped.where(uuid: nil).in_batches(of: 5_000) do |batch|
+      total += batch.update_all("uuid = uuid_generate_v4()")
+    end
+
+    say "#{TAG} backfilled=#{total}"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260703145835_add_uuid_to_provider_school.rb
+++ b/db/migrate/20260703145835_add_uuid_to_provider_school.rb
@@ -1,0 +1,11 @@
+class AddUuidToProviderSchool < ActiveRecord::Migration[8.1]
+  def up
+    add_column :provider_school, :uuid, :uuid # rubocop:disable Rails/BulkChangeTable
+
+    change_column_default :provider_school, :uuid, "uuid_generate_v4()"
+  end
+
+  def down
+    remove_column :provider_school, :uuid
+  end
+end

--- a/db/migrate/20260706120100_set_provider_school_uuid_not_null.rb
+++ b/db/migrate/20260706120100_set_provider_school_uuid_not_null.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class SetProviderSchoolUuidNotNull < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    # Add the constraint unvalidated first so we don't take a long
+    # ACCESS EXCLUSIVE lock while every existing row is checked.
+    add_check_constraint :provider_school, "uuid IS NOT NULL",
+                         name: "provider_school_uuid_not_null", validate: false
+    validate_check_constraint :provider_school, name: "provider_school_uuid_not_null"
+
+    change_column_null :provider_school, :uuid, false
+
+    remove_check_constraint :provider_school, name: "provider_school_uuid_not_null"
+  end
+
+  def down
+    change_column_null :provider_school, :uuid, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_194000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_145835) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -464,6 +464,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_01_194000) do
     t.bigint "provider_id", null: false
     t.text "site_code", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }
     t.index ["gias_school_id"], name: "index_provider_school_on_gias_school_id"
     t.index ["provider_id", "gias_school_id", "site_code"], name: "index_provider_school_unique", unique: true
     t.index ["provider_id"], name: "index_provider_school_one_main_per_provider", unique: true, where: "(site_code = '-'::text)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_145835) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_06_120100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -464,7 +464,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_145835) do
     t.bigint "provider_id", null: false
     t.text "site_code", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "uuid_generate_v4()" }
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.index ["gias_school_id"], name: "index_provider_school_on_gias_school_id"
     t.index ["provider_id", "gias_school_id", "site_code"], name: "index_provider_school_unique", unique: true
     t.index ["provider_id"], name: "index_provider_school_one_main_per_provider", unique: true, where: "(site_code = '-'::text)"

--- a/docs/database-diagram.mmd
+++ b/docs/database-diagram.mmd
@@ -270,6 +270,7 @@ erDiagram
 		integer id PK
 		integer provider_id FK
 		text site_code
+		uuid uuid
 	}
 	ProviderPartnership {
 		integer accredited_provider_id FK

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -166,6 +166,13 @@ describe Provider::School do
       }.to raise_error(ActiveRecord::NotNullViolation)
     end
 
+    it "enforces NOT NULL on uuid" do
+      provider_school = create(:provider_school, provider:, gias_school:)
+      expect {
+        provider_school.update_column(:uuid, nil)
+      }.to raise_error(ActiveRecord::NotNullViolation)
+    end
+
     it "enforces the gias_school_id foreign key" do
       missing_id = GiasSchool.maximum(:id).to_i + 1_000
       record = described_class.new(provider:, site_code: "-")

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -115,6 +115,35 @@ describe Provider::School do
     end
   end
 
+  describe "uuid" do
+    it "is auto-generated on create" do
+      provider_school = create(:provider_school)
+      expect(provider_school.reload.uuid).to be_present
+    end
+
+    it "is a valid v4 uuid" do
+      provider_school = create(:provider_school)
+      expect(provider_school.reload.uuid).to match(
+        /\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/,
+      )
+    end
+
+    it "assigns a distinct uuid to each record" do
+      first = create(:provider_school, site_code: "A")
+      second = create(:provider_school, site_code: "B", provider: first.provider)
+      expect(first.reload.uuid).not_to eq(second.reload.uuid)
+    end
+
+    it "can be updated" do
+      provider_school = create(:provider_school)
+      new_uuid = "11111111-1111-4111-8111-111111111111"
+
+      provider_school.update!(uuid: new_uuid)
+
+      expect(provider_school.reload.uuid).to eq(new_uuid)
+    end
+  end
+
   describe "database constraints" do
     let(:provider) { create(:provider) }
     let(:gias_school) { create(:gias_school) }


### PR DESCRIPTION
## Context


This PR adds a default value to the database column. For our migration, we will want to set the uuid to a specific value. For the ProviderSchools that already exist, we will update the uuid that will be generated during this schema migration.

When creating new records during the datamigration, we pass the uuid explicitly to create a new record with proscribed uuid value.

When new provider schools are created in BAU, the uuid is generated by the db by default.

<details>
<summary><b>Strong migrations recommends adding this column in separate steps to avoid locking the table.</b></summary>

=== Dangerous operation detected #strong_migrations ===

Adding a column with a volatile default blocks reads and writes while the entire table is rewritten.
Instead, add the column without a default value, then change the default.

```ruby
class AddUuidToProviderSchool < ActiveRecord::Migration[8.1]
  def up
    add_column :provider_school, :uuid, :uuid
    change_column_default :provider_school, :uuid, "uuid_generate_v4()"
  end

  def down
    remove_column :provider_school, :uuid
  end
end
```

Then backfill the existing rows in the Rails console or a separate migration with disable_ddl_transaction!.

```ruby
class BackfillAddUuidToProviderSchool < ActiveRecord::Migration[8.1]
  disable_ddl_transaction!

  def up
    ProviderSchool.unscoped.in_batches(of: 10000) do |relation|
      relation.where(uuid: nil).update_all("uuid = uuid_generate_v4()")
      sleep(0.01)
    end
  end
end
```
Then add the NOT NULL constraint in separate migrations.

</details>

## Changes proposed in this pull request

1. Add UUID column to provider_school
2. Backfill uuid
3. Contrain the column to not null



## Guidance to review

The database task `*:with_data` will interleve the schema and data migrations so we can release in one go.

```
up     schema  20260703145835  Add uuid to provider school
up      data   20260706120000  Backfill provider school uuids
up     schema  20260706120100  Set provider school uuid not null
```


The next steps will be to update the *::School backfill to set the correct UUID for each provider school
## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
