### PR TITLE
Add Rollover soon notification banner for Publish

### DIFF
--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -5,6 +5,7 @@ class FeatureFlags
     [
       [:maintenance_mode, "Puts Find into maintenance mode", "Find and Publish team"],
       [:maintenance_banner, "Displays the maintenance mode banner", "Find and Publish team"],
+      [:publish_rollover_soon_banner, "Displays the rollover soon banner in Publish", "Find and Publish team"],
       [:bursaries_and_scholarships_announced, "Display scholarship and bursary information", "Find and Publish team"],
       [:candidate_accounts, "Enable candidate accounts feature", "Find and Publish team"],
       [:email_alerts, "Enable email alerts for candidates", "Find and Publish team"],

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,6 +59,7 @@
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= render(FlashBanner.new(flash:)) %>
         <%= render Find::MaintenanceBannerComponent.new %>
+        <%= render "publish/rollover_notification_banner" %>
 
         <%= yield %>
       </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,9 @@
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= render(FlashBanner.new(flash:)) %>
         <%= render Find::MaintenanceBannerComponent.new %>
-        <%= render "publish/rollover_notification_banner" %>
+        <% if(FeatureFlag.active?(:publish_rollover_soon_banner)) %>
+          <%= render "publish/rollover_notification_banner" %>
+        <% end %>
 
         <%= yield %>
       </main>

--- a/app/views/publish/_rollover_notification_banner.html.erb
+++ b/app/views/publish/_rollover_notification_banner.html.erb
@@ -1,0 +1,6 @@
+<%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+  <% notification_banner.with_heading(
+    text: "You can start rolling over your courses from mid August",
+  ) %>
+  <p class="govuk-body">In mid August, your courses will be ready to be rolled over to the 2026 to 2027 recruitment cycle. We will email you when you need to sign in to check and publish, or delete, your courses.</p>
+<% end %>

--- a/spec/system/publish/rollover_soon_banner_spec.rb
+++ b/spec/system/publish/rollover_soon_banner_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Display rollover soon banner in publish" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario "when rollover soon banner feature flag is enabled the banner is visible" do
+    and_the_rollover_soon_banner_feature_flag_is_enabled
+    when_i_visit_the_courses_page
+    then_i_see_the_rollover_soon_banner
+  end
+
+  scenario "when rollover soon banner feature flag is disabled the banner is not visible" do
+    and_the_rollover_soon_banner_feature_flag_is_disabled
+    when_i_visit_the_courses_page
+    then_i_do_not_see_the_rollover_soon_banner
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(
+      user: create(:user, providers: [create(:provider, sites: [build(:site)])]),
+    )
+  end
+
+  def when_i_visit_the_courses_page
+    publish_provider_courses_index_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year,
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def and_the_rollover_soon_banner_feature_flag_is_enabled
+    FeatureFlag.activate(:publish_rollover_soon_banner)
+  end
+
+  def and_the_rollover_soon_banner_feature_flag_is_disabled
+    FeatureFlag.deactivate(:publish_rollover_soon_banner)
+  end
+
+  def then_i_see_the_rollover_soon_banner
+    expect(page).to have_content("your courses will be ready to be rolled over to the")
+    expect(page).to have_content("We will email you when you need to sign in to check and publish, or delete, your courses.")
+  end
+
+  def then_i_do_not_see_the_rollover_soon_banner
+    expect(page).not_to have_content("your courses will be ready to be rolled over to the")
+    expect(page).not_to have_content("We will email you when you need to sign in to check and publish, or delete, your courses.")
+  end
+end


### PR DESCRIPTION
## Context

We need to communicate to Provider users that rollover date period has been decided and to give them notice.

<img width="1209" height="856" alt="image" src="https://github.com/user-attachments/assets/1b7f51e9-040d-4f83-a87a-da0fbc63c0e7" />


## Changes proposed in this pull request

Add a banner that is only visible in Publish interface.
It can be enabled / disabled via a feature flag
The content must be updated via a code change

## Guidance to review

I've used a rails partial instead of  a view component for simplicity

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
