### PR TITLE
Fix ruby version in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby            3.4.8
+ruby            3.4.10
 kubectl         1.32.2
 yarn            1.22.22
 nodejs          24.13.0


### PR DESCRIPTION
## Context

We updated ruby version everywhere except .tool-versions

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
