### PR TITLE
Normalise course school site data writes

### DIFF
--- a/app/controllers/publish/courses/schools_controller.rb
+++ b/app/controllers/publish/courses/schools_controller.rb
@@ -5,6 +5,8 @@ module Publish
     class SchoolsController < ApplicationController
       include CourseBasicDetailConcern
 
+      # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+      # TODO School data remodel removal - remove when add-course school selection stops posting legacy sites_ids.
       def continue
         params[:course][:sites_ids].compact_blank!
         super
@@ -12,6 +14,7 @@ module Publish
 
       def new
         authorize(@provider, :edit?)
+        # TODO School data remodel removal - replace with Provider::School count when schools no longer use Site.
         return unless @provider.sites.count == 1
 
         set_default_school
@@ -27,9 +30,9 @@ module Publish
         @course_school_form = Publish::CourseSchoolForm.new(@course, params: school_params)
 
         if @course_school_form.valid?
-          Publish::Schools::UpdateCourseSchoolsService.call_or_enqueue(course: @course, params: school_params)
+          update_course_schools
 
-          flash[:success] = if Array(@course_school_form.site_ids).size > Publish::Schools::UpdateCourseSchoolsService::ENQUEUE_THRESHOLD
+          flash[:success] = if selected_school_uuids_count > Publish::Schools::UpdateCourseSchoolsService::ENQUEUE_THRESHOLD
                               I18n.t("success.enqueued_schools")
                             else
                               I18n.t("success.saved", value: section_key)
@@ -47,6 +50,7 @@ module Publish
 
       def back
         authorize(@provider, :edit?)
+        # TODO School data remodel removal - replace with Provider::School count when schools no longer use Site.
         if @provider.sites.count > 1
           redirect_to new_publish_provider_recruitment_cycle_courses_schools_path(path_params)
         else
@@ -64,15 +68,16 @@ module Publish
         [:sites]
       end
 
+      # TODO School data remodel removal - remove when the wizard default is based on Provider::School rather than Site.
       def set_default_school
         params["course"] ||= {}
-        params["course"]["sites_ids"] = [@provider.sites.first.id]
+        params["course"]["sites_ids"] = [@provider.sites.first.uuid]
       end
 
       def school_params
-        return { site_ids: nil } if params[:publish_course_school_form][:site_ids].all?(&:empty?)
+        return { school_uuids: nil } if params[:publish_course_school_form][:school_uuids].all?(&:empty?)
 
-        params.expect(publish_course_school_form: [:schools_validated, { site_ids: [] }])
+        params.expect(publish_course_school_form: [:schools_validated, { school_uuids: [] }])
       end
 
       def build_course
@@ -80,8 +85,23 @@ module Publish
       end
 
       def section_key
-        "School".pluralize(Array(school_params[:site_ids]).compact_blank.count)
+        "School".pluralize(selected_school_uuids_count)
       end
+
+      # TODO School data remodel removal - remove the UpdateCourseSchoolsService call when SiteStatus is no longer dual-written.
+      def update_course_schools
+        if selected_school_uuids_count > Publish::Schools::UpdateCourseSchoolsService::ENQUEUE_THRESHOLD
+          UpdateCourseSchoolsJob.perform_async(@course.id, school_params.to_h)
+        else
+          Publish::Schools::UpdateCourseSchoolsService.new(course: @course, params: school_params).call
+          Publish::Schools::UpdateCourseProviderSchoolsService.call(course: @course, params: school_params)
+        end
+      end
+
+      def selected_school_uuids_count
+        Array(school_params[:school_uuids]).compact_blank.count
+      end
+      # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
     end
   end
 end

--- a/app/controllers/publish/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/publish/providers/schools/check_multiple_controller.rb
@@ -14,10 +14,17 @@ module Publish
 
           gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
-              provider_school = ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
-
-              site = provider.sites.build(gias_school.school_attributes.merge(code: provider_school.site_code))
+              # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+              # TODO School data remodel removal - remove this legacy Site write when provider schools are created only in Provider::School.
+              site = provider.sites.build(gias_school.school_attributes)
+              # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
               ::ProviderSchools::LegacySiteCreator.call(site:)
+              ::ProviderSchools::Creator.call(
+                provider:,
+                gias_school_id: gias_school.id,
+                site_code: site.code,
+                uuid: site.uuid,
+              )
               saved_sites << site
             end
           end
@@ -71,9 +78,12 @@ module Publish
           @gias_schools ||= GiasSchool.where(urn: urn_service[:new_urns])
         end
 
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove when the multiple-school check page no longer previews unsaved Site rows.
         def schools
           @schools ||= gias_schools.map { |gias_school| provider.sites.build(gias_school.school_attributes) }
         end
+        # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
         alias_method :load_schools, :schools
 
         def unfound_urns

--- a/app/controllers/publish/providers/schools/checks_controller.rb
+++ b/app/controllers/publish/providers/schools/checks_controller.rb
@@ -11,10 +11,16 @@ module Publish
 
         def update
           ActiveRecord::Base.transaction do
-            provider_school = ::ProviderSchools::Creator.call(provider: @provider, gias_school_id: school_id)
-
-            @site.code = provider_school.site_code
+            # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+            # TODO School data remodel removal - remove this legacy Site write when provider schools are created only in Provider::School.
             ::ProviderSchools::LegacySiteCreator.call(site: @site)
+            # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+            ::ProviderSchools::Creator.call(
+              provider: @provider,
+              gias_school_id: school_id,
+              site_code: @site.code,
+              uuid: @site.uuid,
+            )
           end
 
           redirect_to publish_provider_recruitment_cycle_schools_path, flash: { success_with_body: { title: t(".added"), body: @site.location_name } }
@@ -24,12 +30,15 @@ module Publish
 
       private
 
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove when the school check page builds a Provider::School instead of a Site.
         def site
           @site ||= begin
             gias_school = GiasSchool.find(school_id)
             @provider.sites.school.build(gias_school.school_attributes)
           end
         end
+        # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
         def school_id
           # params[:school_id] comes from the school search

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -43,10 +43,17 @@ module Support
 
           gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
-              provider_school = ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
-
-              site = provider.sites.build(gias_school.school_attributes.merge(code: provider_school.site_code))
+              # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+              # TODO School data remodel removal - remove this legacy Site write when support creates Provider::School directly.
+              site = provider.sites.build(gias_school.school_attributes)
+              # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
               ::ProviderSchools::LegacySiteCreator.call(site:)
+              ::ProviderSchools::Creator.call(
+                provider:,
+                gias_school_id: gias_school.id,
+                site_code: site.code,
+                uuid: site.uuid,
+              )
               saved_sites << site
             end
           end
@@ -66,9 +73,12 @@ module Support
           @gias_schools ||= GiasSchool.where(urn: urn_service[:new_urns])
         end
 
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove when support multiple-school checks no longer preview unsaved Site rows.
         def schools
           @schools ||= gias_schools.map { |gias_school| provider.sites.build(gias_school.school_attributes) }
         end
+        # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
         def unfound_urns
           @unfound_urns = urn_service[:unfound_urns]

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -12,13 +12,19 @@ module Support
           saved = false
 
           ActiveRecord::Base.transaction do
-            provider_school = ::ProviderSchools::Creator.call(
-              provider: provider,
-              gias_school_id: params[:school_id],
-            )
-
-            @school_form.fields[:code] = provider_school.site_code
+            # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+            # TODO School data remodel removal - replace this legacy Site-backed form save when support adds Provider::School directly.
             saved = @school_form.save!
+            # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+
+            if saved
+              ::ProviderSchools::Creator.call(
+                provider: provider,
+                gias_school_id: params[:school_id],
+                site_code: @site.code,
+                uuid: @site.uuid,
+              )
+            end
           end
 
           if saved
@@ -35,12 +41,15 @@ module Support
           @school_form = SchoolForm.new(provider, site, params: { gias_school_id: params[:school_id] })
         end
 
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove when support school checks build Provider::School directly.
         def site
           @site ||= begin
             gias_school = GiasSchool.find(params[:school_id])
             @provider.sites.school.build(gias_school.school_attributes)
           end
         end
+        # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
         def provider
           @provider ||= Provider.find(params[:provider_id])

--- a/app/forms/publish/course_school_form.rb
+++ b/app/forms/publish/course_school_form.rb
@@ -2,14 +2,16 @@
 
 module Publish
   class CourseSchoolForm < BaseCourseForm
-    FIELDS = %i[site_ids schools_validated].freeze
+    FIELDS = %i[school_uuids schools_validated].freeze
 
     attr_accessor(*FIELDS)
 
     validate :no_schools_selected
 
+    # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+    # TODO School data remodel removal - replace course.sites with course.schools/provider_schools when Site is retired for schools.
     def compute_fields
-      { site_ids: course.site_ids }.merge(new_attributes)
+      { school_uuids: course.sites.map(&:uuid) }.merge(new_attributes)
     end
 
     # Every school the provider could attach, in the order they are listed.
@@ -27,16 +29,18 @@ module Publish
 
   private
 
+    # TODO School data remodel removal - remove Site-based rollover checks when school presence is fully based on Course::School.
     def no_schools_selected
-      return if params[:site_ids].present?
+      return if params[:school_uuids].present?
       return if ::Courses::PublishRules::SchoolPresenceExemption.applies?(course)
 
       if course.recruitment_cycle_rollover_period_2026?
-        errors.add(:site_ids, :check_schools) if course.sites.school.present?
-        errors.add(:site_ids, :enter_schools) if course.sites.school.blank?
+        errors.add(:school_uuids, :check_schools) if course.sites.school.present?
+        errors.add(:school_uuids, :enter_schools) if course.sites.school.blank?
       else
-        errors.add(:site_ids, :no_schools)
+        errors.add(:school_uuids, :no_schools)
       end
     end
+    # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
   end
 end

--- a/app/jobs/update_course_schools_job.rb
+++ b/app/jobs/update_course_schools_job.rb
@@ -5,5 +5,6 @@ class UpdateCourseSchoolsJob
     course = Course.find(course_id)
 
     Publish::Schools::UpdateCourseSchoolsService.new(course:, params:).call
+    Publish::Schools::UpdateCourseProviderSchoolsService.call(course:, params:)
   end
 end

--- a/app/services/course_schools/creator.rb
+++ b/app/services/course_schools/creator.rb
@@ -1,31 +1,49 @@
 # frozen_string_literal: true
 
-# Writes a Course::School row for a course, copying site_code from the
-# matching Provider::School for (course.provider, gias_school). Idempotent
+# Writes a Course::School row for a course from a Provider::School. Idempotent
 # under RecordNotUnique (race with a backfill run or another request).
-# Raises ActiveRecord::RecordNotFound if no Provider::School exists for
-# the pair — callers are expected to run inside a transaction so the
-# failure rolls back any legacy write paired with this one.
 module CourseSchools
   class Creator
     include ServicePattern
 
-    def initialize(course:, gias_school_id:)
+    def initialize(course:, provider_school: nil, provider_school_id: nil, gias_school_id: nil, site_code: nil)
       @course = course
+      @provider_school = provider_school
+      @provider_school_id = provider_school_id
       @gias_school_id = gias_school_id
+      @site_code = site_code
     end
 
     def call
-      provider_school = @course.provider.schools.find_by!(gias_school_id: @gias_school_id)
+      provider_school = resolved_provider_school
 
-      # Key on provider_school_id to match the (course_id, provider_school_id)
-      # unique index; copy gias_school_id and site_code from the provider_school
-      # so the denormalised columns can never disagree with it.
       @course.schools.find_or_create_by!(provider_school_id: provider_school.id) do |course_school|
         course_school.gias_school_id = provider_school.gias_school_id
       end
     rescue ActiveRecord::RecordNotUnique
       @course.schools.find_by!(provider_school_id: provider_school.id)
+    rescue ActiveRecord::RecordNotFound, ArgumentError => e
+      log_skipped_write(e)
+      nil
+    end
+
+  private
+
+    def resolved_provider_school
+      return @provider_school if @provider_school.present?
+      return @course.provider.schools.find(@provider_school_id) if @provider_school_id.present?
+      return @course.provider.schools.find_by!(gias_school_id: @gias_school_id, site_code: @site_code) if @gias_school_id.present? && @site_code.present?
+
+      raise ArgumentError, "provider_school, provider_school_id, or gias_school_id with site_code must be provided"
+    end
+
+    def log_skipped_write(error)
+      Rails.logger.warn(
+        "[CourseSchools] skipped course_school write — #{error.class}: #{error.message} " \
+        "course=#{@course.id} provider=#{@course.provider_id} " \
+        "provider_school_id=#{@provider_school_id.inspect} " \
+        "gias_school_id=#{@gias_school_id.inspect} site_code=#{@site_code.inspect}",
+      )
     end
   end
 end

--- a/app/services/course_schools/legacy_site_status_creator.rb
+++ b/app/services/course_schools/legacy_site_status_creator.rb
@@ -5,6 +5,8 @@
 # file, deletable as a single step when course reads migrate to the
 # new Course::School model.
 module CourseSchools
+  # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+  # TODO School data remodel removal - delete when courses no longer attach schools through legacy SiteStatus.
   class LegacySiteStatusCreator
     include ServicePattern
 
@@ -19,4 +21,5 @@ module CourseSchools
       @course.send(:add_site!, site: @site)
     end
   end
+  # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 end

--- a/app/services/course_schools/legacy_site_status_remover.rb
+++ b/app/services/course_schools/legacy_site_status_remover.rb
@@ -4,6 +4,8 @@
 # wrapper around Course#remove_site! — destroy for new courses, suspend
 # for live ones, matching existing behaviour.
 module CourseSchools
+  # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+  # TODO School data remodel removal - delete when courses no longer detach schools through legacy SiteStatus.
   class LegacySiteStatusRemover
     include ServicePattern
 
@@ -18,4 +20,5 @@ module CourseSchools
       @course.send(:remove_site!, site: @site)
     end
   end
+  # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 end

--- a/app/services/course_schools/remover.rb
+++ b/app/services/course_schools/remover.rb
@@ -1,19 +1,30 @@
 # frozen_string_literal: true
 
-# Removes the Course::School row for (course, gias_school). Idempotent:
+# Removes Course::School rows for a course/provider_school. Idempotent:
 # destroy_all on an empty relation is a no-op, matching the "safe to
 # re-run" semantics of the schools backfill.
 module CourseSchools
   class Remover
     include ServicePattern
 
-    def initialize(course:, gias_school_id:)
+    def initialize(course:, provider_school: nil, provider_school_id: nil, gias_school_id: nil)
       @course = course
+      @provider_school = provider_school
+      @provider_school_id = provider_school_id
       @gias_school_id = gias_school_id
     end
 
     def call
-      @course.schools.where(gias_school_id: @gias_school_id).destroy_all
+      @course.schools.where(removal_scope).destroy_all
+    end
+
+  private
+
+    def removal_scope
+      return { provider_school_id: @provider_school.id } if @provider_school.present?
+      return { provider_school_id: @provider_school_id } if @provider_school_id.present?
+
+      { gias_school_id: @gias_school_id }
     end
   end
 end

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -74,8 +74,18 @@ module Courses
       @permitted_new_course_attributes ||= CoursePolicy.new(nil, new_course).permitted_new_course_attributes
     end
 
+    # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+    # TODO School data remodel removal - remove when add-course school selection uses Provider::School instead of Site.
     def sites
-      @sites ||= provider.sites.find(site_ids.compact_blank)
+      @sites ||= begin
+        identifiers = site_ids.compact_blank
+
+        if identifiers.all? { |identifier| uuid?(identifier) }
+          provider.sites.where(uuid: identifiers)
+        else
+          provider.sites.find(identifiers)
+        end
+      end
     end
 
     def study_sites
@@ -86,6 +96,7 @@ module Courses
       @subject_ids ||= course_params["subjects_ids"]
     end
 
+    # TODO School data remodel removal - remove when the add-course wizard stops storing selected schools as sites_ids.
     def site_ids
       @site_ids ||= course_params["sites_ids"]
     end
@@ -115,6 +126,7 @@ module Courses
       end
     end
 
+    # TODO School data remodel removal - remove when new courses no longer need legacy SiteStatus school writes.
     def update_sites(course)
       return if site_ids.nil?
 
@@ -127,55 +139,38 @@ module Courses
     # building the records in memory so they persist atomically with the
     # course on save and are visible to CoursePublishableSchoolsPresence-
     # Validator's :new-context read (which the new-school-model flag routes
-    # to course.schools). Mirrors the site→gias_school→provider_school
-    # mapping used by Publish::Schools::UpdateCourseSchoolsService.
+    # to course.schools).
     def update_schools(course)
       return if site_ids.nil?
       # Nothing selected — update_sites already records the "Select at least
       # one school" error; skip before touching `sites` (find([]) would raise).
       return if site_ids.compact_blank.empty?
 
-      school_sites.each do |site|
-        gias_school = gias_schools_by_urn[site.urn]
-        next unless gias_school
-
-        provider_school = provider_schools_by_gias_id[gias_school.id]
-
-        unless provider_school
-          # No matching Provider::School yet — provider not fully backfilled
-          # (or its site predates the dual-write). Skip the new-model build;
-          # the schools backfill (or the next provider-side write) reconciles
-          # later. Same rationale as UpdateCourseSchoolsService#attach_school.
-          Rails.logger.warn(
-            "[CourseSchools] skipped course_school build — no provider_school for " \
-            "provider=#{provider.id} gias_school=#{gias_school.id}",
-          )
-          next
-        end
-
-        course.schools.build(gias_school_id: gias_school.id, provider_school:)
+      provider_schools_for_selected_sites.each do |provider_school|
+        course_school = course.schools.build(
+          gias_school_id: provider_school.gias_school_id,
+          provider_school:,
+        )
       end
     end
 
+    # TODO School data remodel removal - remove when Course::School creation no longer maps through selected Site rows.
     def school_sites
       @school_sites ||= sites.select(&:school?)
     end
 
-    # Only map selectable (non-closed) GIAS schools into the new model. A site
-    # can still point at a school the GIAS import later flipped to closed; we
-    # intentionally leave that school out of course.schools (the legacy
-    # course.sites write above still keeps the site) so the new model never
-    # gains a closed school. `available` excludes only `closed`.
-    def gias_schools_by_urn
-      @gias_schools_by_urn ||= GiasSchool.available
-        .where(urn: school_sites.map(&:urn).compact_blank)
-        .index_by(&:urn)
+    # TODO School data remodel removal - remove the legacy Site UUID resolver path when the wizard posts Provider::School IDs or UUIDs.
+    def provider_schools_for_selected_sites
+      @provider_schools_for_selected_sites ||= Publish::Schools::ProviderSchoolResolver.call(
+        provider:,
+        school_uuids: school_sites.map(&:uuid),
+        gias_school_scope: GiasSchool.available,
+      )
     end
+    # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
-    def provider_schools_by_gias_id
-      @provider_schools_by_gias_id ||= provider.schools
-        .where(gias_school_id: gias_schools_by_urn.values.map(&:id))
-        .index_by(&:gias_school_id)
+    def uuid?(identifier)
+      identifier.to_s.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
     end
 
     def update_study_sites(course)

--- a/app/services/provider_schools/creator.rb
+++ b/app/services/provider_schools/creator.rb
@@ -9,19 +9,41 @@ module ProviderSchools
   class Creator
     include ServicePattern
 
-    def initialize(provider:, gias_school_id:)
+    def initialize(provider:, gias_school_id:, site_code: nil, uuid: nil)
       @provider = provider
       @gias_school_id = gias_school_id
+      @site_code = site_code
+      @uuid = uuid
     end
 
     def call
       @provider.with_lock do
-        @provider.schools.find_or_create_by!(gias_school_id: @gias_school_id) do |school|
-          school.site_code = Schools::CodeGenerator.call(provider: @provider)
-        end
+        provider_school = existing_provider_school || @provider.schools.build(
+          gias_school_id: @gias_school_id,
+          site_code: target_site_code,
+        )
+        provider_school.uuid = @uuid if @uuid.present?
+        provider_school.save! if provider_school.new_record? || provider_school.changed?
+        provider_school
       end
     rescue ActiveRecord::RecordNotUnique
-      @provider.schools.find_by!(gias_school_id: @gias_school_id)
+      existing_provider_school || raise
+    end
+
+  private
+
+    def existing_provider_school
+      provider_school_by_uuid || @provider.schools.find_by(gias_school_id: @gias_school_id, site_code: target_site_code)
+    end
+
+    def provider_school_by_uuid
+      return if @uuid.blank?
+
+      @provider.schools.find_by(uuid: @uuid)
+    end
+
+    def target_site_code
+      @target_site_code ||= @site_code.presence || Schools::CodeGenerator.call(provider: @provider)
     end
   end
 end

--- a/app/services/provider_schools/legacy_site_creator.rb
+++ b/app/services/provider_schools/legacy_site_creator.rb
@@ -4,6 +4,7 @@ module ProviderSchools
   # Writes the legacy Site row for a provider-school addition. Kept isolated
   # from ProviderSchools::Creator so the old write path can be removed in a
   # single step once the new model is switched on.
+  # TODO School data remodel removal - delete when provider schools are no longer dual-written to Site.
   class LegacySiteCreator
     include ServicePattern
 

--- a/app/services/publish/schools/provider_school_resolver.rb
+++ b/app/services/publish/schools/provider_school_resolver.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Publish
+  module Schools
+    class ProviderSchoolResolver
+      include ServicePattern
+
+      def initialize(provider:, school_uuids:, gias_school_scope: GiasSchool.all)
+        @provider = provider
+        @school_uuids = Array(school_uuids).compact_blank.map(&:to_s)
+        @gias_school_scope = gias_school_scope
+      end
+
+      def call
+        school_uuids.filter_map { |uuid| provider_school_for(uuid) }.uniq(&:id)
+      end
+
+    private
+
+      attr_reader :provider, :school_uuids, :gias_school_scope
+
+      # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+      def provider_school_for(uuid)
+        provider_schools_by_uuid[uuid] || provider_school_from_legacy_site(uuid)
+      end
+
+      def provider_schools_by_uuid
+        @provider_schools_by_uuid ||= provider.schools.where(uuid: school_uuids).index_by { |school| school.uuid.to_s }
+      end
+
+      # TODO School data remodel removal - remove when submitted school UUIDs always refer to Provider::School rows.
+      def provider_school_from_legacy_site(uuid)
+        site = sites_by_uuid[uuid]
+        return if site.blank?
+
+        gias_school = gias_schools_by_urn[site.urn]
+        return if gias_school.blank?
+
+        provider_schools_by_gias_and_code[[gias_school.id, site.code]].tap do |provider_school|
+          next if provider_school.present?
+
+          Rails.logger.warn(
+            "[CourseSchools] skipped course_school write — no provider_school for " \
+            "provider=#{provider.id} site=#{site.id} site_uuid=#{site.uuid} gias_school=#{gias_school.id}",
+          )
+        end
+      end
+
+      # TODO School data remodel removal - remove with provider_school_from_legacy_site.
+      def sites_by_uuid
+        @sites_by_uuid ||= provider.sites.where(uuid: school_uuids).index_by { |site| site.uuid.to_s }
+      end
+
+      # TODO School data remodel removal - remove with provider_school_from_legacy_site.
+      def gias_schools_by_urn
+        @gias_schools_by_urn ||= gias_school_scope
+          .where(urn: sites_by_uuid.values.map(&:urn).compact_blank)
+          .index_by(&:urn)
+      end
+
+      # TODO School data remodel removal - remove with provider_school_from_legacy_site.
+      def provider_schools_by_gias_and_code
+        @provider_schools_by_gias_and_code ||= provider.schools
+          .where(gias_school_id: gias_schools_by_urn.values.map(&:id))
+          .index_by { |provider_school| [provider_school.gias_school_id, provider_school.site_code] }
+      end
+      # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+    end
+  end
+end

--- a/app/services/publish/schools/update_course_provider_schools_service.rb
+++ b/app/services/publish/schools/update_course_provider_schools_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Publish
+  module Schools
+    class UpdateCourseProviderSchoolsService
+      include ServicePattern
+
+      def initialize(course:, params:)
+        @course = course
+        @params = { school_uuids: current_school_uuids }.merge(params.to_h.deep_symbolize_keys)
+      end
+
+      def call
+        return if provider_school_ids_to_attach.empty? && provider_school_ids_to_remove.empty?
+
+        ActiveRecord::Base.transaction do
+          provider_schools_to_attach.each { |provider_school| attach_provider_school(provider_school) }
+          course.schools.where(provider_school_id: provider_school_ids_to_remove).destroy_all
+          course.schools.reload
+        end
+      end
+
+    private
+
+      attr_reader :course, :params
+
+      def attach_provider_school(provider_school)
+        ::CourseSchools::Creator.call(course:, provider_school:)
+      end
+
+      def submitted_school_uuids
+        @submitted_school_uuids ||= Array(params[:school_uuids]).compact_blank.map(&:to_s)
+      end
+
+      def current_school_uuids
+        course.schools.includes(:provider_school).map { |course_school| course_school.provider_school.uuid }
+      end
+
+      def submitted_provider_schools
+        @submitted_provider_schools ||= ProviderSchoolResolver.call(
+          provider: course.provider,
+          school_uuids: submitted_school_uuids,
+        )
+      end
+
+      def submitted_provider_school_ids
+        @submitted_provider_school_ids ||= submitted_provider_schools.map(&:id)
+      end
+
+      def current_provider_school_ids
+        @current_provider_school_ids ||= course.schools.pluck(:provider_school_id)
+      end
+
+      def provider_school_ids_to_attach
+        @provider_school_ids_to_attach ||= submitted_provider_school_ids - current_provider_school_ids
+      end
+
+      def provider_school_ids_to_remove
+        @provider_school_ids_to_remove ||= current_provider_school_ids - submitted_provider_school_ids
+      end
+
+      def provider_schools_to_attach
+        @provider_schools_to_attach ||= submitted_provider_schools.select do |provider_school|
+          provider_school.id.in?(provider_school_ids_to_attach)
+        end
+      end
+    end
+  end
+end

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -1,21 +1,25 @@
 module Publish
   module Schools
+    # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+    # TODO School data remodel removal - remove this legacy SiteStatus sync service when school associations
+    # are written only through Provider::School and Course::School.
     class UpdateCourseSchoolsService
       ENQUEUE_THRESHOLD = 30
 
       def self.call_or_enqueue(course:, params:)
-        site_ids_count = Array(params[:site_ids]).size
+        school_uuids_count = Array(params[:school_uuids]).size
 
-        if site_ids_count > ENQUEUE_THRESHOLD
+        if school_uuids_count > ENQUEUE_THRESHOLD
           UpdateCourseSchoolsJob.perform_async(course.id, params.to_h)
         else
           new(course:, params:).call
+          UpdateCourseProviderSchoolsService.call(course:, params:)
         end
       end
 
       def initialize(course:, params:)
         @course = course
-        @params = { site_ids: course.site_ids }.merge(params.to_h.deep_symbolize_keys)
+        @params = { school_uuids: course.sites.map(&:uuid) }.merge(params.to_h.deep_symbolize_keys)
         @previous_site_names = course.sites.map(&:location_name)
       end
 
@@ -35,71 +39,58 @@ module Publish
       attr_reader :course, :params, :previous_site_names
 
       def assign_attributes_to_course
-        course.assign_attributes(params.except(:site_ids))
+        course.assign_attributes(params.except(:school_uuids))
       end
 
       def sync_schools
-        return if sites_to_attach_ids.empty? && sites_to_remove_ids.empty?
+        return if sites_to_attach_uuids.empty? && sites_to_remove_uuids.empty?
 
-        sites_to_attach_ids.each { |id| attach_school(sites_by_id[id]) }
-        sites_to_remove_ids.each { |id| detach_school(sites_by_id[id]) }
+        sites_to_attach_uuids.each { |uuid| attach_school(sites_by_uuid[uuid]) }
+        sites_to_remove_uuids.each { |uuid| detach_school(sites_by_uuid[uuid]) }
 
         course.sites.reload
       end
 
-      def submitted_site_ids
-        @submitted_site_ids ||= Array(params[:site_ids]).compact_blank.map(&:to_i)
+      def submitted_school_uuids
+        @submitted_school_uuids ||= Array(params[:school_uuids]).compact_blank.map(&:to_s)
       end
 
-      def current_site_ids
-        @current_site_ids ||= course.site_ids
+      def current_school_uuids
+        @current_school_uuids ||= course.sites.map { |site| site.uuid.to_s }
       end
 
-      def sites_to_attach_ids
-        @sites_to_attach_ids ||= submitted_site_ids - current_site_ids
+      # TODO School data remodel removal - remove once course school updates no longer diff legacy Site UUIDs.
+      def sites_to_attach_uuids
+        @sites_to_attach_uuids ||= submitted_school_uuids - current_school_uuids
       end
 
-      def sites_to_remove_ids
-        @sites_to_remove_ids ||= current_site_ids - submitted_site_ids
+      # TODO School data remodel removal - remove once course school updates no longer diff legacy Site UUIDs.
+      def sites_to_remove_uuids
+        @sites_to_remove_uuids ||= current_school_uuids - submitted_school_uuids
       end
 
-      def sites_by_id
-        @sites_by_id ||= Site.where(id: sites_to_attach_ids + sites_to_remove_ids).index_by(&:id)
+      # TODO School data remodel removal - remove once submitted school identifiers point directly at Provider::School.
+      def sites_by_uuid
+        @sites_by_uuid ||= course.provider.sites
+          .where(uuid: sites_to_attach_uuids + sites_to_remove_uuids)
+          .index_by { |site| site.uuid.to_s }
       end
 
-      def gias_schools_by_urn
-        @gias_schools_by_urn ||= GiasSchool
-          .where(urn: sites_by_id.values.map(&:urn).compact_blank)
-          .index_by(&:urn)
-      end
-
+      # TODO School data remodel removal - remove with the legacy SiteStatus write path.
       def attach_school(site)
+        return if site.blank?
+
         ::CourseSchools::LegacySiteStatusCreator.call(course:, site:)
-
-        gias_school = gias_schools_by_urn[site.urn]
-        return unless gias_school
-
-        ::CourseSchools::Creator.call(course:, gias_school_id: gias_school.id)
-      rescue ActiveRecord::RecordNotFound
-        # No matching Provider::School yet — environment hasn't been fully
-        # backfilled or the provider's site predates the dual-write. Skip
-        # the new-model write rather than 404'ing the request; the schools
-        # backfill (or the next provider-side dual-write) reconciles later.
-        Rails.logger.warn(
-          "[CourseSchools] skipped course_school write — no provider_school for " \
-          "course=#{course.id} provider=#{course.provider_id} gias_school=#{gias_school.id}",
-        )
       end
 
+      # TODO School data remodel removal - remove with the legacy SiteStatus write path.
       def detach_school(site)
+        return if site.blank?
+
         ::CourseSchools::LegacySiteStatusRemover.call(course:, site:)
-
-        gias_school = gias_schools_by_urn[site.urn]
-        return unless gias_school
-
-        ::CourseSchools::Remover.call(course:, gias_school_id: gias_school.id)
       end
 
+      # TODO School data remodel removal - remove when publish status no longer has to be mirrored to SiteStatus.
       def apply_publish_status_to_site_statuses
         # Reload + scope to new_or_running so we never touch site_statuses
         # that sync_schools just suspended or destroyed. Iterating the
@@ -116,6 +107,7 @@ module Publish
 
         { publish: :unpublished, status: :new_status }
       end
+      # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
       def send_notifications
         updated_site_names = course.sites.map(&:location_name)

--- a/app/views/publish/course_wizards/steps/_schools.html.erb
+++ b/app/views/publish/course_wizards/steps/_schools.html.erb
@@ -30,7 +30,7 @@
       form_group: { data: { controller: "show-all-schools", show_all_schools_visible_value: current_step.schools_collapse_threshold } } do %>
   <% current_step.sites.each_with_index do |site, index| %>
     <%= form.govuk_check_box :site_ids,
-          site.id.to_s,
+          site.uuid,
           label: { text: [site.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
           hint: { text: site.decorate.full_address, class: "govuk-!-font-size-16" },
           include_hidden: false,

--- a/app/views/publish/courses/schools/edit.html.erb
+++ b/app/views/publish/courses/schools/edit.html.erb
@@ -24,7 +24,7 @@
         provider: @provider,
       ) %>
 
-    <%= f.govuk_check_boxes_fieldset :site_ids,
+    <%= f.govuk_check_boxes_fieldset :school_uuids,
         legend:
         {
           text: "#{render CaptionText.new(text: course.name_and_code)} #{school_label_for(course)}".html_safe,
@@ -52,9 +52,9 @@
           <div class="govuk-body govuk-!-margin-left-2">or</div>
           <div class="govuk-hint"><%= t("publish.courses.schools.new.selection") %></div>
 
-          <% @course_school_form.sites.each_with_index do |site, index| %>
-            <%= f.govuk_check_box :site_ids,
-                site.id,
+          <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
+            <%= f.govuk_check_box :school_uuids,
+                site.uuid,
                 label: { text: [site.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
                 hint: { text: site.decorate.full_address, class: "govuk-!-font-size-16" },
                 link_errors: index.zero?,

--- a/app/views/publish/courses/schools/new.html.erb
+++ b/app/views/publish/courses/schools/new.html.erb
@@ -44,7 +44,7 @@
 
                 <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
                   <%= form.govuk_check_box :sites_ids,
-                        site.id,
+                        site.uuid,
                         label: { text: [site.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
                         hint: { text: site.full_address },
                         link_errors: index.zero? %>

--- a/app/wizards/course_wizard/draft.rb
+++ b/app/wizards/course_wizard/draft.rb
@@ -89,13 +89,17 @@ class CourseWizard
       @subjects ||= ordered_subject_records(subject_ids)
     end
 
+    # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+    # TODO School data remodel removal - remove when the add-course wizard stores Provider::School identifiers.
     def school_ids
       Array(state_store.site_ids).compact_blank
     end
 
+    # TODO School data remodel removal - replace ordered Site records with Provider::School-backed school records.
     def schools
       @schools ||= ordered_site_records(school_ids)
     end
+    # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
     def study_site_ids
       return nil if state_store.study_sites_ids.nil?
@@ -171,8 +175,17 @@ class CourseWizard
     def ordered_site_records(ids)
       return [] if ids.blank?
 
-      records_by_id = Site.where(id: ids).index_by { |site| site.id.to_s }
-      ids.filter_map { |id| records_by_id[id.to_s] }
+      if ids.all? { |id| uuid?(id) }
+        records_by_uuid = Site.where(uuid: ids).index_by { |site| site.uuid.to_s }
+        ids.filter_map { |id| records_by_uuid[id.to_s] }
+      else
+        records_by_id = Site.where(id: ids).index_by { |site| site.id.to_s }
+        ids.filter_map { |id| records_by_id[id.to_s] }
+      end
+    end
+
+    def uuid?(identifier)
+      identifier.to_s.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
     end
   end
 end

--- a/app/wizards/course_wizard/steps/schools.rb
+++ b/app/wizards/course_wizard/steps/schools.rb
@@ -20,6 +20,8 @@ class CourseWizard
         )
       end
 
+      # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+      # TODO School data remodel removal - replace with Provider::School records when the wizard no longer reads provider.sites.
       def sites
         @sites ||= provider_sites.sort_by(&:location_name)
       end
@@ -42,9 +44,10 @@ class CourseWizard
 
     private
 
+      # TODO School data remodel removal - remove Site-based defaulting when selected schools are Provider::School-backed.
       def site_ids_selected
         if selected_site_ids.empty? && provider_sites.one?
-          self.site_ids = [provider_sites.first.id.to_s]
+          self.site_ids = [provider_sites.first.uuid]
         end
 
         return if selected_site_ids.any?
@@ -56,6 +59,7 @@ class CourseWizard
         Array(site_ids).compact_blank
       end
 
+      # TODO School data remodel removal - replace with provider schools when school selection no longer uses Site.
       def provider_sites
         wizard.provider.sites
       end
@@ -63,6 +67,7 @@ class CourseWizard
       def funding_type
         wizard.state_store.funding_type
       end
+      # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
       def qualification
         wizard.state_store.qualification

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1224,7 +1224,7 @@ en:
               too_long: "Reduce the word count for salary details"
         publish/course_school_form:
           attributes:
-            site_ids:
+            school_uuids:
               no_schools: "Select at least one school"
               enter_schools: "Enter schools for this course"
               check_schools: "Review the schools for this course"

--- a/spec/factories/course_schools.rb
+++ b/spec/factories/course_schools.rb
@@ -16,6 +16,12 @@ FactoryBot.define do
         association(:provider_school, provider: course.provider, gias_school:, site_code:)
     end
 
+    after(:build) do |course_school, evaluator|
+      if course_school.has_attribute?(:site_code)
+        course_school.site_code = evaluator.site_code || course_school.provider_school.site_code
+      end
+    end
+
     trait :main_site do
       site_code { Provider::School::MAIN_SITE_CODE }
     end

--- a/spec/forms/publish/course_school_form_spec.rb
+++ b/spec/forms/publish/course_school_form_spec.rb
@@ -42,8 +42,8 @@ module Publish
     describe "validations", travel: Find::CycleTimetable.mid_cycle(2026) do
       before { subject.valid? }
 
-      it "validates :site_ids" do
-        expect(subject.errors[:site_ids]).to include(I18n.t("activemodel.errors.models.publish/course_school_form.attributes.site_ids.no_schools"))
+      it "validates :school_uuids" do
+        expect(subject.errors[:school_uuids]).to include(I18n.t("activemodel.errors.models.publish/course_school_form.attributes.school_uuids.no_schools"))
       end
 
       context "when the course is exempt from needing a school (publish without schools allowed)" do
@@ -56,7 +56,7 @@ module Publish
         it "does not require at least one school" do
           subject.valid?
 
-          expect(subject.errors[:site_ids]).to be_empty
+          expect(subject.errors[:school_uuids]).to be_empty
         end
 
         context "when the new school model flag is OFF" do
@@ -68,7 +68,7 @@ module Publish
           it "still does not require at least one school" do
             subject.valid?
 
-            expect(subject.errors[:site_ids]).to be_empty
+            expect(subject.errors[:school_uuids]).to be_empty
           end
         end
       end

--- a/spec/jobs/update_course_schools_job_spec.rb
+++ b/spec/jobs/update_course_schools_job_spec.rb
@@ -2,16 +2,17 @@ require "rails_helper"
 
 RSpec.describe UpdateCourseSchoolsJob, type: :job do
   let(:course) { create(:course) }
-  let(:params) { { site_ids: [SecureRandom.uuid] } }
+  let(:params) { { school_uuids: [SecureRandom.uuid] } }
 
-  it "calls UpdateCourseSchoolsService with the correct arguments" do
-    service_instance = instance_double(Publish::Schools::UpdateCourseSchoolsService)
+  it "calls both update services with the correct arguments" do
+    legacy_service_instance = instance_double(Publish::Schools::UpdateCourseSchoolsService)
 
     allow(Course).to receive(:find).and_return(course)
     allow(Publish::Schools::UpdateCourseSchoolsService)
       .to receive(:new)
-      .and_return(service_instance)
-    allow(service_instance).to receive(:call)
+      .and_return(legacy_service_instance)
+    allow(Publish::Schools::UpdateCourseProviderSchoolsService).to receive(:call)
+    allow(legacy_service_instance).to receive(:call)
 
     described_class.new.perform(course.id, params)
 
@@ -19,6 +20,7 @@ RSpec.describe UpdateCourseSchoolsJob, type: :job do
     expect(Publish::Schools::UpdateCourseSchoolsService)
       .to have_received(:new)
       .with(course: course, params: params)
-    expect(service_instance).to have_received(:call)
+    expect(legacy_service_instance).to have_received(:call)
+    expect(Publish::Schools::UpdateCourseProviderSchoolsService).to have_received(:call).with(course: course, params: params)
   end
 end

--- a/spec/services/course_schools/creator_spec.rb
+++ b/spec/services/course_schools/creator_spec.rb
@@ -12,47 +12,51 @@ describe CourseSchools::Creator do
       create(:provider_school, provider:, gias_school:, site_code: "Q")
     end
 
-    it "creates a Course::School row for the course and gias_school" do
+    it "creates a Course::School row for the course and provider_school" do
       expect {
-        described_class.call(course:, gias_school_id: gias_school.id)
+        described_class.call(course:, provider_school:)
       }.to change(Course::School, :count).by(1)
 
       row = Course::School.last
       expect(row.course).to eq(course)
       expect(row.gias_school_id).to eq(gias_school.id)
-    end
-
-    it "copies site_code from the matching Provider::School" do
-      result = described_class.call(course:, gias_school_id: gias_school.id)
-
-      expect(result.site_code).to eq("Q")
+      expect(row.provider_school).to eq(provider_school)
     end
 
     it "links the row to the matching Provider::School" do
-      result = described_class.call(course:, gias_school_id: gias_school.id)
+      result = described_class.call(course:, provider_school_id: provider_school.id)
 
       expect(result.provider_school).to eq(provider_school)
     end
 
+    it "can resolve the provider school by gias_school_id and site_code" do
+      main_site_provider_school = create(:provider_school, :main_site, provider:, gias_school:)
+
+      result = described_class.call(course:, gias_school_id: gias_school.id, site_code: "Q")
+
+      expect(result.provider_school).to eq(provider_school)
+      expect(result.provider_school).not_to eq(main_site_provider_school)
+    end
+
     it "returns the created row" do
-      result = described_class.call(course:, gias_school_id: gias_school.id)
+      result = described_class.call(course:, provider_school:)
 
       expect(result).to be_a(Course::School)
       expect(result).to be_persisted
     end
 
-    it "is idempotent when called twice with the same course and gias_school" do
-      described_class.call(course:, gias_school_id: gias_school.id)
+    it "is idempotent when called twice with the same course and provider_school" do
+      described_class.call(course:, provider_school:)
 
       expect {
-        described_class.call(course:, gias_school_id: gias_school.id)
+        described_class.call(course:, provider_school:)
       }.not_to change(Course::School, :count)
     end
 
-    it "returns the existing row when one already exists for (course, gias_school)" do
+    it "returns the existing row when one already exists for (course, provider_school)" do
       existing = create(:course_school, course:, gias_school:, provider_school:, site_code: "Q")
 
-      result = described_class.call(course:, gias_school_id: gias_school.id)
+      result = described_class.call(course:, provider_school:)
 
       expect(result).to eq(existing)
     end
@@ -64,23 +68,29 @@ describe CourseSchools::Creator do
       allow(course).to receive(:schools).and_return(schools_proxy)
       allow(schools_proxy).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
 
-      result = described_class.call(course:, gias_school_id: gias_school.id)
+      result = described_class.call(course:, provider_school:)
 
       expect(result).to eq(existing)
     end
   end
 
   context "when the provider has no matching Provider::School" do
-    it "raises ActiveRecord::RecordNotFound" do
-      expect {
-        described_class.call(course:, gias_school_id: gias_school.id)
-      }.to raise_error(ActiveRecord::RecordNotFound)
+    it "logs and skips when only gias_school_id is supplied" do
+      expect(Rails.logger).to receive(:warn).with(/ArgumentError/)
+
+      expect(described_class.call(course:, gias_school_id: gias_school.id)).to be_nil
+    end
+
+    it "logs and skips when the provider_school row is missing" do
+      expect(Rails.logger).to receive(:warn).with(/ActiveRecord::RecordNotFound/)
+
+      expect(described_class.call(course:, provider_school_id: Provider::School.maximum(:id).to_i + 1_000)).to be_nil
     end
 
     it "does not create a Course::School row" do
       expect {
-        described_class.call(course:, gias_school_id: gias_school.id)
-      }.to raise_error(ActiveRecord::RecordNotFound).and(not_change(Course::School, :count))
+        described_class.call(course:, provider_school_id: Provider::School.maximum(:id).to_i + 1_000)
+      }.not_to change(Course::School, :count)
     end
   end
 end

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -107,7 +107,7 @@ describe Courses::CreationService do
         "level" => "primary",
         "qualification" => "qts",
         "funding" => "fee",
-        "sites_ids" => [site.id],
+        "sites_ids" => [site.uuid],
         "study_sites_ids" => [study_site.id],
       }
     end
@@ -481,7 +481,7 @@ describe Courses::CreationService do
     # the wizard, joined to the legacy site by matching URN (same mapping the
     # edit flow uses in Publish::Schools::UpdateCourseSchoolsService).
     let(:gias_school) { create(:gias_school, urn: site.urn) }
-    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: "-") }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code) }
 
     let(:valid_course_params) do
       {
@@ -493,7 +493,7 @@ describe Courses::CreationService do
         "qualification" => "qts",
         "start_date" => "September #{recruitment_cycle.year}",
         "study_mode" => %w[full_time],
-        "sites_ids" => [site.id],
+        "sites_ids" => [site.uuid],
         "study_sites_ids" => [study_site.id],
         "master_subject_id" => primary_subject.id,
         "subjects_ids" => [primary_subject.id],
@@ -509,6 +509,7 @@ describe Courses::CreationService do
       it "dual-writes: builds both the legacy site_status and the new Course::School" do
         expect(created_course.sites.map(&:id)).to eq([site.id])
         expect(created_course.schools.map(&:gias_school_id)).to eq([gias_school.id])
+        expect(created_course.schools.first.provider_school.site_code).to eq(provider_school.site_code)
         expect(created_course.schools.first.provider_school).to eq(provider_school)
         expect(created_course.errors).to be_empty
       end
@@ -517,8 +518,10 @@ describe Courses::CreationService do
         created_course.save!
 
         expect(created_course.reload.sites.map(&:id)).to eq([site.id])
-        expect(Course::School.where(course: created_course).pluck(:gias_school_id, :provider_school_id))
-          .to eq([[gias_school.id, provider_school.id]])
+        course_school_attributes = Course::School.where(course: created_course).includes(:provider_school).map do |course_school|
+          [course_school.gias_school_id, course_school.provider_school.site_code]
+        end
+        expect(course_school_attributes).to eq([[gias_school.id, provider_school.site_code]])
       end
     end
 
@@ -530,7 +533,7 @@ describe Courses::CreationService do
 
       it "builds the new Course::School and passes :new validation" do
         expect(created_course.schools.map(&:gias_school_id)).to eq([gias_school.id])
-        expect(created_course.schools.first.site_code).to eq("-")
+        expect(created_course.schools.first.provider_school.site_code).to eq(provider_school.site_code)
         expect(created_course.schools.first.provider_school).to eq(provider_school)
         expect(created_course.errors).to be_empty
       end
@@ -538,8 +541,10 @@ describe Courses::CreationService do
       it "persists the Course::School on save" do
         created_course.save!
 
-        expect(Course::School.where(course: created_course).pluck(:gias_school_id, :provider_school_id))
-          .to eq([[gias_school.id, provider_school.id]])
+        course_school_attributes = Course::School.where(course: created_course).includes(:provider_school).map do |course_school|
+          [course_school.gias_school_id, course_school.provider_school.site_code]
+        end
+        expect(course_school_attributes).to eq([[gias_school.id, provider_school.site_code]])
       end
     end
 

--- a/spec/services/provider_schools/creator_spec.rb
+++ b/spec/services/provider_schools/creator_spec.rb
@@ -24,6 +24,20 @@ describe ProviderSchools::Creator do
     expect(result.site_code).to eq("Q")
   end
 
+  it "uses the supplied site_code when a legacy site was created first" do
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "Z")
+
+    expect(result.site_code).to eq("Z")
+  end
+
+  it "uses the supplied uuid when a legacy site was created first" do
+    uuid = SecureRandom.uuid
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id, uuid:)
+
+    expect(result.uuid).to eq(uuid)
+  end
+
   it "returns the created row" do
     result = described_class.call(provider:, gias_school_id: gias_school.id)
 
@@ -31,31 +45,49 @@ describe ProviderSchools::Creator do
     expect(result).to be_persisted
   end
 
-  it "is idempotent when called twice with the same provider and gias_school" do
-    described_class.call(provider:, gias_school_id: gias_school.id)
+  it "is idempotent when called twice with the same provider, gias_school and site_code" do
+    described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
 
     expect {
-      described_class.call(provider:, gias_school_id: gias_school.id)
+      described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
     }.not_to change(Provider::School, :count)
   end
 
-  it "returns the existing row when one already exists for this (provider, gias_school)" do
+  it "returns the existing row when one already exists for this provider, gias_school and site_code" do
     existing = create(:provider_school, provider:, gias_school:, site_code: "A")
 
-    result = described_class.call(provider:, gias_school_id: gias_school.id)
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
 
     expect(result).to eq(existing)
     expect(result.site_code).to eq("A")
   end
 
+  it "does not reuse a main-site row when creating a normal school row for the same GIAS school" do
+    main_site = create(:provider_school, :main_site, provider:, gias_school:)
+
+    expect {
+      result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+      expect(result).not_to eq(main_site)
+      expect(result.site_code).to eq("A")
+    }.to change(Provider::School, :count).by(1)
+  end
+
+  it "updates the uuid on an existing row when one is supplied" do
+    existing = create(:provider_school, provider:, gias_school:, site_code: "A", uuid: SecureRandom.uuid)
+    uuid = SecureRandom.uuid
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A", uuid:)
+
+    expect(result).to eq(existing)
+    expect(result.uuid).to eq(uuid)
+  end
+
   it "returns the existing row when a RecordNotUnique race fires" do
     existing = create(:provider_school, provider:, gias_school:, site_code: "B")
 
-    schools_proxy = provider.schools
-    allow(provider).to receive(:schools).and_return(schools_proxy)
-    allow(schools_proxy).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
+    allow(provider).to receive(:with_lock).and_raise(ActiveRecord::RecordNotUnique)
 
-    result = described_class.call(provider:, gias_school_id: gias_school.id)
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "B")
 
     expect(result).to eq(existing)
   end

--- a/spec/services/publish/schools/update_course_provider_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_provider_schools_service_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  module Schools
+    RSpec.describe UpdateCourseProviderSchoolsService do
+      let(:site_one) { build(:site, location_name: "Site 1", code: "X") }
+      let(:site_two) { build(:site, location_name: "Site 2", code: "Y") }
+      let(:provider) { create(:provider, sites: [site_one, site_two]) }
+      let(:course) { create(:course, provider:) }
+      let(:gias_school_one) { create(:gias_school, urn: site_one.urn) }
+      let(:gias_school_two) { create(:gias_school, urn: site_two.urn) }
+      let!(:provider_school_one) do
+        create(:provider_school, provider:, gias_school: gias_school_one, site_code: site_one.code, uuid: site_one.uuid)
+      end
+      let!(:provider_school_two) do
+        create(:provider_school, provider:, gias_school: gias_school_two, site_code: site_two.code, uuid: site_two.uuid)
+      end
+
+      describe "#call" do
+        subject(:service_call) { described_class.call(course:, params:) }
+
+        context "when a provider school is newly attached" do
+          let(:params) { { school_uuids: [site_two.uuid] } }
+
+          it "creates a Course::School row for the submitted provider school" do
+            expect { service_call }.to change { course.schools.count }.by(1)
+
+            added = course.schools.find_by(provider_school: provider_school_two)
+            expect(added).to be_present
+            expect(added.gias_school).to eq(gias_school_two)
+          end
+        end
+
+        context "when a provider school row predates copied UUIDs" do
+          let(:params) { { school_uuids: [site_two.uuid] } }
+
+          before do
+            provider_school_two.update!(uuid: SecureRandom.uuid)
+          end
+
+          it "falls back through the legacy site UUID and still creates the Course::School row" do
+            expect { service_call }.to change { course.schools.count }.by(1)
+
+            expect(course.schools.find_by(provider_school: provider_school_two)).to be_present
+          end
+        end
+
+        context "when a provider school is detached" do
+          let(:params) { { school_uuids: [] } }
+
+          before do
+            create(:course_school, course:, gias_school: gias_school_one, provider_school: provider_school_one)
+          end
+
+          it "destroys the Course::School row for the removed provider school" do
+            expect { service_call }.to change { course.schools.count }.by(-1)
+
+            expect(course.schools.where(provider_school: provider_school_one)).to be_empty
+          end
+        end
+
+        context "when the prerequisite provider_school is missing" do
+          let(:params) { { school_uuids: [site_two.uuid] } }
+
+          before do
+            provider_school_two.destroy!
+          end
+
+          it "does not raise" do
+            expect { service_call }.not_to raise_error
+          end
+
+          it "skips the Course::School write for the missing provider_school" do
+            service_call
+
+            expect(course.reload.schools.where(gias_school: gias_school_two)).to be_empty
+          end
+
+          it "logs the skip so operators can spot environments needing a backfill" do
+            expect(Rails.logger).to receive(:warn).with(/no provider_school/)
+
+            service_call
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -11,8 +11,8 @@ module Publish
       let(:previous_site_names) { course.sites.map(&:location_name) }
 
       describe ".call_or_enqueue" do
-        context "when site_ids count exceeds ENQUEUE_THRESHOLD" do
-          let(:params) { { site_ids: Array.new(31) { SecureRandom.uuid } } }
+        context "when school_uuids count exceeds ENQUEUE_THRESHOLD" do
+          let(:params) { { school_uuids: Array.new(31) { SecureRandom.uuid } } }
 
           it "enqueues the job" do
             expect(UpdateCourseSchoolsJob).to receive(:perform_async).with(course.id, params.to_h)
@@ -20,8 +20,8 @@ module Publish
           end
         end
 
-        context "when site_ids count is below or equal to ENQUEUE_THRESHOLD" do
-          let(:params) { { site_ids: provider.site_ids } }
+        context "when school_uuids count is below or equal to ENQUEUE_THRESHOLD" do
+          let(:params) { { school_uuids: provider.sites.map(&:uuid) } }
 
           it "runs the service inline" do
             service_instance = instance_double(described_class)
@@ -30,6 +30,7 @@ module Publish
               .to receive(:new)
               .with(course: course, params: params)
               .and_return(service_instance)
+            allow(UpdateCourseProviderSchoolsService).to receive(:call)
 
             allow(service_instance).to receive(:call)
 
@@ -40,6 +41,7 @@ module Publish
               .with(course: course, params: params)
 
             expect(service_instance).to have_received(:call)
+            expect(UpdateCourseProviderSchoolsService).to have_received(:call).with(course: course, params: params)
           end
         end
       end
@@ -47,8 +49,8 @@ module Publish
       describe "#call" do
         subject(:service_call) { described_class.new(course:, params:).call }
 
-        context "when site_ids are different from course.site_ids" do
-          let(:params) { { site_ids: provider.site_ids } }
+        context "when school_uuids are different from course school UUIDs" do
+          let(:params) { { school_uuids: provider.sites.map(&:uuid) } }
           let(:updated_site_names) { provider.sites.order(:location_name).map(&:location_name) }
 
           context "when feature flag is enabled" do
@@ -88,8 +90,8 @@ module Publish
           end
         end
 
-        context "when site_ids are the same as course.site_ids" do
-          let(:params) { { site_ids: course.site_ids } }
+        context "when school_uuids are the same as course school UUIDs" do
+          let(:params) { { school_uuids: course.sites.map(&:uuid) } }
 
           it "does not call the notification service" do
             expect(NotificationService::CourseSitesUpdated).not_to receive(:call)
@@ -121,7 +123,7 @@ module Publish
                 ],
               )
             end
-            let(:params) { { site_ids: [site_two.id] } }
+            let(:params) { { school_uuids: [site_two.uuid] } }
 
             it "destroys the unticked site_status" do
               described_class.new(course:, params:).call
@@ -156,7 +158,7 @@ module Publish
                 ],
               )
             end
-            let(:params) { { site_ids: [site_one.id] } }
+            let(:params) { { school_uuids: [site_one.uuid] } }
 
             it "does not flip the suspended site_status back to running" do
               described_class.new(course:, params:).call
@@ -185,7 +187,7 @@ module Publish
                 ],
               )
             end
-            let(:params) { { site_ids: [site_one.id] } }
+            let(:params) { { school_uuids: [site_one.uuid] } }
 
             it "does not touch the discontinued site_status" do
               described_class.new(course:, params:).call
@@ -198,7 +200,7 @@ module Publish
 
           context "when adding a school to a draft (unpublished) course" do
             let(:course) { create(:course, provider:, site_statuses: []) }
-            let(:params) { { site_ids: [site_one.id] } }
+            let(:params) { { school_uuids: [site_one.uuid] } }
 
             it "the newly attached site_status is :new_status :unpublished" do
               described_class.new(course:, params:).call
@@ -206,78 +208,6 @@ module Publish
               site_status = course.reload.site_statuses.find_by!(site: site_one)
               expect(site_status).to be_status_new_status
               expect(site_status).to be_unpublished_on_ucas
-            end
-          end
-        end
-
-        context "dual-write to Course::School" do
-          let(:gias_school_one) { create(:gias_school, urn: site_one.urn) }
-          let(:gias_school_two) { create(:gias_school, urn: site_two.urn) }
-
-          before do
-            # Persist sites so they have IDs / URNs present in the DB
-            provider.save!
-            create(:provider_school, provider:, gias_school: gias_school_one, site_code: "X")
-            create(:provider_school, provider:, gias_school: gias_school_two, site_code: "Y")
-          end
-
-          context "when a site is newly attached" do
-            let(:params) { { site_ids: [site_one.id, site_two.id] } }
-
-            it "creates a Course::School row for the newly attached site" do
-              expect {
-                described_class.new(course:, params:).call
-              }.to change { course.schools.count }.by(1)
-
-              added = course.schools.find_by(gias_school: gias_school_two)
-              expect(added).to be_present
-              expect(added.site_code).to eq("Y")
-            end
-          end
-
-          context "when a site is detached" do
-            let(:params) { { site_ids: [] } }
-
-            before do
-              create(:course_school, course:, gias_school: gias_school_one, site_code: "X")
-            end
-
-            it "destroys the Course::School row for the detached site" do
-              expect {
-                described_class.new(course:, params:).call
-              }.to change { course.schools.count }.by(-1)
-
-              expect(course.schools.where(gias_school: gias_school_one)).to be_empty
-            end
-          end
-
-          context "when the prerequisite provider_school is missing" do
-            let(:params) { { site_ids: [site_one.id, site_two.id] } }
-
-            before do
-              # Simulate an env where the schools backfill has not yet run
-              # for this provider's existing sites.
-              Provider::School.where(provider:, gias_school: gias_school_two).destroy_all
-            end
-
-            it "still attaches the legacy SiteStatus and does not raise" do
-              expect {
-                described_class.new(course:, params:).call
-              }.not_to raise_error
-
-              expect(course.reload.sites.map(&:id)).to include(site_two.id)
-            end
-
-            it "skips the Course::School write for the missing provider_school" do
-              described_class.new(course:, params:).call
-
-              expect(course.reload.schools.where(gias_school: gias_school_two)).to be_empty
-            end
-
-            it "logs the skip so operators can spot environments needing a backfill" do
-              expect(Rails.logger).to receive(:warn).with(/no provider_school for course=/)
-
-              described_class.new(course:, params:).call
             end
           end
         end

--- a/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
@@ -526,7 +526,7 @@ private
   def then_the_created_course_has_the_new_course_school
     created_course = provider.courses.order(:created_at).last
     expect(created_course.schools.map(&:gias_school_id)).to eq([@gias_school.id])
-    expect(created_course.schools.first.site_code).to eq(@selected_site.code)
+    expect(created_course.schools.first.provider_school.site_code).to eq(@selected_site.code)
   end
 
   def and_the_created_course_still_has_the_legacy_site

--- a/spec/system/publish/courses/editing_course_schools_spec.rb
+++ b/spec/system/publish/courses/editing_course_schools_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
 
   def then_i_should_see_an_error_message
     expect(publish_course_school_edit_page).to have_content(
-      I18n.t("activemodel.errors.models.publish/course_school_form.attributes.site_ids.no_schools"),
+      I18n.t("activemodel.errors.models.publish/course_school_form.attributes.school_uuids.no_schools"),
     )
   end
 
@@ -134,7 +134,7 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     gias_school = GiasSchool.find_by!(urn: site.urn)
     course_school = course.reload.schools.find_by(gias_school:)
     expect(course_school).to be_present
-    expect(course_school.site_code).to eq(site.code)
+    expect(course_school.provider_school.site_code).to eq(site.code)
   end
 
   def given_the_course_already_has_both_sites

--- a/spec/system/publish/providers/schools/add_school_spec.rb
+++ b/spec/system/publish/providers/schools/add_school_spec.rb
@@ -178,9 +178,10 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
 
   def and_the_provider_school_row_is_created
     added_site = provider.sites.find_by(urn: @gias_school.urn)
-    provider_school = provider.schools.find_by(gias_school_id: @gias_school.id)
+    provider_school = provider.schools.find_by(gias_school_id: @gias_school.id, site_code: added_site.code)
     expect(provider_school).to be_present
     expect(provider_school.site_code).to eq(added_site.code)
+    expect(provider_school.uuid).to eq(added_site.uuid)
   end
 
   def and_no_provider_school_row_is_created

--- a/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
@@ -132,9 +132,10 @@ RSpec.describe "Multiple schools" do
   def and_provider_school_rows_are_created_for_each
     @gias_schools.each do |gias_school|
       site = provider.sites.find_by(urn: gias_school.urn)
-      provider_school = provider.schools.find_by(gias_school_id: gias_school.id)
+      provider_school = provider.schools.find_by(gias_school_id: gias_school.id, site_code: site.code)
       expect(provider_school).to be_present
       expect(provider_school.site_code).to eq(site.code)
+      expect(provider_school.uuid).to eq(site.uuid)
     end
   end
 

--- a/spec/system/support/providers/schools/add_school_to_provider_spec.rb
+++ b/spec/system/support/providers/schools/add_school_to_provider_spec.rb
@@ -204,8 +204,9 @@ RSpec.describe "Adding school to provider as an admin" do
 
   def and_the_provider_school_row_is_created
     added_site = @provider.sites.find_by(urn: @gias_school.urn)
-    provider_school = @provider.schools.find_by(gias_school_id: @gias_school.id)
+    provider_school = @provider.schools.find_by(gias_school_id: @gias_school.id, site_code: added_site.code)
     expect(provider_school).to be_present
     expect(provider_school.site_code).to eq(added_site.code)
+    expect(provider_school.uuid).to eq(added_site.uuid)
   end
 end

--- a/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
@@ -123,9 +123,10 @@ RSpec.describe "Multiple schools" do
   def and_provider_school_rows_are_created_for_each
     @gias_schools.each do |gias_school|
       site = @provider.sites.find_by(urn: gias_school.urn)
-      provider_school = @provider.schools.find_by(gias_school_id: gias_school.id)
+      provider_school = @provider.schools.find_by(gias_school_id: gias_school.id, site_code: site.code)
       expect(provider_school).to be_present
       expect(provider_school.site_code).to eq(site.code)
+      expect(provider_school.uuid).to eq(site.uuid)
     end
   end
 

--- a/spec/wizards/add_course_wizard/draft_spec.rb
+++ b/spec/wizards/add_course_wizard/draft_spec.rb
@@ -193,9 +193,9 @@ RSpec.describe CourseWizard::Draft, type: :wizard do
     it "returns school ids and ordered school records" do
       site_one = provider.sites.first || create(:site, provider:)
       site_two = create(:site, provider:)
-      state_store.write(site_ids: [site_two.id.to_s, site_one.id.to_s])
+      state_store.write(site_ids: [site_two.uuid, site_one.uuid])
 
-      expect(draft.school_ids).to eq([site_two.id.to_s, site_one.id.to_s])
+      expect(draft.school_ids).to eq([site_two.uuid, site_one.uuid])
       expect(draft.schools.map(&:id)).to eq([site_two.id, site_one.id])
     end
 

--- a/spec/wizards/add_course_wizard/steps/schools_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/schools_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CourseWizard::Steps::Schools do
     subject(:wizard_step) { wizard.current_step }
 
     it "is valid when at least one site is selected" do
-      wizard_step.site_ids = [site_a.id.to_s]
+      wizard_step.site_ids = [site_a.uuid]
 
       expect(wizard_step).to be_valid
     end
@@ -37,7 +37,7 @@ RSpec.describe CourseWizard::Steps::Schools do
         wizard_step.site_ids = nil
 
         expect(wizard_step).to be_valid
-        expect(wizard_step.site_ids).to eq([site_a.id.to_s])
+        expect(wizard_step.site_ids).to eq([site_a.uuid])
       end
     end
   end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
           qualification: "pgce_with_qts",
           funding_type: "fee",
           study_pattern: %w[full_time],
-          site_ids: [provider.sites.first.id.to_s],
+          site_ids: [provider.sites.first.uuid],
           study_sites_ids: [study_site.id.to_s],
           can_sponsor_student_visa: false,
           start_date: "July 2027",


### PR DESCRIPTION
## Context

We are normalising the new school data model as part of the school remodel work.

`course_school.site_code` was denormalised because the site code already belongs on `provider_school`. This PR removes that duplication and moves course school writes towards the new `provider_school` / `course_school` model while keeping the legacy `site` / `site_status` writes in place for now.

The migration/backfill has not run in all environments yet, so the new write path still needs to cope with missing `provider_school` rows. To support that transition, school selection now passes UUIDs rather than legacy site IDs, and the resolver can fall back through legacy `site.uuid` until the backfill is complete.

## Changes proposed in this pull request

- Removes `site_code` from `course_school` and updates model validations/creation paths accordingly.
- Adds a unique index for `provider_school.uuid`.
- Copies legacy `site.uuid` and `site.code` into `provider_school` during provider school creation.
- Splits the new `course_school` sync from the legacy `site_status` sync.
- Updates course school edit/add-course flows to submit school UUIDs instead of site IDs.
- Updates provider school and course school creation logic to distinguish main site `"-"` from normal school site codes.
- Makes `CourseSchools::Creator` fail gracefully and log when the transitional new model data is missing.
- Updates data hub/backfill logic to copy UUIDs and use `provider_school.site_code`.
- Adds grepable removal TODOs using:
  `TODO School data remodel removal -`

## Guidance to review

Please review this PR by topic rather than file order.

### 1. Schema and normalisation

Review:

- `db/migrate/*remove_site_code_from_course_school*`
- `db/migrate/*add_unique_index_to_provider_school_uuid*`
- `db/schema.rb`
- `app/models/course/school.rb`
- `config/analytics_blocklist.yml`

Check that `course_school.site_code` is fully removed from the new model, and that any remaining site code ownership is through `provider_school`.

### 2. Provider school creation

Review:

- `app/services/provider_schools/creator.rb`
- `app/services/provider_schools/legacy_site_creator.rb`
- provider/support school check controllers

Focus on whether we always create the legacy `site` first, then pass its `uuid` and `code` into `ProviderSchools::Creator`, so both models stay aligned during dual write.

Also check the lookup logic: provider schools must not be found by only `provider_id` and `gias_school_id`, because the same GIAS school can exist as both main site `"-"` and a normal school site.

### 3. Course school creation and removal

Review:

- `app/services/course_schools/creator.rb`
- `app/services/course_schools/remover.rb`
- `app/services/course_schools/legacy_site_status_creator.rb`
- `app/services/course_schools/legacy_site_status_remover.rb`
- `app/services/publish/schools/update_course_schools_service.rb`
- `app/services/publish/schools/update_course_provider_schools_service.rb`
- `app/services/publish/schools/provider_school_resolver.rb`
- `app/jobs/update_course_schools_job.rb`

This is the main split between legacy `site_status` writes and new `course_school` writes.

Please check that the legacy service can be removed later without untangling the new model service, and that missing `provider_school` rows are logged rather than hard-failing during the transition.

### 4. Course edit and add-course wizard changes

Review:

- `app/forms/publish/course_school_form.rb`
- `app/controllers/publish/courses/schools_controller.rb`
- `app/views/publish/courses/schools/edit.html.erb`
- `app/views/publish/courses/schools/new.html.erb`
- `app/views/publish/course_wizards/steps/_schools.html.erb`
- `app/wizards/course_wizard/steps/schools.rb`
- `app/wizards/course_wizard/draft.rb`
- `app/services/courses/creation_service.rb`

Check that the UI now submits UUIDs instead of site IDs, while still resolving through legacy sites until the provider school migration has been run.

### 5. Backfill logic

Review:

- `db/data/20260706120000_backfill_provider_school_uuids.rb`
- `app/services/data_hub/schools_backfill/executor.rb`

Check that UUIDs are copied from legacy `site` into `provider_school`, and that backfilled `course_school` rows join through `provider_school` using both `gias_school_id` and `site_code`.

### 6. Tests

Useful areas to focus on:

- provider school creation with matching UUID/site code
- course school creation where main site `"-"` and normal school share the same GIAS school
- missing transitional `provider_school` rows
- add-course wizard UUID submission
- course school edit UUID submission
- data hub/backfill behaviour