### PR TITLE
Enable Airbyte in Production

### DIFF
--- a/.github/workflows/database-replication-monitor.yml
+++ b/.github/workflows/database-replication-monitor.yml
@@ -1,0 +1,39 @@
+name: Monitor Database logical replication
+
+on:
+  schedule:
+    - cron: "0 0,6,12,18 * * *"
+
+permissions:
+  id-token: write
+
+env:
+  SERVICE_NAME: publish
+  SERVICE_SHORT: ptt
+  TF_VARS_PATH: terraform/aks/workspace_variables
+
+jobs:
+  monitor-wal-usage:
+    name: Parallel postgres monitor
+    environment:
+      name: ${{ matrix.environment }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [production]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Monitor ${{ matrix.environment }}
+      uses: DFE-Digital/github-actions/monitor-postgres-wal@master
+      with:
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        environment: ${{ matrix.environment }}
+        teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+        service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+        app-name: ${{ env.SERVICE_NAME }}-${{ matrix.environment }}
+        tf-vars-path: ${{ env.TF_VARS_PATH }}

--- a/bin/stop-replication.psql
+++ b/bin/stop-replication.psql
@@ -1,0 +1,4 @@
+\echo 'Wal used is high. Dropping replication slot.'
+ ALTER ROLE CURRENT_USER WITH REPLICATION;
+ select * from pg_drop_replication_slot('airbyte_slot');
+ ALTER ROLE CURRENT_USER WITH NOREPLICATION;

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -53,7 +53,7 @@ DfE::Analytics.configure do |config|
   # use a new version of the BigQuery streaming APIs.
   config.azure_federated_auth = true
 
-  if Rails.env.in?(%w[development review])
+  if Rails.env.in?(%w[development review production])
     # Path of airbyte stream config file relative to the App root (Rails.root)
     config.airbyte_stream_config_path = "terraform/aks/workspace_variables/airbyte_stream_config.json"
 

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -43,5 +43,6 @@
   "enable_sanitised_storage": true,
   "pg_airbyte_enabled": true,
   "airbyte_enabled": true,
-  "connection_status": "active"
+  "connection_status": "active",
+  "wal_threshold": 10000000000
 }

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -41,5 +41,7 @@
     "https://publish-teacher-training-courses.service.gov.uk"
   ],
   "enable_sanitised_storage": true,
-  "pg_airbyte_enabled": true
+  "pg_airbyte_enabled": true,
+  "airbyte_enabled": true,
+  "connection_status": "active"
 }


### PR DESCRIPTION
## Context

Enable Airbyte in DfE Analytics for Production.
Adds monitor workflow for amount of database storage used by WAL.

## Changes proposed in this pull request

App code and terraform to enable Airbyte in production.
Github workflow to monitor database storage
required secrets added to keyvault

## Guidance to review

Same config enabled in review
make production terraform-plan

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
