### PR TITLE
Add interruption page tracking

### DIFF
--- a/app/views/find/courses/school_experience_interstitial.html.erb
+++ b/app/views/find/courses/school_experience_interstitial.html.erb
@@ -20,25 +20,34 @@
       <p class="govuk-body govuk-!-margin-bottom-0">
         <%= govuk_link_to(
               t("find.courses.confirm_apply.school_experience_interruption.contact_provider", provider_name: @course.provider_name),
-              find_provider_path(@course.provider_code, @course.course_code),
+              find_track_click_path(
+                url: find_provider_path(@course.provider_code, @course.course_code),
+                utm_content: "school_experience_interruption_contact_provider",
+              ),
             ) %>
       </p>
 
       <h3 class="govuk-heading-s govuk-!-margin-top-5"><%= t("find.courses.confirm_apply.school_experience_interruption.question_heading") %></h3>
       <%= govuk_button_link_to(
             t("find.courses.confirm_apply.school_experience_interruption.confirm_button"),
-            find_confirm_apply_path(
-              provider_code: @course.provider.provider_code,
-              course_code: @course.course_code,
+            find_track_click_path(
+              url: find_confirm_apply_path(
+                provider_code: @course.provider.provider_code,
+                course_code: @course.course_code,
+              ),
+              utm_content: "school_experience_interruption_confirm_button",
             ),
           ) %>
 
       <p class="govuk-body govuk-!-margin-bottom-0">
         <%= govuk_link_to(
               t("find.courses.confirm_apply.cancel"),
-              find_course_path(
-                provider_code: @course.provider_code,
-                course_code: @course.course_code,
+              find_track_click_path(
+                url: find_course_path(
+                  provider_code: @course.provider_code,
+                  course_code: @course.course_code,
+                ),
+                utm_content: "school_experience_interruption_cancel_link",
               ),
               class: "govuk-link govuk-body",
             ) %>
@@ -53,7 +62,10 @@
               "find.courses.confirm_apply.school_experience_interruption.salaried_callout_body_two_html",
               bursaries_and_scholarships_link: govuk_link_to(
                 t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_text"),
-                t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_url"),
+                find_track_click_path(
+                  url: t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_url"),
+                  utm_content: "school_experience_interruption_bursaries_and_scholarships",
+                ),
                 target: "_blank",
               ),
             ) %>

--- a/app/views/find/courses/school_experience_interstitial.html.erb
+++ b/app/views/find/courses/school_experience_interstitial.html.erb
@@ -20,8 +20,9 @@
       <p class="govuk-body govuk-!-margin-bottom-0">
         <%= govuk_link_to(
               t("find.courses.confirm_apply.school_experience_interruption.contact_provider", provider_name: @course.provider_name),
-              find_track_click_path(
-                url: find_provider_path(@course.provider_code, @course.course_code),
+              find_provider_path(
+                @course.provider_code,
+                @course.course_code,
                 utm_content: "school_experience_interruption_contact_provider",
               ),
             ) %>
@@ -30,11 +31,9 @@
       <h3 class="govuk-heading-s govuk-!-margin-top-5"><%= t("find.courses.confirm_apply.school_experience_interruption.question_heading") %></h3>
       <%= govuk_button_link_to(
             t("find.courses.confirm_apply.school_experience_interruption.confirm_button"),
-            find_track_click_path(
-              url: find_confirm_apply_path(
-                provider_code: @course.provider.provider_code,
-                course_code: @course.course_code,
-              ),
+            find_confirm_apply_path(
+              provider_code: @course.provider.provider_code,
+              course_code: @course.course_code,
               utm_content: "school_experience_interruption_confirm_button",
             ),
           ) %>
@@ -42,11 +41,9 @@
       <p class="govuk-body govuk-!-margin-bottom-0">
         <%= govuk_link_to(
               t("find.courses.confirm_apply.cancel"),
-              find_track_click_path(
-                url: find_course_path(
-                  provider_code: @course.provider_code,
-                  course_code: @course.course_code,
-                ),
+              find_course_path(
+                provider_code: @course.provider_code,
+                course_code: @course.course_code,
                 utm_content: "school_experience_interruption_cancel_link",
               ),
               class: "govuk-link govuk-body",
@@ -62,9 +59,10 @@
               "find.courses.confirm_apply.school_experience_interruption.salaried_callout_body_two_html",
               bursaries_and_scholarships_link: govuk_link_to(
                 t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_text"),
-                find_track_click_path(
-                  url: t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_url"),
-                  utm_content: "school_experience_interruption_bursaries_and_scholarships",
+                with_utm(
+                  t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_url"),
+                  params: {},
+                  content: "school_experience_interruption_bursaries_and_scholarships",
                 ),
                 target: "_blank",
               ),
@@ -73,9 +71,10 @@
       <p class="govuk-body govuk-!-margin-bottom-0">
         <%= govuk_link_to(
               t("find.courses.confirm_apply.school_experience_interruption.salaried_callout_link_text"),
-              find_track_click_path(
-                url: t("find.get_into_teaching.url_teacher_salaries"),
-                utm_content: "school_experience_interruption_salaried_courses",
+              with_utm(
+                t("find.get_into_teaching.url_teacher_salaries"),
+                params: {},
+                content: "school_experience_interruption_salaried_courses",
               ),
             ) %>
       </p>
@@ -88,9 +87,10 @@
               "find.courses.confirm_apply.school_experience_interruption.adviser_callout_body_html",
               teacher_training_adviser_link: govuk_link_to(
                 t("find.courses.confirm_apply.school_experience_interruption.adviser_callout_link_text"),
-                find_track_click_path(
-                  url: t("find.get_into_teaching.url_training_adviser"),
-                  utm_content: "school_experience_interruption_teacher_training_adviser",
+                with_utm(
+                  t("find.get_into_teaching.url_training_adviser"),
+                  params: {},
+                  content: "school_experience_interruption_teacher_training_adviser",
                 ),
               ),
             ) %>

--- a/app/views/find/courses/school_experience_interstitial.html.erb
+++ b/app/views/find/courses/school_experience_interstitial.html.erb
@@ -59,10 +59,9 @@
               "find.courses.confirm_apply.school_experience_interruption.salaried_callout_body_two_html",
               bursaries_and_scholarships_link: govuk_link_to(
                 t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_text"),
-                with_utm(
-                  t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_url"),
-                  params: {},
-                  content: "school_experience_interruption_bursaries_and_scholarships",
+                find_track_click_path(
+                  url: t("find.courses.confirm_apply.school_experience_interruption.bursaries_and_scholarships_link_url"),
+                  utm_content: "school_experience_interruption_bursaries_and_scholarships",
                 ),
                 target: "_blank",
               ),
@@ -71,10 +70,9 @@
       <p class="govuk-body govuk-!-margin-bottom-0">
         <%= govuk_link_to(
               t("find.courses.confirm_apply.school_experience_interruption.salaried_callout_link_text"),
-              with_utm(
-                t("find.get_into_teaching.url_teacher_salaries"),
-                params: {},
-                content: "school_experience_interruption_salaried_courses",
+              find_track_click_path(
+                url: t("find.get_into_teaching.url_teacher_salaries"),
+                utm_content: "school_experience_interruption_salaried_courses",
               ),
             ) %>
       </p>
@@ -87,10 +85,9 @@
               "find.courses.confirm_apply.school_experience_interruption.adviser_callout_body_html",
               teacher_training_adviser_link: govuk_link_to(
                 t("find.courses.confirm_apply.school_experience_interruption.adviser_callout_link_text"),
-                with_utm(
-                  t("find.get_into_teaching.url_training_adviser"),
-                  params: {},
-                  content: "school_experience_interruption_teacher_training_adviser",
+                find_track_click_path(
+                  url: t("find.get_into_teaching.url_training_adviser"),
+                  utm_content: "school_experience_interruption_teacher_training_adviser",
                 ),
               ),
             ) %>

--- a/spec/system/find/courses/apply_for_course_spec.rb
+++ b/spec/system/find/courses/apply_for_course_spec.rb
@@ -90,23 +90,26 @@ RSpec.describe "Saving a course", service: :find do
 
     expect(page).to have_link(
       "For more information contact #{@course.provider_name}.",
-      href: find_track_click_path(
-        url: find_provider_path(@course.provider_code, @course.course_code),
+      href: find_provider_path(
+        @course.provider_code,
+        @course.course_code,
         utm_content: "school_experience_interruption_contact_provider",
       ),
     )
 
     expect(page).to have_link(
       "Yes, I understand the school experience requirements",
-      href: find_track_click_path(
-        url: find_confirm_apply_path(provider_code: @course.provider.provider_code, course_code: @course.course_code),
+      href: find_confirm_apply_path(
+        provider_code: @course.provider.provider_code,
+        course_code: @course.course_code,
         utm_content: "school_experience_interruption_confirm_button",
       ),
     )
     expect(page).to have_link(
       "Cancel and return to the course page",
-      href: find_track_click_path(
-        url: find_course_path(provider_code: @course.provider_code, course_code: @course.course_code),
+      href: find_course_path(
+        provider_code: @course.provider_code,
+        course_code: @course.course_code,
         utm_content: "school_experience_interruption_cancel_link",
       ),
     )
@@ -114,10 +117,7 @@ RSpec.describe "Saving a course", service: :find do
     expect(page).to have_content("Get free one-to-one support")
     expect(page).to have_link(
       "bursaries or scholarships",
-      href: find_track_click_path(
-        url: "https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries",
-        utm_content: "school_experience_interruption_bursaries_and_scholarships",
-      ),
+      href: "https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries?utm_content=school_experience_interruption_bursaries_and_scholarships",
     )
   end
 

--- a/spec/system/find/courses/apply_for_course_spec.rb
+++ b/spec/system/find/courses/apply_for_course_spec.rb
@@ -117,7 +117,10 @@ RSpec.describe "Saving a course", service: :find do
     expect(page).to have_content("Get free one-to-one support")
     expect(page).to have_link(
       "bursaries or scholarships",
-      href: "https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries?utm_content=school_experience_interruption_bursaries_and_scholarships",
+      href: find_track_click_path(
+        url: "https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries",
+        utm_content: "school_experience_interruption_bursaries_and_scholarships",
+      ),
     )
   end
 

--- a/spec/system/find/courses/apply_for_course_spec.rb
+++ b/spec/system/find/courses/apply_for_course_spec.rb
@@ -89,17 +89,36 @@ RSpec.describe "Saving a course", service: :find do
     expect(page).to have_content("You must have completed 10 days of school experience in the last 12 months.")
 
     expect(page).to have_link(
-      "For more information contact #{@course.provider_name}",
-      href: find_provider_path(@course.provider_code, @course.course_code),
+      "For more information contact #{@course.provider_name}.",
+      href: find_track_click_path(
+        url: find_provider_path(@course.provider_code, @course.course_code),
+        utm_content: "school_experience_interruption_contact_provider",
+      ),
     )
 
     expect(page).to have_link(
       "Yes, I understand the school experience requirements",
-      href: find_confirm_apply_path(provider_code: @course.provider.provider_code, course_code: @course.course_code),
+      href: find_track_click_path(
+        url: find_confirm_apply_path(provider_code: @course.provider.provider_code, course_code: @course.course_code),
+        utm_content: "school_experience_interruption_confirm_button",
+      ),
     )
-    expect(page).to have_link("Cancel and return to the course page", href: find_course_path(provider_code: @course.provider_code, course_code: @course.course_code))
+    expect(page).to have_link(
+      "Cancel and return to the course page",
+      href: find_track_click_path(
+        url: find_course_path(provider_code: @course.provider_code, course_code: @course.course_code),
+        utm_content: "school_experience_interruption_cancel_link",
+      ),
+    )
     expect(page).to have_content("Is a salaried course right for me?")
     expect(page).to have_content("Get free one-to-one support")
+    expect(page).to have_link(
+      "bursaries or scholarships",
+      href: find_track_click_path(
+        url: "https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries",
+        utm_content: "school_experience_interruption_bursaries_and_scholarships",
+      ),
+    )
   end
 
   def given_a_published_course_exists


### PR DESCRIPTION
## Context

The school experience interruption page had no click tracking on key candidate actions, so we could not reliably measure interaction and progression from this step to application.  
This change adds tracking without changing the user journey itself.

## Changes proposed in this pull request

- Added `find_track_click_path` tracking on `school_experience_interstitial` for:
  - contact provider link (`school_experience_interruption_contact_provider`)
  - confirm button (`school_experience_interruption_confirm_button`)
  - cancel link (`school_experience_interruption_cancel_link`)
  - bursaries/scholarships link (`school_experience_interruption_bursaries_and_scholarships`)
- Updated system specs in `spec/system/find/courses/apply_for_course_spec.rb` to assert tracked URLs for these actions.

## Guidance to review

- Open a salaried course requiring school experience and visit the school experience interruption page.
- Check each tracked link/button URL now routes via `/track_click` with expected `utm_content`.
- Run:
  - `bundle exec rspec spec/system/find/courses/apply_for_course_spec.rb`
- Focus review on:
  - correctness/consistency of `utm_content` naming
  - whether all intended CTA links on this page are now covered

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.