### PR TITLE
2825 - Enable pg WAL in prod and disable in sandbox

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -40,5 +40,6 @@
     "https://find-postgraduate-teacher-training.service.gov.uk",
     "https://publish-teacher-training-courses.service.gov.uk"
   ],
-  "enable_sanitised_storage": true
+  "enable_sanitised_storage": true,
+  "pg_airbyte_enabled": true
 }

--- a/terraform/aks/workspace_variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox.tfvars.json
@@ -28,6 +28,6 @@
   "statuscake_contact_groups": [
     324594
   ],
-  "pg_airbyte_enabled": true,
+  "pg_airbyte_enabled": false,
   "airbyte_enabled": false
 }


### PR DESCRIPTION
### Context

Add logical replication to production Postgres, which is a pre-requisite for AirByte.
Remove logical replication from sandbox Postgres as AirByte is no longer desirable in sandbox.
Note that this will trigger several restarts of the production and sandbox Postgres servers.

### Changes proposed in this pull request

Add pg_airbyte_enabled: true for the production environment.
Change pg_airbyte_enabled to false for the sandbox  environment.

### Guidance to review

make sandbox deploy-plan
make production deploy-plan CONFIRM_PRODUCTION=yes

both should show changes to 5 Postgres server parameters.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
