### PR TITLE
Update deadline banner to add academic year for explicity

### DIFF
--- a/config/locales/en/components/find/deadline_banner_component.yml
+++ b/config/locales/en/components/find/deadline_banner_component.yml
@@ -1,7 +1,7 @@
 en:
   important: Important
   apply_deadline_banner:
-    heading: The deadline for applying to courses starting in %{academic_cycle_year_range} is %{apply_deadline}
+    heading: The deadline for applying to courses starting in the %{academic_cycle_year_range} academic year is %{apply_deadline}
     text: Courses may fill up before then. Check course availability with the provider.
   apply_opens_soon_banner:
     heading: Apply for courses from %{apply_opens}

--- a/spec/components/find/deadline_banner_component_spec.rb
+++ b/spec/components/find/deadline_banner_component_spec.rb
@@ -37,7 +37,7 @@ module Find
 
           cycle_year_range = Find::CycleTimetable.cycle_year_range
           apply_deadline = Find::CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time)
-          expect(result.text).to include("The deadline for applying to courses starting in #{cycle_year_range} is #{apply_deadline}")
+          expect(result.text).to include("The deadline for applying to courses starting in the #{cycle_year_range} academic year is #{apply_deadline}")
           expect(result.text).to include("Courses may fill up before then. Check course availability with the provider.")
         end
       end

--- a/spec/system/find/switcher_cycles_spec.rb
+++ b/spec/system/find/switcher_cycles_spec.rb
@@ -106,14 +106,14 @@ RSpec.describe "switcher cycle" do
   def and_i_see_mid_cycle_banner
     cycle_year_range = Find::CycleTimetable.cycle_year_range
     apply_deadline = Find::CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time)
-    banner_text = "The deadline for applying to courses starting in #{cycle_year_range} is #{apply_deadline}"
+    banner_text = "The deadline for applying to courses starting in the #{cycle_year_range} academic year is #{apply_deadline}"
     and_i_see_deadline_banner(banner_text)
   end
 
   def and_i_do_not_see_mid_cycle_banner
     cycle_year_range = Find::CycleTimetable.cycle_year_range
     apply_deadline = Find::CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time)
-    banner_text = "The deadline for applying to courses starting in #{cycle_year_range} is #{apply_deadline}"
+    banner_text = "The deadline for applying to courses starting in the #{cycle_year_range} academic year is #{apply_deadline}"
     and_i_do_not_see_deadline_banner(banner_text)
   end
 


### PR DESCRIPTION
## Context

Update deadline banner text

## Changes proposed in this pull request

Add " in the academic year" to explicitly communicate the cycle is not the recruitment cycle.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
