### PR TITLE
6.2 School remodel - Touch Provider on ProviderSchool and CourseSchool destroy action

### DIFF
--- a/app/models/course/school.rb
+++ b/app/models/course/school.rb
@@ -5,6 +5,8 @@ class Course::School < ApplicationRecord
 
   self.table_name = "course_school"
 
+  after_destroy :touch_course
+
   belongs_to :course, class_name: "::Course", inverse_of: :schools
   belongs_to :gias_school
 

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -7,6 +7,8 @@ class Provider::School < ApplicationRecord
 
   MAIN_SITE_CODE = "-"
 
+  after_destroy :touch_provider
+
   belongs_to :provider, class_name: "::Provider", inverse_of: :schools
   belongs_to :gias_school
 

--- a/spec/models/course/school_spec.rb
+++ b/spec/models/course/school_spec.rb
@@ -61,11 +61,21 @@ describe Course::School do
       end
     end
 
-    it "bumps the course and only its provider.changed_at on destroy" do
+    it "bumps course.changed_at on destroy" do
+      course_school = create(:course_school, course:)
+      course.update_columns(changed_at: 1.hour.ago)
+
+      Timecop.freeze do
+        course_school.destroy!
+
+        expect(course.reload.changed_at).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+
+    it "bumps only the course's provider.changed_at on destroy" do
       course_school = create(:course_school, course:)
       provider = course.provider
       other_provider = create(:provider)
-      course.update_columns(changed_at: 1.hour.ago)
       provider.update_columns(changed_at: 1.hour.ago)
       other_provider.update_columns(changed_at: 2.hours.ago)
       other_provider_changed_at = other_provider.reload.changed_at
@@ -73,7 +83,6 @@ describe Course::School do
       Timecop.freeze do
         course_school.destroy!
 
-        expect(course.reload.changed_at).to be_within(1.second).of(Time.zone.now)
         expect(provider.reload.changed_at).to be_within(1.second).of(Time.zone.now)
         expect(other_provider.reload.changed_at).to be_within(1.second).of(other_provider_changed_at)
       end

--- a/spec/models/course/school_spec.rb
+++ b/spec/models/course/school_spec.rb
@@ -61,13 +61,22 @@ describe Course::School do
       end
     end
 
-    it "does not bump course.changed_at on destroy" do
+    it "bumps the course and only its provider.changed_at on destroy" do
       course_school = create(:course_school, course:)
+      provider = course.provider
+      other_provider = create(:provider)
       course.update_columns(changed_at: 1.hour.ago)
-      before_changed_at = course.reload.changed_at
+      provider.update_columns(changed_at: 1.hour.ago)
+      other_provider.update_columns(changed_at: 2.hours.ago)
+      other_provider_changed_at = other_provider.reload.changed_at
 
-      course_school.destroy!
-      expect(course.reload.changed_at).to be_within(1.second).of(before_changed_at)
+      Timecop.freeze do
+        course_school.destroy!
+
+        expect(course.reload.changed_at).to be_within(1.second).of(Time.zone.now)
+        expect(provider.reload.changed_at).to be_within(1.second).of(Time.zone.now)
+        expect(other_provider.reload.changed_at).to be_within(1.second).of(other_provider_changed_at)
+      end
     end
 
     it "leaves course.updated_at unchanged" do

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -97,13 +97,19 @@ describe Provider::School do
       end
     end
 
-    it "does not bump provider.changed_at on destroy" do
+    it "bumps only the associated provider.changed_at on destroy" do
       provider_school = create(:provider_school, provider:)
+      other_provider = create(:provider)
       provider.update_columns(changed_at: 1.hour.ago)
-      before_changed_at = provider.reload.changed_at
+      other_provider.update_columns(changed_at: 2.hours.ago)
+      other_provider_changed_at = other_provider.reload.changed_at
 
-      provider_school.destroy!
-      expect(provider.reload.changed_at).to be_within(1.second).of(before_changed_at)
+      Timecop.freeze do
+        provider_school.destroy!
+
+        expect(provider.reload.changed_at).to be_within(1.second).of(Time.zone.now)
+        expect(other_provider.reload.changed_at).to be_within(1.second).of(other_provider_changed_at)
+      end
     end
 
     it "leaves provider.updated_at unchanged" do


### PR DESCRIPTION
## Context
As part of the main site / schools remodel, we added logic to touch the parent Provider when school relationships change.

However, we didn’t add the destroy paths.

When a provider_school is removed, the associated Provider needs to be touched so updated_at changes.

When a course_school is removed, the provider for the associated course also needs to be touched so Apply can detect that the provider’s school data has changed and re-sync the affected provider/course/school data.

Apply uses our API to detect changed providers by checking the provider updated_at. If the provider is not touched on school removal, Apply may not pick up the change.

## Changes proposed in this pull request

- Touch the associated provider when a `Provider::School` is destroyed.
- Touch the course and its provider when a `Course::School` is destroyed.
- Add specs confirming only the relevant provider is touched.
- Preserve existing create and update behaviour.

## Guidance to review

Run:

`bundle exec rspec spec/models/provider/school_spec.rb spec/models/course/school_spec.rb`

Check that destroying either school relationship updates the associated provider’s `changed_at` without affecting unrelated providers.

## Checklist

- [x] I have moved hard-coded strings to locale files (not applicable).
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests (not applicable).