### PR TITLE
Normalised site_code in course_school

### DIFF
--- a/app/models/course/school.rb
+++ b/app/models/course/school.rb
@@ -9,16 +9,14 @@ class Course::School < ApplicationRecord
   belongs_to :gias_school
   belongs_to :provider_school, class_name: "Provider::School", inverse_of: :course_schools
 
-  validates :site_code, presence: true
   validates :provider_school_id, uniqueness: { scope: :course_id }
   validate :consistent_with_provider_school
 
 private
 
-  # gias_school_id and site_code are denormalised copies of the linked
-  # Provider::School (gias_school_id is kept so courses can be filtered by the
-  # GIAS school's lat/long without joining provider_school). Guard against the
-  # two sources of truth drifting apart.
+  # gias_school_id is a denormalised copy of the linked Provider::School so
+  # courses can be filtered by the GIAS school's lat/long without joining
+  # provider_school. Guard against the two sources of truth drifting apart.
   def consistent_with_provider_school
     return if provider_school.blank?
 
@@ -31,10 +29,6 @@ private
 
     if gias_school != provider_school.gias_school
       errors.add(:gias_school_id, "must match the provider school's GIAS school")
-    end
-
-    if site_code != provider_school.site_code
-      errors.add(:site_code, "must match the provider school's site code")
     end
   end
 end

--- a/app/models/course/school.rb
+++ b/app/models/course/school.rb
@@ -12,6 +12,8 @@ class Course::School < ApplicationRecord
   validates :provider_school_id, uniqueness: { scope: :course_id }
   validate :consistent_with_provider_school
 
+  delegate :site_code, to: :provider_school
+
 private
 
   # gias_school_id is a denormalised copy of the linked Provider::School so

--- a/app/services/course_schools/creator.rb
+++ b/app/services/course_schools/creator.rb
@@ -23,7 +23,6 @@ module CourseSchools
       # so the denormalised columns can never disagree with it.
       @course.schools.find_or_create_by!(provider_school_id: provider_school.id) do |course_school|
         course_school.gias_school_id = provider_school.gias_school_id
-        course_school.site_code = provider_school.site_code
       end
     rescue ActiveRecord::RecordNotUnique
       @course.schools.find_by!(provider_school_id: provider_school.id)

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -153,7 +153,7 @@ module Courses
           next
         end
 
-        course.schools.build(gias_school_id: gias_school.id, provider_school:, site_code: provider_school.site_code)
+        course.schools.build(gias_school_id: gias_school.id, provider_school:)
       end
     end
 

--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -37,11 +37,37 @@ module DataHub
 
       def insert_provider_schools
         inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
-          INSERT INTO provider_school (provider_id, gias_school_id, site_code, created_at, updated_at)
+          INSERT INTO provider_school (provider_id, gias_school_id, site_code, uuid, created_at, updated_at)
           SELECT DISTINCT ON (site.provider_id, gias_school.id, site.code)
-                 site.provider_id, gias_school.id, site.code, NOW(), NOW()
+                 site.provider_id, gias_school.id, site.code, site.uuid, NOW(), NOW()
           FROM site
           JOIN gias_school ON gias_school.urn = site.urn
+          WHERE site.site_type = 0
+            AND site.discarded_at IS NULL
+            AND site.urn IS NOT NULL
+            AND site.urn <> ''
+          ON CONFLICT (provider_id, gias_school_id, site_code) DO UPDATE
+            SET uuid = EXCLUDED.uuid,
+                updated_at = NOW()
+            WHERE provider_school.uuid IS DISTINCT FROM EXCLUDED.uuid
+          RETURNING 1
+        SQL
+        inserted_rows.length
+      end
+
+      def insert_course_schools
+        return insert_course_schools_with_site_code if course_school_has_site_code?
+
+        inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
+          INSERT INTO course_school (course_id, gias_school_id, provider_school_id, created_at, updated_at)
+          SELECT DISTINCT ON (course_site.course_id, provider_school.id)
+                 course_site.course_id, gias_school.id, provider_school.id, NOW(), NOW()
+          FROM course_site
+          JOIN site            ON site.id = course_site.site_id
+          JOIN gias_school     ON gias_school.urn = site.urn
+          JOIN provider_school ON provider_school.provider_id = site.provider_id
+                              AND provider_school.gias_school_id = gias_school.id
+                              AND provider_school.site_code = site.code
           WHERE site.site_type = 0
             AND site.discarded_at IS NULL
             AND site.urn IS NOT NULL
@@ -52,14 +78,17 @@ module DataHub
         inserted_rows.length
       end
 
-      def insert_course_schools
+      def insert_course_schools_with_site_code
         inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
-          INSERT INTO course_school (course_id, gias_school_id, site_code, created_at, updated_at)
-          SELECT DISTINCT ON (course_site.course_id, gias_school.id, site.code)
-                 course_site.course_id, gias_school.id, site.code, NOW(), NOW()
+          INSERT INTO course_school (course_id, gias_school_id, provider_school_id, site_code, created_at, updated_at)
+          SELECT DISTINCT ON (course_site.course_id, provider_school.id)
+                 course_site.course_id, gias_school.id, provider_school.id, provider_school.site_code, NOW(), NOW()
           FROM course_site
-          JOIN site        ON site.id = course_site.site_id
-          JOIN gias_school ON gias_school.urn = site.urn
+          JOIN site            ON site.id = course_site.site_id
+          JOIN gias_school     ON gias_school.urn = site.urn
+          JOIN provider_school ON provider_school.provider_id = site.provider_id
+                              AND provider_school.gias_school_id = gias_school.id
+                              AND provider_school.site_code = site.code
           WHERE site.site_type = 0
             AND site.discarded_at IS NULL
             AND site.urn IS NOT NULL
@@ -68,6 +97,10 @@ module DataHub
           RETURNING 1
         SQL
         inserted_rows.length
+      end
+
+      def course_school_has_site_code?
+        @course_school_has_site_code ||= Course::School.column_names.include?("site_code")
       end
 
       def fetch_skipped_sites
@@ -102,17 +135,23 @@ module DataHub
                    WHEN site.site_type <> 0 THEN 'non_school_site'
                    WHEN site.discarded_at IS NOT NULL THEN 'site_discarded'
                    WHEN site.urn IS NULL OR site.urn = '' THEN 'no_urn'
+                   WHEN gias_school.id IS NULL THEN 'urn_not_in_gias_school'
+                   WHEN provider_school.id IS NULL THEN 'provider_school_missing'
                    ELSE 'urn_not_in_gias_school'
                  END AS reason
           FROM course_site
-          LEFT JOIN site        ON site.id = course_site.site_id
-          LEFT JOIN gias_school ON gias_school.urn = site.urn
+          LEFT JOIN site            ON site.id = course_site.site_id
+          LEFT JOIN gias_school     ON gias_school.urn = site.urn
+          LEFT JOIN provider_school ON provider_school.provider_id = site.provider_id
+                                  AND provider_school.gias_school_id = gias_school.id
+                                  AND provider_school.site_code = site.code
           WHERE site.id IS NULL
              OR site.site_type <> 0
              OR site.discarded_at IS NOT NULL
              OR site.urn IS NULL
              OR site.urn = ''
              OR gias_school.id IS NULL
+             OR provider_school.id IS NULL
           ORDER BY course_site.course_id, course_site.site_id
         SQL
       end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -67,7 +67,6 @@
   - course_id
   - gias_school_id
   - provider_school_id
-  - site_code
   - created_at
   - updated_at
   :candidate_recent_search:

--- a/db/migrate/20260714120000_remove_site_code_from_course_school.rb
+++ b/db/migrate/20260714120000_remove_site_code_from_course_school.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSiteCodeFromCourseSchool < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :course_school, :site_code, :text
+  end
+end

--- a/db/migrate/20260714120500_add_unique_index_to_provider_school_uuid.rb
+++ b/db/migrate/20260714120500_add_unique_index_to_provider_school_uuid.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToProviderSchoolUuid < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :provider_school, :uuid, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_102253) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_120500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -261,7 +261,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_102253) do
     t.datetime "created_at", null: false
     t.bigint "gias_school_id", null: false
     t.bigint "provider_school_id", null: false
-    t.text "site_code", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id", "provider_school_id"], name: "index_course_school_on_course_id_and_provider_school_id", unique: true
     t.index ["gias_school_id"], name: "index_course_school_on_gias_school_id"
@@ -470,6 +469,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_102253) do
     t.index ["gias_school_id"], name: "index_provider_school_on_gias_school_id"
     t.index ["provider_id", "gias_school_id", "site_code"], name: "index_provider_school_unique", unique: true
     t.index ["provider_id"], name: "index_provider_school_one_main_per_provider", unique: true, where: "(site_code = '-'::text)"
+    t.index ["uuid"], name: "index_provider_school_on_uuid", unique: true
   end
 
   create_table "provider_ucas_preference", force: :cascade do |t|

--- a/spec/factories/course_schools.rb
+++ b/spec/factories/course_schools.rb
@@ -16,12 +16,6 @@ FactoryBot.define do
         association(:provider_school, provider: course.provider, gias_school:, site_code:)
     end
 
-    after(:build) do |course_school, evaluator|
-      if course_school.has_attribute?(:site_code)
-        course_school.site_code = evaluator.site_code || course_school.provider_school.site_code
-      end
-    end
-
     trait :main_site do
       site_code { Provider::School::MAIN_SITE_CODE }
     end

--- a/spec/factories/course_schools.rb
+++ b/spec/factories/course_schools.rb
@@ -1,14 +1,25 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  sequence(:course_school_provider_site_code, "A")
+
   factory :course_school, class: "Course::School" do
     course
     gias_school
-    # Walks "A", "B", ... "Z", "AA", ... via String#next
-    sequence(:site_code, "A")
+
+    transient do
+      site_code { generate(:course_school_provider_site_code) }
+    end
+
     provider_school do
       Provider::School.find_by(provider: course.provider, gias_school:, site_code:) ||
         association(:provider_school, provider: course.provider, gias_school:, site_code:)
+    end
+
+    after(:build) do |course_school, evaluator|
+      if course_school.has_attribute?(:site_code)
+        course_school.site_code = evaluator.site_code || course_school.provider_school.site_code
+      end
     end
 
     trait :main_site do

--- a/spec/models/course/school_spec.rb
+++ b/spec/models/course/school_spec.rb
@@ -12,8 +12,6 @@ describe Course::School do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:site_code) }
-
     it "creates a valid record" do
       expect(course_school).to be_valid
     end
@@ -25,7 +23,6 @@ describe Course::School do
         course: existing.course,
         provider_school: existing.provider_school,
         gias_school: existing.gias_school,
-        site_code: existing.site_code,
       )
       expect(dup).not_to be_valid
       expect(dup.errors[:provider_school_id]).to be_present
@@ -38,7 +35,6 @@ describe Course::School do
         course: build(:course, provider: build(:provider)),
         provider_school:,
         gias_school: provider_school.gias_school,
-        site_code: provider_school.site_code,
       )
       expect(course_school).not_to be_valid
       expect(course_school.errors[:provider_school_id]).to be_present
@@ -50,26 +46,24 @@ describe Course::School do
         :course_school,
         provider_school:,
         gias_school: build(:gias_school),
-        site_code: provider_school.site_code,
       )
       expect(course_school).not_to be_valid
       expect(course_school.errors[:gias_school_id]).to be_present
     end
 
-    it "rejects a site_code that disagrees with the provider_school" do
-      course_school = build(:course_school)
-      course_school.site_code = "#{course_school.provider_school.site_code}X"
-      expect(course_school).not_to be_valid
-      expect(course_school.errors[:site_code]).to be_present
-    end
-
     it "allows the same course and gias_school with different site codes" do
       existing = create(:course_school, site_code: "-")
+      second_provider_school = create(
+        :provider_school,
+        provider: existing.course.provider,
+        gias_school: existing.gias_school,
+        site_code: "A",
+      )
       second = build(
         :course_school,
         course: existing.course,
         gias_school: existing.gias_school,
-        site_code: "A",
+        provider_school: second_provider_school,
       )
       expect(second).to be_valid
     end
@@ -91,7 +85,7 @@ describe Course::School do
       course.update_columns(changed_at: 1.hour.ago)
 
       Timecop.freeze do
-        course_school.update!(provider_school: other, gias_school: other.gias_school, site_code: other.site_code)
+        course_school.update!(provider_school: other, gias_school: other.gias_school)
         expect(course.reload.changed_at).to be_within(1.second).of(Time.zone.now)
       end
     end
@@ -121,31 +115,25 @@ describe Course::School do
 
     it "enforces NOT NULL on course_id" do
       expect {
-        described_class.new(gias_school:, provider_school:, site_code: "-").save(validate: false)
+        described_class.new(gias_school:, provider_school:).save(validate: false)
       }.to raise_error(ActiveRecord::NotNullViolation)
     end
 
     it "enforces NOT NULL on gias_school_id" do
       expect {
-        described_class.new(course:, provider_school:, site_code: "-").save(validate: false)
-      }.to raise_error(ActiveRecord::NotNullViolation)
-    end
-
-    it "enforces NOT NULL on site_code" do
-      expect {
-        described_class.new(course:, gias_school:, provider_school:).save(validate: false)
+        described_class.new(course:, provider_school:).save(validate: false)
       }.to raise_error(ActiveRecord::NotNullViolation)
     end
 
     it "enforces NOT NULL on provider_school_id" do
       expect {
-        described_class.new(course:, gias_school:, site_code: "-").save(validate: false)
+        described_class.new(course:, gias_school:).save(validate: false)
       }.to raise_error(ActiveRecord::NotNullViolation)
     end
 
     it "enforces the gias_school_id foreign key" do
       missing_id = GiasSchool.maximum(:id).to_i + 1_000
-      record = described_class.new(course:, provider_school:, site_code: "-")
+      record = described_class.new(course:, provider_school:)
       record.gias_school_id = missing_id
       expect {
         record.save(validate: false)
@@ -154,7 +142,7 @@ describe Course::School do
 
     it "enforces the provider_school_id foreign key" do
       missing_id = Provider::School.maximum(:id).to_i + 1_000
-      record = described_class.new(course:, gias_school:, site_code: "-")
+      record = described_class.new(course:, gias_school:)
       record.provider_school_id = missing_id
       expect {
         record.save(validate: false)
@@ -162,20 +150,19 @@ describe Course::School do
     end
 
     it "deletes the row when the provider_school row is deleted" do
-      course_school = create(:course_school, course:, gias_school:, provider_school:, site_code: provider_school.site_code)
+      course_school = create(:course_school, course:, gias_school:, provider_school:)
 
       provider_school.delete
       expect(described_class.exists?(course_school.id)).to be(false)
     end
 
-    it "enforces DB-level uniqueness on (course_id, gias_school_id, site_code)" do
+    it "enforces DB-level uniqueness on (course_id, provider_school_id)" do
       existing = create(:course_school)
       expect {
         described_class.new(
           course: existing.course,
           gias_school: existing.gias_school,
           provider_school: existing.provider_school,
-          site_code: existing.site_code,
         ).save(validate: false)
       }.to raise_error(ActiveRecord::RecordNotUnique)
     end

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -509,7 +509,6 @@ describe Courses::CreationService do
       it "dual-writes: builds both the legacy site_status and the new Course::School" do
         expect(created_course.sites.map(&:id)).to eq([site.id])
         expect(created_course.schools.map(&:gias_school_id)).to eq([gias_school.id])
-        expect(created_course.schools.first.site_code).to eq("-")
         expect(created_course.schools.first.provider_school).to eq(provider_school)
         expect(created_course.errors).to be_empty
       end
@@ -518,8 +517,8 @@ describe Courses::CreationService do
         created_course.save!
 
         expect(created_course.reload.sites.map(&:id)).to eq([site.id])
-        expect(Course::School.where(course: created_course).pluck(:gias_school_id, :site_code))
-          .to eq([[gias_school.id, "-"]])
+        expect(Course::School.where(course: created_course).pluck(:gias_school_id, :provider_school_id))
+          .to eq([[gias_school.id, provider_school.id]])
       end
     end
 
@@ -539,8 +538,8 @@ describe Courses::CreationService do
       it "persists the Course::School on save" do
         created_course.save!
 
-        expect(Course::School.where(course: created_course).pluck(:gias_school_id, :site_code))
-          .to eq([[gias_school.id, "-"]])
+        expect(Course::School.where(course: created_course).pluck(:gias_school_id, :provider_school_id))
+          .to eq([[gias_school.id, provider_school.id]])
       end
     end
 

--- a/spec/services/data_hub/schools_backfill/executor_spec.rb
+++ b/spec/services/data_hub/schools_backfill/executor_spec.rb
@@ -21,6 +21,7 @@ describe DataHub::SchoolsBackfill::Executor do
           gias_school_id: gias_school.id,
         )
         expect(provider_school.site_code).to eq("A")
+        expect(provider_school.uuid).to eq(site.uuid)
       end
 
       it "does not insert provider_school for a different gias_school" do
@@ -47,19 +48,22 @@ describe DataHub::SchoolsBackfill::Executor do
         create(:site_status, course: course, site: site)
       end
 
-      it "inserts one course_school row with the correct site_code" do
-        pending "insert_course_schools must set the now NOT NULL provider_school_id before the backfill can run again"
+      it "inserts one course_school row linked to the matching provider_school" do
         executor.execute
 
+        provider_school = Provider::School.find_by!(
+          provider_id: provider.id,
+          gias_school_id: gias_school.id,
+          site_code: "B",
+        )
         course_school = Course::School.find_by!(
           course_id: course.id,
           gias_school_id: gias_school.id,
         )
-        expect(course_school.site_code).to eq("B")
+        expect(course_school.provider_school).to eq(provider_school)
       end
 
       it "copies unpublished course_site rows too (parity with source)" do
-        pending "insert_course_schools must set the now NOT NULL provider_school_id before the backfill can run again"
         expect(Course::School.where(course_id: course.id).count).to eq(0)
         executor.execute
         expect(Course::School.where(course_id: course.id).count).to eq(1)
@@ -157,7 +161,6 @@ describe DataHub::SchoolsBackfill::Executor do
       end
 
       it "does not duplicate rows and reports zero inserts on the second run" do
-        pending "insert_course_schools must set the now NOT NULL provider_school_id before the backfill can run again"
         first = executor.execute
         expect(first.short_summary["provider_schools_inserted"]).to eq(1)
         expect(first.short_summary["course_schools_inserted"]).to eq(1)


### PR DESCRIPTION
## Context

We are normalising the new school data model as part of the school remodel work.

course_school.site_code was denormalised because the site code already belongs on provider_school. This PR removes that duplication and moves course school writes towards the new provider_school / course_school model while keeping the legacy site / site_status writes in place for now.

## Changes proposed in this pull request

View the changes, comment or approve

## Guidance to review

Please review this PR by topic rather than file order.

### 1. Schema and normalisation

Review:

- `db/migrate/*remove_site_code_from_course_school*`
- `db/migrate/*add_unique_index_to_provider_school_uuid*`
- `db/schema.rb`
- `app/models/course/school.rb`
- `config/analytics_blocklist.yml`

Check that `course_school.site_code` is fully removed from the new model, and that any remaining site code ownership is through `provider_school`.

### 2. Backfill logic can be skipped as this will not run now and will be disected at a later point, changes here are only to make it work for now.

files:
- `db/data/20260706120000_backfill_provider_school_uuids.rb`
- `app/services/data_hub/schools_backfill/executor.rb`

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
