### PR TITLE
Placement schools details component

### DIFF
--- a/app/components/publish/schools/attached_schools_summary_component.html.erb
+++ b/app/components/publish/schools/attached_schools_summary_component.html.erb
@@ -1,0 +1,11 @@
+<% if school_names.empty? %>
+  <span class="app-!-colour-muted">None</span>
+<% elsif school_names.one? %>
+  <%= school_names.first %>
+<% elsif details? %>
+  <%= govuk_details(summary_text: summary_text) do %>
+    <%= school_list %>
+  <% end %>
+<% else %>
+  <%= school_list %>
+<% end %>

--- a/app/components/publish/schools/attached_schools_summary_component.rb
+++ b/app/components/publish/schools/attached_schools_summary_component.rb
@@ -11,9 +11,9 @@ module Publish
       attr_reader :course
 
       def initialize(course:)
-        @course = course
-
         super()
+
+        @course = course
       end
 
       def school_names

--- a/app/components/publish/schools/attached_schools_summary_component.rb
+++ b/app/components/publish/schools/attached_schools_summary_component.rb
@@ -1,0 +1,38 @@
+module Publish
+  module Schools
+    # Renders the "Placement/Employing schools" value on a course's basic details
+    # summary list. Shows the list inline for a handful of schools, but collapses
+    # it into a GOV.UK details component (with the count as the summary link) once
+    # there are more than SCHOOLS_DETAILS_THRESHOLD, so long lists are less
+    # prominent and easier to scan.
+    class AttachedSchoolsSummaryComponent < ViewComponent::Base
+      SCHOOLS_DETAILS_THRESHOLD = 5
+
+      attr_reader :course
+
+      def initialize(course:)
+        @course = course
+
+        super()
+      end
+
+      def school_names
+        @school_names ||= course.sorted_school_names
+      end
+
+      def details?
+        school_names.size > SCHOOLS_DETAILS_THRESHOLD
+      end
+
+      def summary_text
+        t("publish.courses.schools.attached", count: school_names.size)
+      end
+
+      def school_list
+        content_tag(:ul, class: "govuk-list") do
+          safe_join(school_names.map { |name| content_tag(:li, name) })
+        end
+      end
+    end
+  end
+end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -153,6 +153,20 @@ class CourseDecorator < ApplicationDecorator
     object.sites.sort_by(&:location_name)
   end
 
+  # Display names of the schools attached to the course, alphabetically sorted.
+  # Reads from the new Course::School/GiasSchool model or the legacy Site model
+  # depending on the :course_publishing_uses_new_school_model rollout flag, so
+  # the schools list keeps working from either data model.
+  def sorted_school_names
+    names = if FeatureFlag.active?(:course_publishing_uses_new_school_model)
+              object.gias_schools.map(&:name)
+            else
+              object.sites.map(&:location_name)
+            end
+
+    names.sort_by(&:downcase)
+  end
+
   def alphabetically_sorted_study_sites
     object.study_sites.sort_by(&:location_name)
   end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -101,19 +101,12 @@
      end
 
      summary_list.with_row(html_attributes: { data: { qa: "course__schools" } }) do |row|
-       row.with_key { school_label_with_plural(course, count: course.sites.length) }
+       row.with_key { school_label_with_plural(course, count: course.sorted_school_names.length) }
        row.with_value do
          if course.recruitment_cycle_rollover_period_2026?
            raw(render(::Publish::Schools::SchoolSummaryValueComponent.new(course:)))
-         elsif course.sites.blank?
-           raw("<span class=\"app-!-colour-muted\">None</span>")
-         elsif course.sites.size == 1
-           course.sites.first.location_name
          else
-           school_names = course.alphabetically_sorted_sites.map do |site|
-             "<li>#{site.location_name}</li>"
-           end
-           raw("<ul class=\"govuk-list\">#{school_names.join}</ul>")
+           raw(render(::Publish::Schools::AttachedSchoolsSummaryComponent.new(course:)))
          end
        end
 

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -101,19 +101,9 @@
         <% end %>
 
         <% summary_list.with_row(html_attributes: { data: { qa: "course__schools" } }) do |row| %>
-          <% row.with_key { school_label_with_plural(course, count: course.sites.length) } %>
+          <% row.with_key { school_label_with_plural(course, count: course.sorted_school_names.length) } %>
           <% row.with_value do %>
-            <% if course.sites.nil? || course.sites.empty? %>
-              <span class="app-!-colour-muted"><%= t(".none") %></span>
-            <% elsif course.sites.size == 1 %>
-              <%= course.sites.first.location_name %>
-            <% else %>
-              <ul class="govuk-list">
-                <% course.alphabetically_sorted_sites.each do |site| %>
-                  <li><%= site.location_name %></li>
-                <% end %>
-              </ul>
-            <% end %>
+            <%= render(::Publish::Schools::AttachedSchoolsSummaryComponent.new(course:)) %>
           <% end %>
           <% if @course.provider.sites.count > 1 %>
             <% row.with_action(

--- a/app/views/publish/courses/details.html.erb
+++ b/app/views/publish/courses/details.html.erb
@@ -37,7 +37,7 @@
 
 <section class="app-section" id="basic_details">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
       <%= render partial: "basic_details_tab" %>
     </div>
   </div>

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -37,6 +37,9 @@ en:
         label:
           one: "%{prefix} school"
           other: "%{prefix} schools"
+        attached:
+          one: "%{count} school attached"
+          other: "%{count} schools attached"
         new:
           schools_selection: The more schools you select, the more searches your course will appear in. You should only add schools that are relevent to this course.
           searches_by_location: 60% of searches are by location.

--- a/spec/components/publish/schools/attached_schools_summary_component_spec.rb
+++ b/spec/components/publish/schools/attached_schools_summary_component_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Publish::Schools::AttachedSchoolsSummaryComponent, type: :component do
+  subject(:rendered) { render_inline(described_class.new(course:)) }
+
+  let(:course) { build_stubbed(:course).decorate }
+
+  def stub_school_names(names)
+    allow(course).to receive(:sorted_school_names).and_return(names)
+  end
+
+  context "when there are no schools" do
+    before { stub_school_names([]) }
+
+    it "renders a muted None" do
+      expect(rendered.css(".app-\\!-colour-muted").text).to eq("None")
+    end
+
+    it "does not render a details component or a list" do
+      expect(rendered.css("details")).to be_empty
+      expect(rendered.css("ul")).to be_empty
+    end
+  end
+
+  context "when there is a single school" do
+    before { stub_school_names(["Greenhill Academy"]) }
+
+    it "renders the school name inline without a list or details" do
+      expect(rendered.text).to include("Greenhill Academy")
+      expect(rendered.css("ul")).to be_empty
+      expect(rendered.css("details")).to be_empty
+    end
+  end
+
+  context "when there are 5 schools (at the threshold)" do
+    let(:names) { Array.new(5) { |i| "School #{i + 1}" } }
+
+    before { stub_school_names(names) }
+
+    it "renders a plain list, not a details component" do
+      expect(rendered.css("ul.govuk-list li").map(&:text)).to eq(names)
+      expect(rendered.css("details")).to be_empty
+    end
+  end
+
+  context "when there are 6 or more schools" do
+    let(:names) { Array.new(6) { |i| "School #{i + 1}" } }
+
+    before { stub_school_names(names) }
+
+    it "wraps the list in a details component" do
+      expect(rendered.css("details ul.govuk-list li").map(&:text)).to eq(names)
+    end
+
+    it "uses the school count as the summary link text" do
+      expect(rendered.css("details summary").text).to include("6 schools attached")
+    end
+  end
+end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -893,4 +893,35 @@ describe CourseDecorator do
       end
     end
   end
+
+  describe "#sorted_school_names" do
+    context "when the new school model flag is off (legacy sites)" do
+      let(:course) do
+        create(:course, sites: [
+          build(:site, location_name: "Zebra School"),
+          build(:site, location_name: "alpha school"),
+          build(:site, location_name: "Mango School"),
+        ])
+      end
+
+      it "returns site location names sorted case-insensitively" do
+        expect(course.decorate.sorted_school_names).to eq(["alpha school", "Mango School", "Zebra School"])
+      end
+    end
+
+    context "when the new school model flag is on (Course::School / GiasSchool)" do
+      let(:course) { create(:course) }
+
+      before do
+        FeatureFlag.activate(:course_publishing_uses_new_school_model)
+        create(:course_school, course:, gias_school: build(:gias_school, name: "Zebra School"))
+        create(:course_school, course:, gias_school: build(:gias_school, name: "alpha school"))
+        create(:course_school, course:, gias_school: build(:gias_school, name: "Mango School"))
+      end
+
+      it "returns gias school names sorted case-insensitively" do
+        expect(course.decorate.sorted_school_names).to eq(["alpha school", "Mango School", "Zebra School"])
+      end
+    end
+  end
 end

--- a/spec/system/publish/courses/viewing_placement_schools_on_basic_details_spec.rb
+++ b/spec/system/publish/courses/viewing_placement_schools_on_basic_details_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Viewing placement schools on the basic details tab", travel: mid_cycle(2026) do
+  before { given_i_am_authenticated_as_a_provider_user }
+
+  scenario "with 6 or more schools the list collapses into a details component" do
+    given_a_course_with_school_count(6)
+    when_i_visit_the_course_basic_details_page
+    then_the_schools_are_inside_a_details_component
+    and_the_details_summary_shows_the_count(6)
+  end
+
+  scenario "with 5 or fewer schools the list is shown inline" do
+    given_a_course_with_school_count(5)
+    when_i_visit_the_course_basic_details_page
+    then_the_schools_are_shown_inline_without_a_details_component
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, providers: [build(:provider)]))
+  end
+
+  def provider
+    @provider ||= current_user.providers.first
+  end
+
+  def given_a_course_with_school_count(count)
+    sites = Array.new(count) { |i| build(:site, provider:, location_name: sprintf("School %02d", i + 1)) }
+    @course = create(:course, provider:, sites:)
+  end
+
+  def when_i_visit_the_course_basic_details_page
+    visit details_publish_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      provider.recruitment_cycle_year,
+      @course.course_code,
+    )
+  end
+
+  def schools_row
+    page.find('[data-qa="course__schools"]')
+  end
+
+  def then_the_schools_are_inside_a_details_component
+    # The list is collapsed inside the details component, so its content is
+    # hidden until the summary is toggled — assert against all elements.
+    expect(schools_row).to have_css("details ul.govuk-list li", text: "School 01", visible: :all)
+  end
+
+  def and_the_details_summary_shows_the_count(count)
+    expect(schools_row).to have_css("details summary", text: "#{count} schools attached")
+  end
+
+  def then_the_schools_are_shown_inline_without_a_details_component
+    expect(schools_row).to have_no_css("details")
+    expect(schools_row).to have_css("ul.govuk-list li", text: "School 01")
+  end
+end


### PR DESCRIPTION
## Context

Research with larger and national providers found the long list of attached placement schools on a course's **Basic details** tab unhelpful and too prominent. Providers want to see the *number* of schools at a glance to cross-check a course, and long school names currently wrap over two lines, making the list hard to scan.

## What this does

- Collapses the placement/employing schools list into a GOV.UK **details component** when there are **6 or more** schools, using the count as the summary link (e.g. "38 schools attached"). **5 or fewer** render inline as before.
- Makes the Basic details summary list **full column width** so long school names no longer wrap.
- Reads the schools list from either the legacy `Site` model or the new `Course::School` / `GiasSchool` model, switched by the existing `course_publishing_uses_new_school_model` flag, so the display keeps working from either data model as the rollout progresses.

The same component is reused on the add-course wizard confirmation page. The 2026 rollover validation view is deliberately left unchanged.

## How it works

- New `CourseDecorator#sorted_school_names` centralises the flag switch and returns the school names alphabetically.
- New `Publish::Schools::AttachedSchoolsSummaryComponent` renders None / single name / inline list / details based on the count.
