### PR TITLE
Complete the snag list for the Salary fees feature

### DIFF
--- a/app/forms/publish/course_salary_fees_form.rb
+++ b/app/forms/publish/course_salary_fees_form.rb
@@ -8,7 +8,7 @@ module Publish
 
     attr_accessor(*FIELDS)
 
-    validates :salary_fee_details, words_count: { maximum: 250, message: :too_long }
+    validates :salary_fee_details, words_count: { maximum: 100, message: :too_long }
 
   private
 

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -90,6 +90,7 @@ class CourseEnrichment < ApplicationRecord
   validates :salary_details, presence: true, on: :publish, unless: :is_fee_based?
   validates :salary_details, words_count: { maximum: 250 }, unless: :is_fee_based?
 
+  validates :salary_fee_details, words_count: { maximum: 100 }
   # Requirements and qualifications
 
   validates :required_qualifications, presence: true, on: :publish, if: :required_qualifications_needed?

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -49,7 +49,7 @@
 
         <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>
 
-        <%= render partial: "publish/courses/fields/dynamic_preview", locals: { preview_heading: t(".preview_heading") } %>
+        <%= render partial: "publish/courses/fields/dynamic_preview", locals: { preview_heading: "" } %>
       </div>
       <%= f.govuk_submit t(".update") %>
     <% end %>

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -31,7 +31,7 @@
       </h1>
 
       <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
-        texts: [[t(".last_cycle_title"), @previous_cycle_enrichment&.salary_details]],
+        texts: [["", @previous_cycle_enrichment&.salary_details]],
       } %>
 
       <%= render partial: "publish/courses/markdown_formatting" %>

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -45,7 +45,7 @@
                 preview_output_target: "shared" },
         label: { text: t(".label"), size: "s" },
         rows: 15,
-        max_words: 250) %>
+        max_words: 100) %>
 
         <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>
 

--- a/app/views/publish/courses/salary_fees/edit.html.erb
+++ b/app/views/publish/courses/salary_fees/edit.html.erb
@@ -44,7 +44,7 @@
                 action: "input-preview#updatePreview",
                 preview_output_target: "shared" },
         label: { text: t(".label"), size: "s" },
-        rows: 15,
+        rows: 5,
         max_words: 100) %>
 
         <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>

--- a/config/locales/en/publish/courses/salary_fees.yml
+++ b/config/locales/en/publish/courses/salary_fees.yml
@@ -5,7 +5,6 @@ en:
         edit:
           course_salary_fees_title: Fees (optional)
           label: Give details about any fees or other costs that the trainee might have to pay (optional)
-          preview_heading: Fees
           update: Update fees
         update:
           course_salary_fee: Fees

--- a/config/locales/en/publish/courses/salary_fees.yml
+++ b/config/locales/en/publish/courses/salary_fees.yml
@@ -5,7 +5,6 @@ en:
         edit:
           course_salary_fees_title: Fees (optional)
           label: Give details about any fees or other costs that the trainee might have to pay (optional)
-          last_cycle_title: Salary fees
           preview_heading: Fees
           update: Update fees
         update:

--- a/spec/forms/publish/course_salary_fees_form_spec.rb
+++ b/spec/forms/publish/course_salary_fees_form_spec.rb
@@ -13,7 +13,7 @@ module Publish
     describe "validations" do
       context "when salary fee details are within the word limit" do
         before do
-          enrichment.salary_fee_details = Faker::Lorem.sentence(word_count: 250)
+          enrichment.salary_fee_details = Faker::Lorem.sentence(word_count: 100)
         end
 
         it "is valid" do
@@ -23,7 +23,7 @@ module Publish
 
       context "when salary fee details exceed the word limit" do
         before do
-          enrichment.salary_fee_details = Faker::Lorem.sentence(word_count: 251)
+          enrichment.salary_fee_details = Faker::Lorem.sentence(word_count: 101)
           subject.valid?
         end
 

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -139,6 +139,11 @@ RSpec.describe CourseEnrichment do
       expect(enrichment.reload.salary_fee_details).to eq("Some fees text")
       expect(enrichment.json_data).to include("SalaryFeeDetails" => "Some fees text")
     end
+
+    it "has a maximum worrd count of 100" do
+      expect(build(:course_enrichment, salary_fee_details: "a " * 101)).to be_invalid
+      expect(build(:course_enrichment, salary_fee_details: "a " * 100)).to be_valid
+    end
   end
 
   #


### PR DESCRIPTION
## Context

During the implementation of Salary fees , I missed some of the snags that were required.

1. Remove heading from within the What you wrote last year element
2. Remove heading in the dynamic preview
3. Reduce the word count from 250 to 100 for Salary fee details
4. Reduce the input row count to 5

|1|2&3|
|---|---|
|<img width="830" height="681" alt="image" src="https://github.com/user-attachments/assets/d2c87e88-f808-4b4b-8b3f-549277e79ed8" />|<img width="936" height="870" alt="image" src="https://github.com/user-attachments/assets/799210fe-19f3-4180-a98f-68ee5903d92f" />|



## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
