### PR TITLE
Restore link to email alerts index in weekly digest

### DIFF
--- a/app/views/email_alert_mailer/weekly_digest.text.erb
+++ b/app/views/email_alert_mailer/weekly_digest.text.erb
@@ -19,7 +19,7 @@
 <%= row[:label] %>: <%= row[:value] %>
 <% end -%>
 
-[Search for a course](<%= with_utm(@search_url, params: @utm_params, content: "search_for_a_course") %>) to set up a new email alert for similar courses.
+[View all your email alerts](<%= with_utm(find_candidate_email_alerts_url, params: @utm_params, content: "view_email_alerts") %>).
 
 ---
 

--- a/spec/mailers/email_alert_mailer_spec.rb
+++ b/spec/mailers/email_alert_mailer_spec.rb
@@ -67,7 +67,7 @@ describe EmailAlertMailer do
     expect(body).to include("utm_medium=email")
     expect(body).to include("utm_campaign=weekly_digest")
     expect(body).to include("utm_content=course_link")
-    expect(body).to include("utm_content=search_for_a_course")
+    expect(body).to include("utm_content=view_email_alerts")
     expect(body).to include("utm_content=unsubscribe")
   end
 


### PR DESCRIPTION
## Context

  - In a previous change I deleted the wrong link. We had duplicate links to the find results page, one of which should be deleted. I deleted the link to the email alerts index which should not have been deleted.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
