### PR TITLE
Require the correct superdiff module in spec_helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -200,9 +200,6 @@ group :development, :test do
 
   gem "capybara-playwright-driver"
 
-  # Make diffs of Ruby objects much more readable
-  gem "super_diff"
-
   # Allow us to freeze time in tests
   gem "timecop"
 
@@ -238,6 +235,9 @@ group :test do
 
   # Page objects
   gem "site_prism", "~> 6.0"
+
+  # Make diffs of Ruby objects much more readable
+  gem "super_diff"
 
   gem "webmock"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require "pundit/rspec"
 require "jsonapi/rspec"
-require "super_diff/rspec"
+require "super_diff/rspec-rails"
 require "fakefs/spec_helpers"
 require "webmock/rspec"
 require "audited-rspec"


### PR DESCRIPTION
## Context


<img width="1103" height="637" alt="image" src="https://github.com/user-attachments/assets/cdb3a1c6-aa22-4b60-9098-767a58d161c7" />

  - https://splitwise.github.io/super_diff/releases/0.19.0/users/getting-started/

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Require the correct module in superdiff so it can handle rails object errors properly


It avoids disasters like this 

<img width="1581" height="909" alt="image" src="https://github.com/user-attachments/assets/b819eab3-d203-446c-917b-d0be2db5a136" />

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
