### PR TITLE
Provider School creation refactor

### DIFF
--- a/app/controllers/publish/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/publish/providers/schools/check_multiple_controller.rb
@@ -57,11 +57,19 @@ module Publish
 
         def create_provider_school(gias_school:)
           if provider_school_identity.after_schools_remodel_cycle?
-            return ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+            create_only_provider_school(gias_school:)
+          else
+            create_provider_school_and_legacy_site(gias_school:)
           end
+        end
 
-          # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
-          # TODO School data remodel removal - remove this legacy Site write when publish creates Provider::School directly.
+        def create_only_provider_school(gias_school:)
+          ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+        end
+
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove this legacy Site write when publish creates Provider::School directly.
+        def create_provider_school_and_legacy_site(gias_school:)
           legacy_site = provider.sites.build(gias_school.school_attributes)
           ::ProviderSchools::LegacySiteCreator.call(site: legacy_site)
           # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective

--- a/app/controllers/publish/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/publish/providers/schools/check_multiple_controller.rb
@@ -10,19 +10,15 @@ module Publish
         def show; end
 
         def update
-          saved_sites = []
+          saved_schools = []
 
           gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
-              provider_school = ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
-
-              site = provider.sites.build(gias_school.school_attributes.merge(code: provider_school.site_code))
-              ::ProviderSchools::LegacySiteCreator.call(site:)
-              saved_sites << site
+              saved_schools << create_provider_school(gias_school:)
             end
           end
 
-          schools_added_message(saved_sites)
+          schools_added_message(saved_schools)
 
           redirect_to publish_provider_recruitment_cycle_schools_path
         end
@@ -57,6 +53,29 @@ module Publish
 
         def provider
           @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
+        end
+
+        def create_provider_school(gias_school:)
+          if provider_school_identity.after_schools_remodel_cycle?
+            return ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+          end
+
+          # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+          # TODO School data remodel removal - remove this legacy Site write when publish creates Provider::School directly.
+          legacy_site = provider.sites.build(gias_school.school_attributes)
+          ::ProviderSchools::LegacySiteCreator.call(site: legacy_site)
+          # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+
+          ::ProviderSchools::Creator.call(
+            provider:,
+            gias_school_id: gias_school.id,
+            site_code: legacy_site.code,
+            uuid: legacy_site.uuid,
+          )
+        end
+
+        def provider_school_identity
+          @provider_school_identity ||= ::ProviderSchools::Identity.new(provider:)
         end
 
         def urn_form

--- a/app/controllers/publish/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/publish/providers/schools/check_multiple_controller.rb
@@ -56,7 +56,8 @@ module Publish
         end
 
         def create_provider_school(gias_school:)
-          if provider_school_identity.after_schools_remodel_cycle?
+          # We stop creating legacy sites in 2027, this if statement takes care of this
+          if provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
             create_only_provider_school(gias_school:)
           else
             create_provider_school_and_legacy_site(gias_school:)
@@ -80,10 +81,6 @@ module Publish
             site_code: legacy_site.code,
             uuid: legacy_site.uuid,
           )
-        end
-
-        def provider_school_identity
-          @provider_school_identity ||= ::ProviderSchools::Identity.new(provider:)
         end
 
         def urn_form

--- a/app/controllers/publish/providers/schools/checks_controller.rb
+++ b/app/controllers/publish/providers/schools/checks_controller.rb
@@ -23,7 +23,8 @@ module Publish
       private
 
         def create_provider_school
-          if provider_school_identity.after_schools_remodel_cycle?
+          # We stop creating legacy sites in 2027, this if statement takes care of this
+          if provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
             create_only_provider_school
           else
             create_provider_school_and_legacy_site
@@ -46,10 +47,6 @@ module Publish
             site_code: @site.code,
             uuid: @site.uuid,
           )
-        end
-
-        def provider_school_identity
-          @provider_school_identity ||= ::ProviderSchools::Identity.new(provider: @provider)
         end
 
         def site

--- a/app/controllers/publish/providers/schools/checks_controller.rb
+++ b/app/controllers/publish/providers/schools/checks_controller.rb
@@ -10,10 +10,8 @@ module Publish
         def show; end
 
         def update
-          provider_school = nil
-
-          ActiveRecord::Base.transaction do
-            provider_school = create_provider_school
+          provider_school = ActiveRecord::Base.transaction do
+            create_provider_school
           end
 
           redirect_to publish_provider_recruitment_cycle_schools_path,
@@ -26,11 +24,19 @@ module Publish
 
         def create_provider_school
           if provider_school_identity.after_schools_remodel_cycle?
-            return ::ProviderSchools::Creator.call(provider: @provider, gias_school_id: school_id)
+            create_only_provider_school
+          else
+            create_provider_school_and_legacy_site
           end
+        end
 
-          # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
-          # TODO School data remodel removal - remove this legacy Site write when publish creates Provider::School directly.
+        def create_only_provider_school
+          ::ProviderSchools::Creator.call(provider: @provider, gias_school_id: school_id)
+        end
+
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove this legacy Site write when publish creates Provider::School directly.
+        def create_provider_school_and_legacy_site
           ::ProviderSchools::LegacySiteCreator.call(site: @site)
           # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 

--- a/app/controllers/publish/providers/schools/checks_controller.rb
+++ b/app/controllers/publish/providers/schools/checks_controller.rb
@@ -10,25 +10,48 @@ module Publish
         def show; end
 
         def update
-          ActiveRecord::Base.transaction do
-            provider_school = ::ProviderSchools::Creator.call(provider: @provider, gias_school_id: school_id)
+          provider_school = nil
 
-            @site.code = provider_school.site_code
-            ::ProviderSchools::LegacySiteCreator.call(site: @site)
+          ActiveRecord::Base.transaction do
+            provider_school = create_provider_school
           end
 
-          redirect_to publish_provider_recruitment_cycle_schools_path, flash: { success_with_body: { title: t(".added"), body: @site.location_name } }
+          redirect_to publish_provider_recruitment_cycle_schools_path,
+                      flash: { success_with_body: { title: t(".added"), body: provider_school.gias_school.name } }
         rescue ActiveRecord::RecordInvalid
           render :show
         end
 
       private
 
-        def site
-          @site ||= begin
-            gias_school = GiasSchool.find(school_id)
-            @provider.sites.school.build(gias_school.school_attributes)
+        def create_provider_school
+          if provider_school_identity.after_schools_remodel_cycle?
+            return ::ProviderSchools::Creator.call(provider: @provider, gias_school_id: school_id)
           end
+
+          # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+          # TODO School data remodel removal - remove this legacy Site write when publish creates Provider::School directly.
+          ::ProviderSchools::LegacySiteCreator.call(site: @site)
+          # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+
+          ::ProviderSchools::Creator.call(
+            provider: @provider,
+            gias_school_id: school_id,
+            site_code: @site.code,
+            uuid: @site.uuid,
+          )
+        end
+
+        def provider_school_identity
+          @provider_school_identity ||= ::ProviderSchools::Identity.new(provider: @provider)
+        end
+
+        def site
+          @site ||= @provider.sites.school.build(gias_school.school_attributes)
+        end
+
+        def gias_school
+          @gias_school ||= GiasSchool.find(school_id)
         end
 
         def school_id

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -52,11 +52,19 @@ module Support
 
         def create_provider_school(gias_school:)
           if provider_school_identity.after_schools_remodel_cycle?
-            return ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+            create_only_provider_school(gias_school:)
+          else
+            create_provider_school_and_legacy_site(gias_school:)
           end
+        end
 
-          # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
-          # TODO School data remodel removal - remove this legacy Site write when support creates Provider::School directly.
+        def create_only_provider_school(gias_school:)
+          ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+        end
+
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove this legacy Site write when support creates Provider::School directly.
+        def create_provider_school_and_legacy_site(gias_school:)
           legacy_site = provider.sites.build(gias_school.school_attributes)
           ::ProviderSchools::LegacySiteCreator.call(site: legacy_site)
           # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -39,26 +39,38 @@ module Support
         end
 
         def save
-          saved_sites = []
+          saved_schools = []
 
           gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
-              # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
-              # TODO School data remodel removal - remove this legacy Site write when support creates Provider::School directly.
-              site = provider.sites.build(gias_school.school_attributes)
-              # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
-              ::ProviderSchools::LegacySiteCreator.call(site:)
-              ::ProviderSchools::Creator.call(
-                provider:,
-                gias_school_id: gias_school.id,
-                site_code: site.code,
-                uuid: site.uuid,
-              )
-              saved_sites << site
+              saved_schools << create_provider_school(gias_school:)
             end
           end
 
-          schools_added_message(saved_sites)
+          schools_added_message(saved_schools)
+        end
+
+        def create_provider_school(gias_school:)
+          if provider_school_identity.after_schools_remodel_cycle?
+            return ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+          end
+
+          # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+          # TODO School data remodel removal - remove this legacy Site write when support creates Provider::School directly.
+          legacy_site = provider.sites.build(gias_school.school_attributes)
+          ::ProviderSchools::LegacySiteCreator.call(site: legacy_site)
+          # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+
+          ::ProviderSchools::Creator.call(
+            provider:,
+            gias_school_id: gias_school.id,
+            site_code: legacy_site.code,
+            uuid: legacy_site.uuid,
+          )
+        end
+
+        def provider_school_identity
+          @provider_school_identity ||= ::ProviderSchools::Identity.new(provider:)
         end
 
         def urn_form

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -43,10 +43,17 @@ module Support
 
           gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
-              provider_school = ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
-
-              site = provider.sites.build(gias_school.school_attributes.merge(code: provider_school.site_code))
+              # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+              # TODO School data remodel removal - remove this legacy Site write when support creates Provider::School directly.
+              site = provider.sites.build(gias_school.school_attributes)
+              # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
               ::ProviderSchools::LegacySiteCreator.call(site:)
+              ::ProviderSchools::Creator.call(
+                provider:,
+                gias_school_id: gias_school.id,
+                site_code: site.code,
+                uuid: site.uuid,
+              )
               saved_sites << site
             end
           end
@@ -66,9 +73,12 @@ module Support
           @gias_schools ||= GiasSchool.where(urn: urn_service[:new_urns])
         end
 
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove when support multiple-school checks no longer preview unsaved Site rows.
         def schools
           @schools ||= gias_schools.map { |gias_school| provider.sites.build(gias_school.school_attributes) }
         end
+        # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
         def unfound_urns
           @unfound_urns = urn_service[:unfound_urns]

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -51,7 +51,8 @@ module Support
         end
 
         def create_provider_school(gias_school:)
-          if provider_school_identity.after_schools_remodel_cycle?
+          # We stop creating legacy sites in 2027, this if statement takes care of this
+          if provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
             create_only_provider_school(gias_school:)
           else
             create_provider_school_and_legacy_site(gias_school:)
@@ -75,10 +76,6 @@ module Support
             site_code: legacy_site.code,
             uuid: legacy_site.uuid,
           )
-        end
-
-        def provider_school_identity
-          @provider_school_identity ||= ::ProviderSchools::Identity.new(provider:)
         end
 
         def urn_form

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -12,19 +12,7 @@ module Support
           saved = false
 
           ActiveRecord::Base.transaction do
-            # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
-            # TODO School data remodel removal - replace this legacy Site-backed form save when support adds Provider::School directly.
-            saved = @school_form.save!
-            # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
-
-            if saved
-              ::ProviderSchools::Creator.call(
-                provider: provider,
-                gias_school_id: params[:school_id],
-                site_code: @site.code,
-                uuid: @site.uuid,
-              )
-            end
+            saved = create_provider_school
           end
 
           if saved
@@ -41,15 +29,49 @@ module Support
           @school_form = SchoolForm.new(provider, site, params: { gias_school_id: params[:school_id] })
         end
 
+        def create_provider_school
+          return create_provider_school_without_legacy_site if provider_school_identity.after_schools_remodel_cycle?
+
+          create_provider_school_with_legacy_site
+        end
+
+        def create_provider_school_with_legacy_site
+          # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+          # TODO School data remodel removal - replace this legacy Site-backed form save when support adds Provider::School directly.
+          saved = @school_form.save!
+          # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+
+          if saved
+            ::ProviderSchools::Creator.call(
+              provider:,
+              gias_school_id: gias_school.id,
+              site_code: @site.code,
+              uuid: @site.uuid,
+            )
+          end
+
+          saved
+        end
+
+        def create_provider_school_without_legacy_site
+          ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+          true
+        end
+
+        def provider_school_identity
+          @provider_school_identity ||= ::ProviderSchools::Identity.new(provider:)
+        end
+
         # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
         # TODO School data remodel removal - remove when support school checks build Provider::School directly.
         def site
-          @site ||= begin
-            gias_school = GiasSchool.find(params[:school_id])
-            @provider.sites.school.build(gias_school.school_attributes)
-          end
+          @site ||= @provider.sites.school.build(gias_school.school_attributes)
         end
         # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+
+        def gias_school
+          @gias_school ||= GiasSchool.find(params[:school_id])
+        end
 
         def provider
           @provider ||= Provider.find(params[:provider_id])

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -30,7 +30,8 @@ module Support
         end
 
         def create_provider_school
-          if provider_school_identity.after_schools_remodel_cycle?
+          # We stop creating legacy sites in 2027, this if statement takes care of this
+          if provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
             create_provider_school_without_legacy_site
           else
             create_provider_school_with_legacy_site
@@ -58,10 +59,6 @@ module Support
         def create_provider_school_without_legacy_site
           ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
           true
-        end
-
-        def provider_school_identity
-          @provider_school_identity ||= ::ProviderSchools::Identity.new(provider:)
         end
 
         # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -30,9 +30,11 @@ module Support
         end
 
         def create_provider_school
-          return create_provider_school_without_legacy_site if provider_school_identity.after_schools_remodel_cycle?
-
-          create_provider_school_with_legacy_site
+          if provider_school_identity.after_schools_remodel_cycle?
+            create_provider_school_without_legacy_site
+          else
+            create_provider_school_with_legacy_site
+          end
         end
 
         def create_provider_school_with_legacy_site

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -12,13 +12,19 @@ module Support
           saved = false
 
           ActiveRecord::Base.transaction do
-            provider_school = ::ProviderSchools::Creator.call(
-              provider: provider,
-              gias_school_id: params[:school_id],
-            )
-
-            @school_form.fields[:code] = provider_school.site_code
+            # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+            # TODO School data remodel removal - replace this legacy Site-backed form save when support adds Provider::School directly.
             saved = @school_form.save!
+            # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+
+            if saved
+              ::ProviderSchools::Creator.call(
+                provider: provider,
+                gias_school_id: params[:school_id],
+                site_code: @site.code,
+                uuid: @site.uuid,
+              )
+            end
           end
 
           if saved
@@ -35,12 +41,15 @@ module Support
           @school_form = SchoolForm.new(provider, site, params: { gias_school_id: params[:school_id] })
         end
 
+        # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+        # TODO School data remodel removal - remove when support school checks build Provider::School directly.
         def site
           @site ||= begin
             gias_school = GiasSchool.find(params[:school_id])
             @provider.sites.school.build(gias_school.school_attributes)
           end
         end
+        # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
         def provider
           @provider ||= Provider.find(params[:provider_id])

--- a/app/services/provider_schools/creator.rb
+++ b/app/services/provider_schools/creator.rb
@@ -33,13 +33,27 @@ module ProviderSchools
   private
 
     def existing_provider_school
-      provider_school_by_uuid || @provider.schools.find_by(gias_school_id: @gias_school_id, site_code: target_site_code)
+      provider_school_by_uuid || provider_school_by_site_code || normal_provider_school
     end
 
     def provider_school_by_uuid
       return if @uuid.blank?
 
       @provider.schools.find_by(uuid: @uuid)
+    end
+
+    def provider_school_by_site_code
+      return if @site_code.blank?
+
+      @provider.schools.find_by(gias_school_id: @gias_school_id, site_code: @site_code)
+    end
+
+    def normal_provider_school
+      return if @site_code.present?
+
+      @provider.schools.where(gias_school_id: @gias_school_id)
+               .where.not(site_code: Provider::School::MAIN_SITE_CODE)
+               .first
     end
 
     def target_site_code

--- a/app/services/provider_schools/creator.rb
+++ b/app/services/provider_schools/creator.rb
@@ -9,19 +9,41 @@ module ProviderSchools
   class Creator
     include ServicePattern
 
-    def initialize(provider:, gias_school_id:)
+    def initialize(provider:, gias_school_id:, site_code: nil, uuid: nil)
       @provider = provider
       @gias_school_id = gias_school_id
+      @site_code = site_code
+      @uuid = uuid
     end
 
     def call
       @provider.with_lock do
-        @provider.schools.find_or_create_by!(gias_school_id: @gias_school_id) do |school|
-          school.site_code = Schools::CodeGenerator.call(provider: @provider)
-        end
+        provider_school = existing_provider_school || @provider.schools.build(
+          gias_school_id: @gias_school_id,
+          site_code: target_site_code,
+        )
+        provider_school.uuid = @uuid if @uuid.present?
+        provider_school.save! if provider_school.new_record? || provider_school.changed?
+        provider_school
       end
     rescue ActiveRecord::RecordNotUnique
-      @provider.schools.find_by!(gias_school_id: @gias_school_id)
+      existing_provider_school || raise
+    end
+
+  private
+
+    def existing_provider_school
+      provider_school_by_uuid || @provider.schools.find_by(gias_school_id: @gias_school_id, site_code: target_site_code)
+    end
+
+    def provider_school_by_uuid
+      return if @uuid.blank?
+
+      @provider.schools.find_by(uuid: @uuid)
+    end
+
+    def target_site_code
+      @target_site_code ||= @site_code.presence || Schools::CodeGenerator.call(provider: @provider)
     end
   end
 end

--- a/app/services/provider_schools/legacy_site_creator.rb
+++ b/app/services/provider_schools/legacy_site_creator.rb
@@ -4,6 +4,7 @@ module ProviderSchools
   # Writes the legacy Site row for a provider-school addition. Kept isolated
   # from ProviderSchools::Creator so the old write path can be removed in a
   # single step once the new model is switched on.
+  # TODO School data remodel removal - delete when provider schools are no longer dual-written to Site.
   class LegacySiteCreator
     include ServicePattern
 

--- a/spec/requests/support/providers/schools/checks_spec.rb
+++ b/spec/requests/support/providers/schools/checks_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Support provider school checks" do
+  include DfESignInUserHelper
+
+  let(:recruitment_cycle) { create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year) }
+  let(:provider) { create(:provider, recruitment_cycle:) }
+  let(:gias_school) { create(:gias_school) }
+  let(:admin) { create(:user, :admin) }
+
+  before do
+    host! URI(Settings.base_url).host
+    login_user(admin)
+  end
+
+  it "rolls back the legacy Site when Provider::School creation fails" do
+    allow(ProviderSchools::Creator).to receive(:call).and_raise(StandardError, "provider school failed")
+
+    expect {
+      expect {
+        put support_recruitment_cycle_provider_schools_check_path(
+          recruitment_cycle.year,
+          provider,
+          school_id: gias_school.id,
+        )
+      }.to raise_error(StandardError, "provider school failed")
+    }.not_to(change { provider.reload.sites.count })
+  end
+end

--- a/spec/services/provider_schools/creator_spec.rb
+++ b/spec/services/provider_schools/creator_spec.rb
@@ -62,6 +62,15 @@ describe ProviderSchools::Creator do
     }.not_to change(Provider::School, :count)
   end
 
+  it "is idempotent when called twice without a site_code" do
+    existing = described_class.call(provider:, gias_school_id: gias_school.id)
+
+    expect {
+      result = described_class.call(provider:, gias_school_id: gias_school.id)
+      expect(result).to eq(existing)
+    }.not_to change(Provider::School, :count)
+  end
+
   it "returns the existing row when one already exists for this provider, gias_school and site_code" do
     existing = create(:provider_school, provider:, gias_school:, site_code: "A")
 
@@ -71,6 +80,14 @@ describe ProviderSchools::Creator do
     expect(result.site_code).to eq("A")
   end
 
+  it "returns the existing normal row when no site_code is supplied" do
+    existing = create(:provider_school, provider:, gias_school:, site_code: "A")
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id)
+
+    expect(result).to eq(existing)
+  end
+
   it "does not reuse a main-site row when creating a normal school row for the same GIAS school" do
     main_site = create(:provider_school, :main_site, provider:, gias_school:)
 
@@ -78,6 +95,16 @@ describe ProviderSchools::Creator do
       result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
       expect(result).not_to eq(main_site)
       expect(result.site_code).to eq("A")
+    }.to change(Provider::School, :count).by(1)
+  end
+
+  it "does not reuse a main-site row when no site_code is supplied" do
+    main_site = create(:provider_school, :main_site, provider:, gias_school:)
+
+    expect {
+      result = described_class.call(provider:, gias_school_id: gias_school.id)
+      expect(result).not_to eq(main_site)
+      expect(result.site_code).not_to eq(Provider::School::MAIN_SITE_CODE)
     }.to change(Provider::School, :count).by(1)
   end
 
@@ -97,6 +124,16 @@ describe ProviderSchools::Creator do
     allow(provider).to receive(:with_lock).and_raise(ActiveRecord::RecordNotUnique)
 
     result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "B")
+
+    expect(result).to eq(existing)
+  end
+
+  it "returns the existing normal row when a RecordNotUnique race fires without a site_code" do
+    existing = create(:provider_school, provider:, gias_school:, site_code: "B")
+
+    allow(provider).to receive(:with_lock).and_raise(ActiveRecord::RecordNotUnique)
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id)
 
     expect(result).to eq(existing)
   end

--- a/spec/services/provider_schools/creator_spec.rb
+++ b/spec/services/provider_schools/creator_spec.rb
@@ -38,6 +38,15 @@ describe ProviderSchools::Creator do
     expect(result.uuid).to eq(uuid)
   end
 
+  it "uses the supplied site_code and uuid together when a legacy site was created first" do
+    uuid = SecureRandom.uuid
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "Z", uuid:)
+
+    expect(result.site_code).to eq("Z")
+    expect(result.uuid).to eq(uuid)
+  end
+
   it "returns the created row" do
     result = described_class.call(provider:, gias_school_id: gias_school.id)
 

--- a/spec/services/provider_schools/creator_spec.rb
+++ b/spec/services/provider_schools/creator_spec.rb
@@ -24,6 +24,20 @@ describe ProviderSchools::Creator do
     expect(result.site_code).to eq("Q")
   end
 
+  it "uses the supplied site_code when a legacy site was created first" do
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "Z")
+
+    expect(result.site_code).to eq("Z")
+  end
+
+  it "uses the supplied uuid when a legacy site was created first" do
+    uuid = SecureRandom.uuid
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id, uuid:)
+
+    expect(result.uuid).to eq(uuid)
+  end
+
   it "returns the created row" do
     result = described_class.call(provider:, gias_school_id: gias_school.id)
 
@@ -31,31 +45,49 @@ describe ProviderSchools::Creator do
     expect(result).to be_persisted
   end
 
-  it "is idempotent when called twice with the same provider and gias_school" do
-    described_class.call(provider:, gias_school_id: gias_school.id)
+  it "is idempotent when called twice with the same provider, gias_school and site_code" do
+    described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
 
     expect {
-      described_class.call(provider:, gias_school_id: gias_school.id)
+      described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
     }.not_to change(Provider::School, :count)
   end
 
-  it "returns the existing row when one already exists for this (provider, gias_school)" do
+  it "returns the existing row when one already exists for this provider, gias_school and site_code" do
     existing = create(:provider_school, provider:, gias_school:, site_code: "A")
 
-    result = described_class.call(provider:, gias_school_id: gias_school.id)
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
 
     expect(result).to eq(existing)
     expect(result.site_code).to eq("A")
   end
 
+  it "does not reuse a main-site row when creating a normal school row for the same GIAS school" do
+    main_site = create(:provider_school, :main_site, provider:, gias_school:)
+
+    expect {
+      result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+      expect(result).not_to eq(main_site)
+      expect(result.site_code).to eq("A")
+    }.to change(Provider::School, :count).by(1)
+  end
+
+  it "updates the uuid on an existing row when one is supplied" do
+    existing = create(:provider_school, provider:, gias_school:, site_code: "A", uuid: SecureRandom.uuid)
+    uuid = SecureRandom.uuid
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A", uuid:)
+
+    expect(result).to eq(existing)
+    expect(result.uuid).to eq(uuid)
+  end
+
   it "returns the existing row when a RecordNotUnique race fires" do
     existing = create(:provider_school, provider:, gias_school:, site_code: "B")
 
-    schools_proxy = provider.schools
-    allow(provider).to receive(:schools).and_return(schools_proxy)
-    allow(schools_proxy).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
+    allow(provider).to receive(:with_lock).and_raise(ActiveRecord::RecordNotUnique)
 
-    result = described_class.call(provider:, gias_school_id: gias_school.id)
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "B")
 
     expect(result).to eq(existing)
   end

--- a/spec/system/publish/providers/schools/add_school_spec.rb
+++ b/spec/system/publish/providers/schools/add_school_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
     and_the_provider_school_row_is_created
   end
 
+  scenario "with new school after the schools remodel cycle" do
+    given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
+    when_i_visit_the_schools_page
+    when_i_click_add_a_school
+    then_i_am_on_the_school_search_page
+
+    when_i_search_with_an_partial_query
+    when_i_choose_the_school_i_want_to_add
+    when_i_click_add_school
+
+    then_i_see_a_confirmation_message
+    and_only_the_provider_school_row_is_created
+  end
+
   scenario "attempting to add a school with duplicate URN" do
     given_the_provider_already_has_a_school_with_the_same_urn
 
@@ -62,6 +76,12 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
     })
   end
 
+  def given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
+    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
+    future_provider = create(:provider, recruitment_cycle:)
+    given_i_am_authenticated(user: create(:user, providers: [future_provider]))
+  end
+
   def given_i_see_the_schools_guidance_text
     expect(page).to have_text("We automatically upload all schools you are working with. These are schools that are on Register trainee teachers.", normalize_ws: true)
     expect(page).to have_link("Register trainee teachers", href: "https://www.register-trainee-teachers.service.gov.uk/")
@@ -81,7 +101,7 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
   end
 
   def then_i_am_on_the_school_search_page
-    expect(page).to have_current_path(search_publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code))
+    expect(page).to have_current_path(search_publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_code: provider.provider_code))
   end
 
   def when_i_search_with_an_empty_query
@@ -178,12 +198,22 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
 
   def and_the_provider_school_row_is_created
     added_site = provider.sites.find_by(urn: @gias_school.urn)
-    provider_school = provider.schools.find_by(gias_school_id: @gias_school.id)
+    provider_school = provider.schools.find_by(gias_school_id: @gias_school.id, site_code: added_site.code)
     expect(provider_school).to be_present
     expect(provider_school.site_code).to eq(added_site.code)
+    expect(provider_school.uuid).to eq(added_site.uuid)
   end
 
   def and_no_provider_school_row_is_created
     expect(provider.schools.where(gias_school_id: @gias_school.id)).to be_empty
+  end
+
+  def and_only_the_provider_school_row_is_created
+    expect(provider.sites.find_by(urn: @gias_school.urn)).to be_nil
+
+    provider_school = provider.schools.find_by(gias_school_id: @gias_school.id)
+    expect(provider_school).to be_present
+    expect(provider_school.site_code).to be_present
+    expect(provider_school.uuid).to be_present
   end
 end

--- a/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe "Multiple schools" do
     and_i_see_the_success_message
   end
 
+  scenario "when adding schools after the schools remodel cycle" do
+    given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
+
+    when_i_visit_the_multiple_schools_new_page
+    and_i_fill_in_the_urns_with_a_mixture_of_new_lines_and_comma
+    and_i_click_continue
+    when_i_click_add_schools
+
+    then_i_am_redirected_to_the_school_index
+    and_only_provider_school_rows_are_created_for_each
+    and_i_see_the_success_message
+  end
+
   scenario "when there are over 50 urns" do
     when_i_visit_the_multiple_schools_new_page
     and_i_enter_51_urns
@@ -113,6 +126,12 @@ RSpec.describe "Multiple schools" do
     @gias_schools = create_list(:gias_school, 3)
   end
 
+  def given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
+    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
+    future_provider = create(:provider, recruitment_cycle:)
+    given_i_am_authenticated(user: create(:user, providers: [future_provider]))
+  end
+
   def and_i_fill_in_the_urns_with_a_mixture_of_new_lines_and_comma
     urns = @gias_schools.map(&:urn)
     input = "  #{urns[0]},#{urns[1]}\n\n#{urns[2]}"
@@ -120,7 +139,7 @@ RSpec.describe "Multiple schools" do
   end
 
   def then_i_am_redirected_to_the_school_index
-    expect(page).to have_current_path(publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code))
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_code: provider.provider_code))
   end
 
   def and_i_see_that_all_schools_are_created
@@ -132,9 +151,21 @@ RSpec.describe "Multiple schools" do
   def and_provider_school_rows_are_created_for_each
     @gias_schools.each do |gias_school|
       site = provider.sites.find_by(urn: gias_school.urn)
-      provider_school = provider.schools.find_by(gias_school_id: gias_school.id)
+      provider_school = provider.schools.find_by(gias_school_id: gias_school.id, site_code: site.code)
       expect(provider_school).to be_present
       expect(provider_school.site_code).to eq(site.code)
+      expect(provider_school.uuid).to eq(site.uuid)
+    end
+  end
+
+  def and_only_provider_school_rows_are_created_for_each
+    @gias_schools.each do |gias_school|
+      expect(provider.sites.find_by(urn: gias_school.urn)).to be_nil
+
+      provider_school = provider.schools.find_by(gias_school_id: gias_school.id)
+      expect(provider_school).to be_present
+      expect(provider_school.site_code).to be_present
+      expect(provider_school.uuid).to be_present
     end
   end
 
@@ -203,16 +234,16 @@ RSpec.describe "Multiple schools" do
   end
 
   def and_i_am_redirected_to_the_multiple_school_check_page
-    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
+    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_multiple_check_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_code: provider.provider_code)
     expect(page).to have_text "Check your answers"
   end
 
   def when_i_visit_the_multiple_schools_new_page
-    visit new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
+    visit new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_code: provider.provider_code)
   end
 
   def when_i_visit_a_provider_schools_page
-    visit publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
+    visit publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_code: provider.provider_code)
   end
 
   def and_i_have_one_existing_school
@@ -278,11 +309,11 @@ RSpec.describe "Multiple schools" do
   end
 
   def when_i_am_redirected_to_the_schools_page
-    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
+    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_code: provider.provider_code)
   end
 
   def and_i_am_on_the_enter_urns_page
-    expect(page).to have_current_path new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
+    expect(page).to have_current_path new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_code: provider.provider_code)
   end
 
   alias_method :and_i_click_back, :when_i_click_back

--- a/spec/system/support/providers/schools/add_school_to_provider_spec.rb
+++ b/spec/system/support/providers/schools/add_school_to_provider_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe "Adding school to provider as an admin" do
       and_the_provider_school_row_is_created
     end
 
+    scenario "with new school after the schools remodel cycle" do
+      and_there_is_a_provider_after_the_schools_remodel_cycle
+
+      given_i_visit_the_support_provider_schools_index_page
+      and_i_click_add_school
+      when_i_search_with_an_partial_query
+      when_i_choose_the_school_i_want_to_add
+      when_i_click_add_school
+
+      then_i_see_a_confirmation_message
+      and_only_the_provider_school_row_is_created
+    end
+
     scenario "i can select a school using the autocomplete", :js do
       given_i_visit_the_support_provider_schools_index_page
       and_i_click_add_school
@@ -94,6 +107,11 @@ RSpec.describe "Adding school to provider as an admin" do
     @provider = create(:provider, provider_name: "School of Cats", provider_code: "V01")
   end
 
+  def and_there_is_a_provider_after_the_schools_remodel_cycle
+    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
+    @provider = create(:provider, provider_name: "School of Cats", provider_code: "V02", recruitment_cycle:)
+  end
+
   def and_there_is_a_gias_school
     @gias_school = create(:gias_school, {
       urn: "123456",
@@ -105,11 +123,11 @@ RSpec.describe "Adding school to provider as an admin" do
   end
 
   def given_i_visit_the_support_provider_schools_index_page
-    support_provider_schools_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id)
+    support_provider_schools_index_page.load(recruitment_cycle_year: @provider.recruitment_cycle_year, provider_id: @provider.id)
   end
 
   def then_i_am_on_the_school_search_page
-    expect(page).to have_current_path(search_support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id))
+    expect(page).to have_current_path(search_support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: @provider.recruitment_cycle_year, provider_id: @provider.id))
   end
 
   def when_i_search_with_an_empty_query
@@ -208,5 +226,14 @@ RSpec.describe "Adding school to provider as an admin" do
     expect(provider_school).to be_present
     expect(provider_school.site_code).to eq(added_site.code)
     expect(provider_school.uuid).to eq(added_site.uuid)
+  end
+
+  def and_only_the_provider_school_row_is_created
+    expect(@provider.sites.find_by(urn: @gias_school.urn)).to be_nil
+
+    provider_school = @provider.schools.find_by(gias_school_id: @gias_school.id)
+    expect(provider_school).to be_present
+    expect(provider_school.site_code).to be_present
+    expect(provider_school.uuid).to be_present
   end
 end

--- a/spec/system/support/providers/schools/add_school_to_provider_spec.rb
+++ b/spec/system/support/providers/schools/add_school_to_provider_spec.rb
@@ -204,8 +204,9 @@ RSpec.describe "Adding school to provider as an admin" do
 
   def and_the_provider_school_row_is_created
     added_site = @provider.sites.find_by(urn: @gias_school.urn)
-    provider_school = @provider.schools.find_by(gias_school_id: @gias_school.id)
+    provider_school = @provider.schools.find_by(gias_school_id: @gias_school.id, site_code: added_site.code)
     expect(provider_school).to be_present
     expect(provider_school.site_code).to eq(added_site.code)
+    expect(provider_school.uuid).to eq(added_site.uuid)
   end
 end

--- a/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe "Multiple schools" do
     and_i_see_the_success_message
   end
 
+  scenario "when adding schools after the schools remodel cycle" do
+    given_the_provider_is_after_the_schools_remodel_cycle
+
+    when_i_visit_the_multiple_schools_new_page
+    and_i_fill_in_the_urns_with_a_mixture_of_new_lines_and_comma
+    and_i_click_continue
+    when_i_click_add_schools
+
+    then_i_am_redirected_to_the_school_index
+    and_only_provider_school_rows_are_created_for_each
+    and_i_see_the_success_message
+  end
+
   scenario "when there are over 50 urns" do
     when_i_visit_the_multiple_schools_new_page
     and_i_enter_51_urns
@@ -104,6 +117,11 @@ RSpec.describe "Multiple schools" do
     @gias_schools = create_list(:gias_school, 3)
   end
 
+  def given_the_provider_is_after_the_schools_remodel_cycle
+    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
+    @provider = create(:provider, recruitment_cycle:)
+  end
+
   def and_i_fill_in_the_urns_with_a_mixture_of_new_lines_and_comma
     urns = @gias_schools.map(&:urn)
     input = "  #{urns[0]},#{urns[1]}\n\n#{urns[2]}"
@@ -111,7 +129,7 @@ RSpec.describe "Multiple schools" do
   end
 
   def then_i_am_redirected_to_the_school_index
-    expect(page).to have_current_path(support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id))
+    expect(page).to have_current_path(support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_id: provider.id))
   end
 
   def and_i_see_that_all_schools_are_created
@@ -127,6 +145,17 @@ RSpec.describe "Multiple schools" do
       expect(provider_school).to be_present
       expect(provider_school.site_code).to eq(site.code)
       expect(provider_school.uuid).to eq(site.uuid)
+    end
+  end
+
+  def and_only_provider_school_rows_are_created_for_each
+    @gias_schools.each do |gias_school|
+      expect(@provider.sites.find_by(urn: gias_school.urn)).to be_nil
+
+      provider_school = @provider.schools.find_by(gias_school_id: gias_school.id)
+      expect(provider_school).to be_present
+      expect(provider_school.site_code).to be_present
+      expect(provider_school.uuid).to be_present
     end
   end
 
@@ -211,16 +240,16 @@ RSpec.describe "Multiple schools" do
   end
 
   def and_i_am_redirected_to_the_multiple_school_check_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
+    expect(page).to have_current_path support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_id: provider.id)
     expect(page).to have_text "Check your answers"
   end
 
   def when_i_visit_the_multiple_schools_new_page
-    visit new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
+    visit new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_id: provider.id)
   end
 
   def when_i_visit_a_provider_schools_page
-    visit support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
+    visit support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_id: provider.id)
   end
 
   def and_i_have_one_existing_school
@@ -290,11 +319,11 @@ RSpec.describe "Multiple schools" do
   end
 
   def when_i_am_redirected_to_the_schools_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
+    expect(page).to have_current_path support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_id: provider.id)
   end
 
   def and_i_am_on_the_enter_urns_page
-    expect(page).to have_current_path new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
+    expect(page).to have_current_path new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: provider.recruitment_cycle_year, provider_id: provider.id)
   end
 
   alias_method :and_i_click_add_schools, :when_i_click_add_schools

--- a/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
@@ -123,9 +123,10 @@ RSpec.describe "Multiple schools" do
   def and_provider_school_rows_are_created_for_each
     @gias_schools.each do |gias_school|
       site = @provider.sites.find_by(urn: gias_school.urn)
-      provider_school = @provider.schools.find_by(gias_school_id: gias_school.id)
+      provider_school = @provider.schools.find_by(gias_school_id: gias_school.id, site_code: site.code)
       expect(provider_school).to be_present
       expect(provider_school.site_code).to eq(site.code)
+      expect(provider_school.uuid).to eq(site.uuid)
     end
   end
 


### PR DESCRIPTION
## Context

We are moving school relationships from the legacy `Site` table to the new `Provider::School` / `Course::School` data model.

During the transition period, provider schools still need to be dual-written to both models. For the 2026 recruitment cycle and earlier, we still create legacy `Site` records for schools, but the matching `Provider::School` must use the same `site_code` and `uuid` as the legacy `Site`. This prevents identity drift between the old and new school records while both models are in use.

From the 2027 recruitment cycle onwards, legacy school `Site` records should no longer be created when adding schools to providers. At that point, adding provider schools should write only to `Provider::School`.

## Changes proposed in this pull request

- Updates support and publish school-add flows so current-cycle provider school creation writes the legacy `Site` first, then creates the matching `Provider::School` using the legacy site's `site_code` and `uuid`.
- Applies the same behaviour to:
  - support single-school add
  - support multiple-school add
  - publish single-school add
  - publish multiple-school add
- Stops creating legacy school `Site` records after `Settings.schools_remodel_cycle_year`.
- Updates `ProviderSchools::Creator` to accept optional `site_code` and `uuid` values from the legacy `Site`.
- Fixes `ProviderSchools::Creator` idempotency for the post-remodel path where callers only pass `provider` and `gias_school_id`.
- Ensures the creator does not accidentally reuse a provider main-site row when creating a normal provider school for the same GIAS school.
- Keeps `RecordNotUnique` recovery working for both explicit `site_code` calls and post-remodel calls without a supplied `site_code`.
- Adds rollback coverage to prove the legacy `Site` is not left behind if `Provider::School` creation fails during the 2026 dual-write flow.
- Adds system coverage for current-cycle UUID parity and post-remodel provider-school-only creation across support and publish add-school flows.

## Guidance to review

- Review the four controller paths that add schools to providers and check that the cycle split is correct:
  - `app/controllers/support/providers/schools/checks_controller.rb`
  - `app/controllers/support/providers/schools/check_multiple_controller.rb`
  - `app/controllers/publish/providers/schools/checks_controller.rb`
  - `app/controllers/publish/providers/schools/check_multiple_controller.rb`
- For 2026 and earlier, confirm the legacy `Site` is created first and its `site_code`/`uuid` are passed into `ProviderSchools::Creator`.
- For 2027 onwards, confirm only `Provider::School` is created.
- Review `ProviderSchools::Creator` idempotency carefully, especially the no-`site_code` path used after the remodel cycle.
- Rollover and school deletion are intentionally out of scope for this PR.
- Useful specs to run:
  - `bundle exec rspec spec/services/provider_schools/creator_spec.rb`
  - `bundle exec rspec spec/requests/support/providers/schools/checks_spec.rb`
  - `bundle exec rspec spec/system/support/providers/schools/add_school_to_provider_spec.rb spec/system/support/providers/schools/creating_multiple_schools_spec.rb`
  - `bundle exec rspec spec/system/publish/providers/schools/add_school_spec.rb spec/system/publish/providers/schools/creating_multiple_schools_spec.rb`

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
