### PR TITLE
Add course wizard new school model

### DIFF
--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -33,7 +33,12 @@ module Courses
       end
 
       update_study_mode(course)
+      # Legacy site_status write always runs (it is the only home for vacancy
+      # and study-mode data). To move to strict "flag-on ⇒ new-model only"
+      # once vacancies migrate off site_status, guard this call with
+      # `unless FeatureFlag.active?(:course_publishing_uses_new_school_model)`.
       update_sites(course)
+      update_schools(course)
       update_study_sites(course)
 
       if assign_accrediting_provider_by_single_partner?(course)

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -118,6 +118,56 @@ module Courses
       course.errors.add(:sites, message: "Select at least one school") if site_ids.empty?
     end
 
+    # Dual-writes the selected schools to the new Course::School model,
+    # building the records in memory so they persist atomically with the
+    # course on save and are visible to CoursePublishableSchoolsPresence-
+    # Validator's :new-context read (which the new-school-model flag routes
+    # to course.schools). Mirrors the site→gias_school→provider_school
+    # mapping used by Publish::Schools::UpdateCourseSchoolsService.
+    def update_schools(course)
+      return if site_ids.nil?
+      # Nothing selected — update_sites already records the "Select at least
+      # one school" error; skip before touching `sites` (find([]) would raise).
+      return if site_ids.compact_blank.empty?
+
+      school_sites.each do |site|
+        gias_school = gias_schools_by_urn[site.urn]
+        next unless gias_school
+
+        provider_school = provider_schools_by_gias_id[gias_school.id]
+
+        unless provider_school
+          # No matching Provider::School yet — provider not fully backfilled
+          # (or its site predates the dual-write). Skip the new-model build;
+          # the schools backfill (or the next provider-side write) reconciles
+          # later. Same rationale as UpdateCourseSchoolsService#attach_school.
+          Rails.logger.warn(
+            "[CourseSchools] skipped course_school build — no provider_school for " \
+            "provider=#{provider.id} gias_school=#{gias_school.id}",
+          )
+          next
+        end
+
+        course.schools.build(gias_school_id: gias_school.id, site_code: provider_school.site_code)
+      end
+    end
+
+    def school_sites
+      @school_sites ||= sites.select(&:school?)
+    end
+
+    def gias_schools_by_urn
+      @gias_schools_by_urn ||= GiasSchool
+        .where(urn: school_sites.map(&:urn).compact_blank)
+        .index_by(&:urn)
+    end
+
+    def provider_schools_by_gias_id
+      @provider_schools_by_gias_id ||= provider.schools
+        .where(gias_school_id: gias_schools_by_urn.values.map(&:id))
+        .index_by(&:gias_school_id)
+    end
+
     def update_study_sites(course)
       return if study_site_ids.nil?
 

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -161,8 +161,13 @@ module Courses
       @school_sites ||= sites.select(&:school?)
     end
 
+    # Only map selectable (non-closed) GIAS schools into the new model. A site
+    # can still point at a school the GIAS import later flipped to closed; we
+    # intentionally leave that school out of course.schools (the legacy
+    # course.sites write above still keeps the site) so the new model never
+    # gains a closed school. `available` excludes only `closed`.
     def gias_schools_by_urn
-      @gias_schools_by_urn ||= GiasSchool
+      @gias_schools_by_urn ||= GiasSchool.available
         .where(urn: school_sites.map(&:urn).compact_blank)
         .index_by(&:urn)
     end

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -561,6 +561,24 @@ describe Courses::CreationService do
       end
     end
 
+    context "when the selected site's GIAS school is closed" do
+      # A site can still point at a school the GIAS import later flipped to
+      # closed. We must not build a Course::School for it, but the legacy site
+      # is still attached.
+      let!(:gias_school) { create(:gias_school, :closed, urn: site.urn) }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: "-") }
+
+      before do
+        allow(FeatureFlag).to receive(:active?).and_call_original
+        allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(false)
+      end
+
+      it "builds no Course::School but still attaches the legacy site" do
+        expect(created_course.schools).to be_empty
+        expect(created_course.sites.map(&:id)).to eq([site.id])
+      end
+    end
+
     context "when no schools are selected" do
       let(:valid_course_params) do
         {
@@ -574,6 +592,27 @@ describe Courses::CreationService do
       before do
         allow(FeatureFlag).to receive(:active?).and_call_original
         allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(false)
+      end
+
+      it "adds the existing error and builds no Course::School" do
+        expect(created_course.errors[:sites]).to include("Select at least one school")
+        expect(created_course.schools).to be_empty
+      end
+    end
+
+    context "when no schools are selected and the flag is on" do
+      let(:valid_course_params) do
+        {
+          "level" => "primary",
+          "qualification" => "qts",
+          "funding" => "fee",
+          "sites_ids" => [],
+        }
+      end
+
+      before do
+        allow(FeatureFlag).to receive(:active?).and_call_original
+        allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(true)
       end
 
       it "adds the existing error and builds no Course::School" do

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -469,4 +469,117 @@ describe Courses::CreationService do
       end
     end
   end
+
+  describe "writing schools to the new school data model" do
+    subject(:created_course) do
+      described_class.call(course_params: valid_course_params, provider:, next_available_course_code: true)
+    end
+
+    let(:primary_subject) { find_or_create(:primary_subject, :primary) }
+
+    # A GIAS school + provider_school that mirror the legacy `site` selected in
+    # the wizard, joined to the legacy site by matching URN (same mapping the
+    # edit flow uses in Publish::Schools::UpdateCourseSchoolsService).
+    let(:gias_school) { create(:gias_school, urn: site.urn) }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: "-") }
+
+    let(:valid_course_params) do
+      {
+        "age_range_in_years" => "3_to_7",
+        "applications_open_from" => recruitment_cycle.application_start_date,
+        "funding" => "fee",
+        "is_send" => "1",
+        "level" => "primary",
+        "qualification" => "qts",
+        "start_date" => "September #{recruitment_cycle.year}",
+        "study_mode" => %w[full_time],
+        "sites_ids" => [site.id],
+        "study_sites_ids" => [study_site.id],
+        "master_subject_id" => primary_subject.id,
+        "subjects_ids" => [primary_subject.id],
+      }
+    end
+
+    context "when the flag is off" do
+      before do
+        allow(FeatureFlag).to receive(:active?).and_call_original
+        allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(false)
+      end
+
+      it "dual-writes: builds both the legacy site_status and the new Course::School" do
+        expect(created_course.sites.map(&:id)).to eq([site.id])
+        expect(created_course.schools.map(&:gias_school_id)).to eq([gias_school.id])
+        expect(created_course.schools.first.site_code).to eq("-")
+        expect(created_course.errors).to be_empty
+      end
+
+      it "persists both models on save" do
+        created_course.save!
+
+        expect(created_course.reload.sites.map(&:id)).to eq([site.id])
+        expect(Course::School.where(course: created_course).pluck(:gias_school_id, :site_code))
+          .to eq([[gias_school.id, "-"]])
+      end
+    end
+
+    context "when the flag is on" do
+      before do
+        allow(FeatureFlag).to receive(:active?).and_call_original
+        allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(true)
+      end
+
+      it "builds the new Course::School and passes :new validation" do
+        expect(created_course.schools.map(&:gias_school_id)).to eq([gias_school.id])
+        expect(created_course.schools.first.site_code).to eq("-")
+        expect(created_course.errors).to be_empty
+      end
+
+      it "persists the Course::School on save" do
+        created_course.save!
+
+        expect(Course::School.where(course: created_course).pluck(:gias_school_id, :site_code))
+          .to eq([[gias_school.id, "-"]])
+      end
+    end
+
+    context "when there is no matching provider_school (not backfilled)" do
+      # GIAS school exists (matched by URN) but the provider has not been
+      # backfilled, so no Provider::School exists for the pair.
+      let!(:gias_school) { create(:gias_school, urn: site.urn) }
+      let!(:provider_school) { nil }
+
+      before do
+        allow(FeatureFlag).to receive(:active?).and_call_original
+        allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(false)
+      end
+
+      it "skips the new-model write, logs a warning, and still builds the legacy site_status" do
+        expect(Rails.logger).to receive(:warn).with(/course_school/)
+
+        expect(created_course.schools).to be_empty
+        expect(created_course.sites.map(&:id)).to eq([site.id])
+      end
+    end
+
+    context "when no schools are selected" do
+      let(:valid_course_params) do
+        {
+          "level" => "primary",
+          "qualification" => "qts",
+          "funding" => "fee",
+          "sites_ids" => [],
+        }
+      end
+
+      before do
+        allow(FeatureFlag).to receive(:active?).and_call_original
+        allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(false)
+      end
+
+      it "adds the existing error and builds no Course::School" do
+        expect(created_course.errors[:sites]).to include("Select at least one school")
+        expect(created_course.schools).to be_empty
+      end
+    end
+  end
 end

--- a/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
@@ -140,7 +140,8 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
 
-    expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
+    and_i_click_add_course
+    then_a_course_is_created
 
     created_course = provider.courses.order(:created_at).last
     visa_deadline = expected_visa_deadline_date
@@ -158,7 +159,8 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
 
-    expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
+    and_i_click_add_course
+    then_a_course_is_created
 
     created_course = provider.courses.order(:created_at).last
     visa_deadline = expected_visa_deadline_date
@@ -177,7 +179,8 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
 
-    expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
+    and_i_click_add_course
+    then_a_course_is_created
 
     then_the_created_course_has_the_new_course_school
     and_the_created_course_still_has_the_legacy_site
@@ -191,7 +194,8 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
 
-    expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
+    and_i_click_add_course
+    then_a_course_is_created
 
     then_the_created_course_has_the_new_course_school
   end
@@ -215,7 +219,8 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
     expect(page).to have_no_text("Skilled Worker visas")
     expect(page).to have_no_text("Visa sponsorship deadline")
 
-    expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
+    and_i_click_add_course
+    then_a_course_is_created
     created_course = provider.courses.order(:created_at).last
     expect(created_course.level).to eq("further_education")
     expect(created_course.qualification).to eq("pgde")
@@ -503,6 +508,10 @@ private
 
   def and_i_click_add_course
     click_on "Add course"
+  end
+
+  def then_a_course_is_created
+    expect(provider.courses.count).to eq(1)
   end
 
   # Mirror the selected legacy school into the new data model: a GIAS school

--- a/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
@@ -183,6 +183,19 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
     and_the_created_course_still_has_the_legacy_site
   end
 
+  scenario "writes the selected school to the new Course::School model when the flag is on" do
+    FeatureFlag.activate(:course_publishing_uses_new_school_model)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    and_the_selected_school_is_mapped_to_the_new_model
+    given_i_have_completed_secondary_fee_wizard_state
+    when_i_visit_check_answers_page
+    then_i_am_taken_to_the_check_answers_page
+
+    expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
+
+    then_the_created_course_has_the_new_course_school
+  end
+
   scenario "further education flow renders expected rows and creates successfully" do
     given_i_have_completed_further_education_wizard_state
     when_i_visit_check_answers_page

--- a/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Add course wizard check your answers navigation", type: :system do
   before do
     FeatureFlag.activate(:wizard_add_course_flow)
-    given_i_am_authenticated_as_a_provider_user(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_a_provider_user(cycle_year: Find::CycleTimetable.current_year)
   end
 
   scenario "every TDA change-link row round-trips back to check answers" do
@@ -23,7 +23,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
   end
 
   scenario "every fee-branch change-link row navigates to the expected step" do
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     given_i_have_completed_secondary_fee_wizard_state
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
@@ -37,7 +37,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
   end
 
   scenario "every salary-branch change-link row navigates to the expected step" do
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     given_i_have_completed_secondary_salary_wizard_state
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
@@ -86,7 +86,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
   end
 
   scenario "shows fee-branch rows including accredited provider and visa sponsorship" do
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     given_i_have_completed_secondary_fee_wizard_state
 
     when_i_visit_check_answers_page
@@ -95,7 +95,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
   end
 
   scenario "shows skilled worker visa row on salary branch" do
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     given_i_have_completed_secondary_salary_wizard_state
 
     when_i_visit_check_answers_page
@@ -135,7 +135,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
   end
 
   scenario "creates a course from secondary fee branch with mapped attributes" do
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     given_i_have_completed_secondary_fee_wizard_state
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
@@ -153,7 +153,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
   end
 
   scenario "creates a course from secondary salary branch with mapped attributes" do
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     given_i_have_completed_secondary_salary_wizard_state
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
@@ -171,7 +171,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
   end
 
   scenario "writes the selected school to the new Course::School model when the flag is off" do
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     and_the_selected_school_is_mapped_to_the_new_model
     given_i_have_completed_secondary_fee_wizard_state
     when_i_visit_check_answers_page
@@ -185,7 +185,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
 
   scenario "writes the selected school to the new Course::School model when the flag is on" do
     FeatureFlag.activate(:course_publishing_uses_new_school_model)
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     and_the_selected_school_is_mapped_to_the_new_model
     given_i_have_completed_secondary_fee_wizard_state
     when_i_visit_check_answers_page
@@ -243,7 +243,7 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
   end
 
   scenario "shows visa deadline question as no and hides date row when deadline step is skipped" do
-    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Find::CycleTimetable.current_year)
     given_i_have_completed_secondary_fee_wizard_state_with_no_visa_deadline
     when_i_visit_check_answers_page
     then_i_am_taken_to_the_check_answers_page
@@ -365,7 +365,7 @@ private
       qualification: "undergraduate_degree_with_qts",
       site_ids: [placement_site.id.to_s],
       study_sites_ids: [study_site.id.to_s],
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
       visa_sponsorship_application_deadline_required: false,
     )
@@ -390,7 +390,7 @@ private
       qualification: "undergraduate_degree_with_qts",
       site_ids: [@placement_site.id.to_s],
       study_sites_ids: [],
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
       visa_sponsorship_application_deadline_required: false,
     )
@@ -417,7 +417,7 @@ private
       study_pattern: %w[full_time],
       site_ids: [@placement_site.id.to_s],
       study_sites_ids: [],
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
       visa_sponsorship_application_deadline_required: false,
     )
@@ -585,7 +585,7 @@ private
       can_sponsor_student_visa: true,
       visa_sponsorship_application_deadline_required: true,
       visa_sponsorship_application_deadline_at: visa_deadline_date_parts,
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
     )
   end
 
@@ -619,7 +619,7 @@ private
       can_sponsor_skilled_worker_visa: true,
       visa_sponsorship_application_deadline_required: true,
       visa_sponsorship_application_deadline_at: visa_deadline_date_parts,
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
     )
   end
 
@@ -653,7 +653,7 @@ private
       study_sites_ids: [study_site.id.to_s],
       can_sponsor_student_visa: false,
       visa_sponsorship_application_deadline_required: false,
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
     )
   end
 
@@ -678,7 +678,7 @@ private
       study_pattern: %w[full_time],
       site_ids: [placement_site.id.to_s],
       study_sites_ids: [study_site.id.to_s],
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
       primary_master_subject_id: nil,
       secondary_master_subject_id: nil,
@@ -708,14 +708,14 @@ private
       qualification: "undergraduate_degree_with_qts",
       site_ids: [placement_site.id.to_s],
       study_sites_ids: [study_site.id.to_s],
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
       visa_sponsorship_application_deadline_required: false,
     )
   end
 
   def given_i_have_completed_secondary_fee_wizard_state_with_single_partner
-    given_i_am_authenticated_as_school_provider_with_single_partner(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_school_provider_with_single_partner(cycle_year: Find::CycleTimetable.current_year)
     physics = find_or_create(:secondary_subject, :physics)
     business = find_or_create(:secondary_subject, :business_studies)
     placement_site = provider.sites.first || create(:site, provider:)
@@ -741,7 +741,7 @@ private
       study_sites_ids: [study_site.id.to_s],
       can_sponsor_student_visa: true,
       visa_sponsorship_application_deadline_required: false,
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
     )
   end
 
@@ -774,7 +774,7 @@ private
       can_sponsor_student_visa: true,
       visa_sponsorship_application_deadline_required: false,
       visa_sponsorship_application_deadline_at: nil,
-      start_date: current_cycle_current_month_label(cycle_year: Date.current.year),
+      start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
     )
   end
 

--- a/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
@@ -170,6 +170,19 @@ RSpec.describe "Add course wizard check your answers navigation", type: :system 
     expect(created_course.visa_sponsorship_application_deadline_at.to_date).to eq(visa_deadline)
   end
 
+  scenario "writes the selected school to the new Course::School model when the flag is off" do
+    given_i_am_authenticated_as_school_provider_with_partners(cycle_year: Date.current.year)
+    and_the_selected_school_is_mapped_to_the_new_model
+    given_i_have_completed_secondary_fee_wizard_state
+    when_i_visit_check_answers_page
+    then_i_am_taken_to_the_check_answers_page
+
+    expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
+
+    then_the_created_course_has_the_new_course_school
+    and_the_created_course_still_has_the_legacy_site
+  end
+
   scenario "further education flow renders expected rows and creates successfully" do
     given_i_have_completed_further_education_wizard_state
     when_i_visit_check_answers_page
@@ -477,6 +490,26 @@ private
 
   def and_i_click_add_course
     click_on "Add course"
+  end
+
+  # Mirror the selected legacy school into the new data model: a GIAS school
+  # matched by URN plus a Provider::School carrying the site_code. This is the
+  # backfilled state the add-course flow maps through when writing Course::School.
+  def and_the_selected_school_is_mapped_to_the_new_model
+    @selected_site = provider.sites.first
+    @gias_school = create(:gias_school, urn: @selected_site.urn)
+    create(:provider_school, provider:, gias_school: @gias_school, site_code: @selected_site.code)
+  end
+
+  def then_the_created_course_has_the_new_course_school
+    created_course = provider.courses.order(:created_at).last
+    expect(created_course.schools.map(&:gias_school_id)).to eq([@gias_school.id])
+    expect(created_course.schools.first.site_code).to eq(@selected_site.code)
+  end
+
+  def and_the_created_course_still_has_the_legacy_site
+    created_course = provider.courses.order(:created_at).last
+    expect(created_course.sites.map(&:id)).to include(@selected_site.id)
   end
 
   def current_cycle_current_month_label(cycle_year:)

--- a/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
@@ -5,13 +5,13 @@ require "rails_helper"
 RSpec.describe "Add course wizard start date step when qualification is undergraduate degree with qts", type: :system do
   before do
     FeatureFlag.activate(:wizard_add_course_flow)
-    given_i_am_authenticated_as_a_provider_user(cycle_year: Date.current.year)
+    given_i_am_authenticated_as_a_provider_user(cycle_year: Find::CycleTimetable.current_year)
   end
 
   scenario "choosing a start date and adds the course from check answers" do
     and_i_have_wizard_state_for_start_date
     when_i_visit_the_wizard_start_date_page
-    and_i_choose_a_start_date(current_cycle_current_month_label(cycle_year: Date.current.year))
+    and_i_choose_a_start_date(current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year))
     and_i_click_continue
     then_i_am_taken_to_the_check_answers_page
     expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
@@ -21,7 +21,7 @@ RSpec.describe "Add course wizard start date step when qualification is undergra
   scenario "failed course creation rerenders check answers with the error summary" do
     and_i_have_wizard_state_for_start_date
     when_i_visit_the_wizard_start_date_page
-    and_i_choose_a_start_date(current_cycle_current_month_label(cycle_year: Date.current.year))
+    and_i_choose_a_start_date(current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year))
     and_i_click_continue
     then_i_am_taken_to_the_check_answers_page
 
@@ -38,18 +38,18 @@ RSpec.describe "Add course wizard start date step when qualification is undergra
   scenario "editing start date from check answers returns to check answers with updated value" do
     and_i_have_wizard_state_for_start_date
     when_i_visit_the_wizard_start_date_page
-    and_i_choose_a_start_date(current_cycle_current_month_label(cycle_year: Date.current.year))
+    and_i_choose_a_start_date(current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year))
     and_i_click_continue
     then_i_am_taken_to_the_check_answers_page
 
     when_i_visit_start_date_for_review
     then_i_am_taken_back_to_start_date_page_for_review
 
-    and_i_choose_a_start_date(alternative_start_date_label(cycle_year: Date.current.year))
+    and_i_choose_a_start_date(alternative_start_date_label(cycle_year: Find::CycleTimetable.current_year))
     and_i_click_continue
 
     then_i_am_taken_to_the_check_answers_page
-    then_i_see_the_updated_start_date_is_persisted(alternative_start_date_label(cycle_year: Date.current.year))
+    then_i_see_the_updated_start_date_is_persisted(alternative_start_date_label(cycle_year: Find::CycleTimetable.current_year))
   end
 
   scenario "submitting start date without selecting an option shows validation errors" do
@@ -64,20 +64,20 @@ RSpec.describe "Add course wizard start date step when qualification is undergra
     when_i_visit_the_wizard_start_date_page
 
     expect(page).to have_content("Course start date")
-    expect(page).to have_field(current_cycle_current_month_label(cycle_year: Date.current.year))
-    expect(page).to have_field("July #{Date.current.year + 1}")
-    expect(page).not_to have_field(previous_month_label(cycle_year: Date.current.year)) if Date.current.month > 1
+    expect(page).to have_field(current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year))
+    expect(page).to have_field("July #{Find::CycleTimetable.current_year + 1}")
+    expect(page).not_to have_field(previous_month_label(cycle_year: Find::CycleTimetable.current_year)) if Date.current.month > 1
   end
 
   scenario "shows options starting from January when provider recruitment cycle is in the future" do
-    given_i_am_authenticated_as_a_provider_user(cycle_year: Date.current.year + 1)
+    given_i_am_authenticated_as_a_provider_user(cycle_year: Find::CycleTimetable.current_year + 1)
     and_i_have_wizard_state_for_start_date
     when_i_visit_the_wizard_start_date_page
 
     expect(page).to have_content("Course start date")
-    expect(page).to have_field("January #{Date.current.year + 1}")
-    expect(page).not_to have_field("December #{Date.current.year}")
-    expect(page).to have_field("July #{Date.current.year + 2}")
+    expect(page).to have_field("January #{Find::CycleTimetable.current_year + 1}")
+    expect(page).not_to have_field("December #{Find::CycleTimetable.current_year}")
+    expect(page).to have_field("July #{Find::CycleTimetable.current_year + 2}")
   end
 
 private

--- a/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe "Add course wizard start date step when qualification is undergra
     and_i_choose_a_start_date(current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year))
     and_i_click_continue
     then_i_am_taken_to_the_check_answers_page
-    expect { and_i_click_add_course }.to change { provider.courses.count }.by(1)
+    and_i_click_add_course
+    then_a_course_is_created
     then_i_am_taken_to_the_courses_index_page
   end
 
@@ -114,6 +115,10 @@ private
 
   def and_i_click_add_course
     click_on "Add course"
+  end
+
+  def then_a_course_is_created
+    expect(provider.courses.count).to eq(1)
   end
 
   def then_i_am_taken_to_the_courses_index_page

--- a/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
@@ -66,19 +66,19 @@ RSpec.describe "Add course wizard start date step when qualification is undergra
 
     expect(page).to have_content("Course start date")
     expect(page).to have_field(current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year))
-    expect(page).to have_field("July #{Find::CycleTimetable.current_year + 1}")
+    expect(page).to have_field("July #{Find::CycleTimetable.next_year}")
     expect(page).not_to have_field(previous_month_label(cycle_year: Find::CycleTimetable.current_year)) if Date.current.month > 1
   end
 
   scenario "shows options starting from January when provider recruitment cycle is in the future" do
-    given_i_am_authenticated_as_a_provider_user(cycle_year: Find::CycleTimetable.current_year + 1)
+    given_i_am_authenticated_as_a_provider_user(cycle_year: Find::CycleTimetable.next_year)
     and_i_have_wizard_state_for_start_date
     when_i_visit_the_wizard_start_date_page
 
     expect(page).to have_content("Course start date")
-    expect(page).to have_field("January #{Find::CycleTimetable.current_year + 1}")
+    expect(page).to have_field("January #{Find::CycleTimetable.next_year}")
     expect(page).not_to have_field("December #{Find::CycleTimetable.current_year}")
-    expect(page).to have_field("July #{Find::CycleTimetable.current_year + 2}")
+    expect(page).to have_field("July #{Find::CycleTimetable.next_year + 1}")
   end
 
 private


### PR DESCRIPTION
## Context

The add course flow wizard currently allows providers to add schools to a new course while creating the course.

This flow currently uses the legacy site data model when storing the selected schools.

As part of the school data remodel, the add course flow wizard needs to support the new school data model and write to the new course_school relationship backed by provider_school and gias_school.
