### PR TITLE
School remodel Find - Courses query

### DIFF
--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -350,10 +350,7 @@ module Courses
     # the legacy path's minimum_distance_to_search_location contract.
     def schools_location_scope(latitude:, longitude:, radius_in_meters:)
       @scope
-        .joins(<<~SQL)
-          INNER JOIN course_school ON course_school.course_id = course.id
-          INNER JOIN gias_school   ON gias_school.id = course_school.gias_school_id
-        SQL
+        .joins(schools: :gias_school)
         .where.not(gias_school: { latitude: nil })
         .where.not(gias_school: { longitude: nil })
         .where(

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -354,7 +354,8 @@ module Courses
           INNER JOIN course_school ON course_school.course_id = course.id
           INNER JOIN gias_school   ON gias_school.id = course_school.gias_school_id
         SQL
-        .where("gias_school.latitude IS NOT NULL AND gias_school.longitude IS NOT NULL")
+        .where.not(gias_school: { latitude: nil })
+        .where.not(gias_school: { longitude: nil })
         .where(
           <<~SQL.squish, longitude, latitude, radius_in_meters
             ST_DistanceSphere(

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -296,10 +296,16 @@ module Courses
         radius: radius_in_miles,
       }
 
-      @scope = sites_location_scope(latitude:, longitude:, radius_in_meters:)
+      @scope =
+        if FeatureFlag.active?(:course_publishing_uses_new_school_model)
+          schools_location_scope(latitude:, longitude:, radius_in_meters:)
+        else
+          sites_location_scope(latitude:, longitude:, radius_in_meters:)
+        end
     end
 
-    # Location filter over the course_site -> site model.
+    # Location filter over the legacy course_site -> site model, used while the
+    # :course_publishing_uses_new_school_model flag is off.
     def sites_location_scope(latitude:, longitude:, radius_in_meters:)
       @scope
         .joins(<<~SQL)
@@ -327,6 +333,44 @@ module Courses
                 provider.provider_name,
                 MIN(ST_DistanceSphere(
                   ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
+                  ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
+                ) / 1609.344) AS minimum_distance_to_search_location
+              SQL
+              longitude,
+              latitude,
+            ],
+          ),
+        )
+        .group(:id, "provider.provider_name")
+    end
+
+    # Location filter over the canonical course_school -> gias_school model, used
+    # while the :course_publishing_uses_new_school_model flag is on. Distance is
+    # measured from each school's coordinate once and exposed in miles, matching
+    # the legacy path's minimum_distance_to_search_location contract.
+    def schools_location_scope(latitude:, longitude:, radius_in_meters:)
+      @scope
+        .joins(<<~SQL)
+          INNER JOIN course_school ON course_school.course_id = course.id
+          INNER JOIN gias_school   ON gias_school.id = course_school.gias_school_id
+        SQL
+        .where("gias_school.latitude IS NOT NULL AND gias_school.longitude IS NOT NULL")
+        .where(
+          <<~SQL.squish, longitude, latitude, radius_in_meters
+            ST_DistanceSphere(
+              ST_SetSRID(ST_MakePoint(gias_school.longitude::float, gias_school.latitude::float), 4326),
+              ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
+            ) <= ?
+          SQL
+        )
+        .select(
+          Course.sanitize_sql_array(
+            [
+              <<~SQL.squish,
+                course.*,
+                provider.provider_name,
+                MIN(ST_DistanceSphere(
+                  ST_SetSRID(ST_MakePoint(gias_school.longitude::float, gias_school.latitude::float), 4326),
                   ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
                 ) / 1609.344) AS minimum_distance_to_search_location
               SQL

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -296,7 +296,12 @@ module Courses
         radius: radius_in_miles,
       }
 
-      @scope = @scope
+      @scope = sites_location_scope(latitude:, longitude:, radius_in_meters:)
+    end
+
+    # Location filter over the course_site -> site model.
+    def sites_location_scope(latitude:, longitude:, radius_in_meters:)
+      @scope
         .joins(<<~SQL)
           INNER JOIN course_site site_statuses ON (
             site_statuses.course_id = course.id

--- a/app/services/saved_courses/query.rb
+++ b/app/services/saved_courses/query.rb
@@ -35,6 +35,12 @@ module SavedCourses
 
       @applied_scopes[:location] = { latitude:, longitude:, radius: radius_in_miles }
 
+      sites_location_scope(latitude:, longitude:)
+    end
+
+    # Distance annotation over the course_site -> site model. Saved courses are
+    # annotated with distance but not filtered by radius.
+    def sites_location_scope(latitude:, longitude:)
       @scope
         .joins(<<~SQL)
           INNER JOIN course_site ON (

--- a/app/services/saved_courses/query.rb
+++ b/app/services/saved_courses/query.rb
@@ -84,7 +84,8 @@ module SavedCourses
           INNER JOIN course_school ON course_school.course_id = course.id
           INNER JOIN gias_school   ON gias_school.id = course_school.gias_school_id
         SQL
-        .where("gias_school.latitude IS NOT NULL AND gias_school.longitude IS NOT NULL")
+        .where.not(gias_school: { latitude: nil })
+        .where.not(gias_school: { longitude: nil })
         .select(
           Course.sanitize_sql_array(
             [

--- a/app/services/saved_courses/query.rb
+++ b/app/services/saved_courses/query.rb
@@ -35,10 +35,15 @@ module SavedCourses
 
       @applied_scopes[:location] = { latitude:, longitude:, radius: radius_in_miles }
 
-      sites_location_scope(latitude:, longitude:)
+      if FeatureFlag.active?(:course_publishing_uses_new_school_model)
+        schools_location_scope(latitude:, longitude:)
+      else
+        sites_location_scope(latitude:, longitude:)
+      end
     end
 
-    # Distance annotation over the course_site -> site model. Saved courses are
+    # Distance annotation over the legacy course_site -> site model, used while
+    # the :course_publishing_uses_new_school_model flag is off. Saved courses are
     # annotated with distance but not filtered by radius.
     def sites_location_scope(latitude:, longitude:)
       @scope
@@ -58,6 +63,35 @@ module SavedCourses
                 saved_course.*,
                 MIN(ST_DistanceSphere(
                   ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
+                  ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
+                ) / 1609.344) AS minimum_distance_to_search_location
+              SQL
+              longitude,
+              latitude,
+            ],
+          ),
+        )
+        .group("saved_course.id, provider.provider_name")
+    end
+
+    # Distance annotation over the canonical course_school -> gias_school model,
+    # used while the :course_publishing_uses_new_school_model flag is on. As with
+    # the legacy path, saved courses are annotated with distance but not filtered
+    # by radius.
+    def schools_location_scope(latitude:, longitude:)
+      @scope
+        .joins(<<~SQL)
+          INNER JOIN course_school ON course_school.course_id = course.id
+          INNER JOIN gias_school   ON gias_school.id = course_school.gias_school_id
+        SQL
+        .where("gias_school.latitude IS NOT NULL AND gias_school.longitude IS NOT NULL")
+        .select(
+          Course.sanitize_sql_array(
+            [
+              <<~SQL.squish,
+                saved_course.*,
+                MIN(ST_DistanceSphere(
+                  ST_SetSRID(ST_MakePoint(gias_school.longitude::float, gias_school.latitude::float), 4326),
                   ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
                 ) / 1609.344) AS minimum_distance_to_search_location
               SQL

--- a/app/services/saved_courses/query.rb
+++ b/app/services/saved_courses/query.rb
@@ -80,10 +80,7 @@ module SavedCourses
     # by radius.
     def schools_location_scope(latitude:, longitude:)
       @scope
-        .joins(<<~SQL)
-          INNER JOIN course_school ON course_school.course_id = course.id
-          INNER JOIN gias_school   ON gias_school.id = course_school.gias_school_id
-        SQL
+        .joins(course: { schools: :gias_school })
         .where.not(gias_school: { latitude: nil })
         .where.not(gias_school: { longitude: nil })
         .select(

--- a/spec/services/courses/query/location_new_school_model_spec.rb
+++ b/spec/services/courses/query/location_new_school_model_spec.rb
@@ -1,0 +1,288 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "query_helper"
+
+# Location search over the canonical course_school -> gias_school model, gated by
+# the :course_publishing_uses_new_school_model flag. Distances are computed from
+# gias_school coordinates instead of course_site -> site, so the same coordinates
+# must produce the same minimum_distance_to_search_location as the legacy path
+# (the values below are shared with location_params_spec.rb on purpose).
+RSpec.describe Courses::Query do # rubocop:disable RSpec/SpecFilePathFormat
+  include QueryHelper
+
+  context "when :course_publishing_uses_new_school_model is active" do
+    before { FeatureFlag.activate(:course_publishing_uses_new_school_model) }
+    after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
+
+    let(:london) { build(:location, :london) }
+    let!(:course_london_result) { course_at(london, name: "Mathematics (London)", distance: 0.0) }
+    let!(:course_canary_wharf_result) { course_at(canary_wharf, name: "Science (Canary Wharf)", distance: 4.46) }
+    let!(:course_lewisham_result) { course_at(lewisham, name: "Science (Lewisham)", distance: 6.07) }
+    let!(:course_romford_result) { course_at(romford, name: "Science (Romford)", distance: 14.36) }
+    let!(:course_cambridge_result) { course_at(cambridge, name: "Chemistry (Cambridge)", distance: 49.38) }
+    let(:canary_wharf) { build(:location, :canary_wharf) }
+    let(:lewisham) { build(:location, :lewisham) }
+    let(:romford) { build(:location, :romford) }
+    let(:cambridge) { build(:location, :cambridge) }
+
+    # Builds a published course taught at a single gias_school at `location`,
+    # wrapped with its expected distance for match_collection assertions.
+    def course_at(location, name:, distance:, provider: nil)
+      course = create(:course, :published, name:, provider: provider || create(:provider))
+      create(
+        :course_school,
+        course:,
+        gias_school: create(:gias_school, latitude: location.latitude, longitude: location.longitude),
+      )
+      test_search_result_wrapper_klass.new(course, minimum_distance_to_search_location: distance)
+    end
+
+    it_behaves_like "location search results", radius: 10 do
+      let(:expected) { [course_london_result, course_canary_wharf_result, course_lewisham_result] }
+    end
+
+    it_behaves_like "location search results", radius: 20 do
+      let(:expected) do
+        [course_london_result, course_canary_wharf_result, course_lewisham_result, course_romford_result]
+      end
+    end
+
+    it_behaves_like "location search results", radius: 50 do
+      let(:expected) do
+        [
+          course_london_result,
+          course_canary_wharf_result,
+          course_lewisham_result,
+          course_romford_result,
+          course_cambridge_result,
+        ]
+      end
+    end
+
+    it "defaults to ordering by distance when latitude and longitude are given" do
+      results = described_class.call(
+        params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+      )
+
+      expect(results).to match_collection(
+        [course_london_result, course_canary_wharf_result, course_lewisham_result],
+        attribute_names: %w[name minimum_distance_to_search_location],
+      )
+    end
+
+    context "when a course is taught only at a non-school site (no course_school edge)" do
+      # The accepted behaviour change: with course_school as the sole source, a
+      # published course whose only location is a non-GIAS site drops out of
+      # location search (it still appears in non-location search).
+      let!(:non_school_course) do
+        create(
+          :course,
+          :published,
+          name: "Campus Only",
+          site_statuses: [
+            create(
+              :site_status,
+              :findable,
+              site: create(:site, latitude: london.latitude, longitude: london.longitude),
+            ),
+          ],
+        )
+      end
+
+      it "is excluded from location search" do
+        results = described_class.call(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+        )
+
+        expect(results.map(&:name)).not_to include("Campus Only")
+      end
+    end
+
+    context "when a gias_school is shared across providers" do
+      let(:shared_school) do
+        create(:gias_school, latitude: london.latitude, longitude: london.longitude)
+      end
+      let(:apple_provider) { create(:provider, provider_name: "Apple University") }
+      let(:zebra_provider) { create(:provider, provider_name: "Zebra University") }
+
+      before do
+        [apple_provider, zebra_provider].each do |provider|
+          course = create(:course, :published, provider:)
+          create(:course_school, course:, gias_school: shared_school)
+        end
+      end
+
+      it "returns each course once, deduplicated by the shared school" do
+        results = described_class.call(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+        ).to_a
+
+        shared = results.select { |c| [apple_provider.id, zebra_provider.id].include?(c.provider_id) }
+        expect(shared.map { |c| c.provider.provider_name }).to eq(["Apple University", "Zebra University"])
+        expect(shared.map(&:minimum_distance_to_search_location).map { |d| d.round(2) }).to eq([0.0, 0.0])
+      end
+    end
+
+    context "when a course is taught at several schools" do
+      let(:oxford) { build(:location, :oxford) }
+
+      # Cambridge (~49mi) and Oxford (~51mi) are outside a 10mi radius; Canary
+      # Wharf (~4.46mi) is inside. The nearest in-radius school should win.
+      let!(:multi_school_course) do
+        course = create(:course, :published, name: "Multi School", provider: create(:provider))
+        [cambridge, canary_wharf, oxford].each do |location|
+          create(
+            :course_school,
+            course:,
+            gias_school: create(:gias_school, latitude: location.latitude, longitude: location.longitude),
+          )
+        end
+        course
+      end
+
+      it "returns the course once, at the distance of its nearest school" do
+        results = described_class.call(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+        ).to_a
+
+        rows = results.select { |c| c.id == multi_school_course.id }
+        expect(rows.size).to eq(1)
+        expect(rows.first.minimum_distance_to_search_location.round(2)).to eq(4.46)
+      end
+    end
+
+    context "when all of a course's schools are outside the radius" do
+      let(:oxford) { build(:location, :oxford) }
+
+      let!(:far_course) do
+        course = create(:course, :published, name: "Far Away", provider: create(:provider))
+        [cambridge, oxford].each do |location|
+          create(
+            :course_school,
+            course:,
+            gias_school: create(:gias_school, latitude: location.latitude, longitude: location.longitude),
+          )
+        end
+        course
+      end
+
+      it "is excluded" do
+        results = described_class.call(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+        )
+
+        expect(results.map(&:name)).not_to include("Far Away")
+      end
+    end
+
+    context "when a course has a school with no coordinates" do
+      # The gias_school factory leaves latitude/longitude nil unless set, mirroring
+      # GIAS rows still awaiting geocoding. The coords guard must skip such schools.
+      let!(:partly_geocoded_course) do
+        course = create(:course, :published, name: "Partly Geocoded", provider: create(:provider))
+        create(:course_school, course:, gias_school: create(:gias_school))
+        create(
+          :course_school,
+          course:,
+          gias_school: create(:gias_school, latitude: london.latitude, longitude: london.longitude),
+        )
+        course
+      end
+
+      let!(:ungeocoded_only_course) do
+        course = create(:course, :published, name: "No Coordinates", provider: create(:provider))
+        create(:course_school, course:, gias_school: create(:gias_school))
+        course
+      end
+
+      it "keeps the course via its geocoded school, ignoring the ungeocoded one" do
+        results = described_class.call(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+        ).to_a
+
+        row = results.find { |c| c.id == partly_geocoded_course.id }
+        expect(row).to be_present
+        expect(row.minimum_distance_to_search_location.round(2)).to eq(0.0)
+      end
+
+      it "excludes a course whose only school has no coordinates" do
+        results = described_class.call(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+        )
+
+        expect(results.map(&:name)).not_to include("No Coordinates")
+      end
+    end
+
+    context "when a course links the same school via two provider schools" do
+      # course_school is unique on [course_id, provider_school_id], so one
+      # gias_school can be reached twice by a course. MIN + GROUP BY must collapse
+      # it to a single result row.
+      let!(:duplicate_edge_course) do
+        course = create(:course, :published, name: "Duplicate Edge", provider: create(:provider))
+        school = create(:gias_school, latitude: london.latitude, longitude: london.longitude)
+        create(:course_school, course:, gias_school: school, site_code: "A")
+        create(:course_school, course:, gias_school: school, site_code: "B")
+        course
+      end
+
+      it "returns the course exactly once" do
+        results = described_class.call(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+        ).to_a
+
+        rows = results.select { |c| c.id == duplicate_edge_course.id }
+        expect(rows.size).to eq(1)
+        expect(rows.first.minimum_distance_to_search_location.round(2)).to eq(0.0)
+      end
+    end
+
+    context "when combined with a subject filter (filter-led search)" do
+      let!(:biology_course) do
+        course = create(
+          :course, :published, :secondary,
+          name: "Biology",
+          provider: create(:provider),
+          subjects: [find_or_create(:secondary_subject, :biology)]
+        )
+        create(:course_school, course:, gias_school: create(:gias_school, latitude: london.latitude, longitude: london.longitude))
+        course
+      end
+
+      let!(:physics_course) do
+        course = create(
+          :course, :published, :secondary,
+          name: "Physics",
+          provider: create(:provider),
+          subjects: [find_or_create(:secondary_subject, :physics)]
+        )
+        create(:course_school, course:, gias_school: create(:gias_school, latitude: london.latitude, longitude: london.longitude))
+        course
+      end
+
+      it "returns only courses matching both the subject and the location" do
+        results = described_class.call(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10, subject_code: "C1" },
+        )
+
+        names = results.map(&:name)
+        expect(names).to include("Biology")
+        expect(names).not_to include("Physics")
+      end
+    end
+
+    describe "#count" do
+      it "counts distinct courses within the radius" do
+        query = described_class.new(
+          params: { latitude: london.latitude, longitude: london.longitude, radius: 10 },
+        )
+        query.call
+
+        # Of the five seeded courses only London (0mi), Canary Wharf (4.46mi) and
+        # Lewisham (6.07mi) fall within 10 miles.
+        expect(query.count).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/services/saved_courses/query_new_school_model_spec.rb
+++ b/spec/services/saved_courses/query_new_school_model_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Saved-courses location annotation over the canonical course_school -> gias_school
+# model, gated by :course_publishing_uses_new_school_model. As with the legacy
+# path, saved courses are annotated with distance and sorted, but NOT filtered by
+# radius.
+RSpec.describe SavedCourses::Query do
+  subject(:results) { described_class.call(candidate:, params:) }
+
+  let(:candidate) { create(:candidate) }
+
+  def test_saved_course_wrapper_klass
+    @test_saved_course_wrapper_klass ||= Class.new(SimpleDelegator) do
+      attr_reader :minimum_distance_to_search_location
+
+      def initialize(saved_course, minimum_distance_to_search_location:)
+        super(saved_course)
+        @minimum_distance_to_search_location = minimum_distance_to_search_location
+      end
+    end
+  end
+
+  context "when :course_publishing_uses_new_school_model is active" do
+    before { FeatureFlag.activate(:course_publishing_uses_new_school_model) }
+    after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
+
+    let(:london) { build(:location, :london) }
+    let!(:london_saved_result) { saved_course_at(london, provider_name: "London University", distance: 0.0) }
+    let!(:lewisham_saved_result) { saved_course_at(lewisham, provider_name: "Lewisham University", distance: 6.07) }
+    let!(:cambridge_saved_result) { saved_course_at(cambridge, provider_name: "Cambridge University", distance: 49.38) }
+    let(:params) { { latitude: london.latitude, longitude: london.longitude } }
+    let(:lewisham) { build(:location, :lewisham) }
+    let(:cambridge) { build(:location, :cambridge) }
+
+    def saved_course_at(location, provider_name:, distance:)
+      course = create(:course, provider: create(:provider, provider_name:))
+      create(
+        :course_school,
+        course:,
+        gias_school: create(:gias_school, latitude: location.latitude, longitude: location.longitude),
+      )
+      test_saved_course_wrapper_klass.new(
+        create(:saved_course, candidate:, course:),
+        minimum_distance_to_search_location: distance,
+      )
+    end
+
+    it "returns all saved courses sorted by distance, without a radius filter" do
+      expect(results).to match_collection(
+        [london_saved_result, lewisham_saved_result, cambridge_saved_result],
+        attribute_names: %w[minimum_distance_to_search_location],
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

Move Find's location/distance search onto the canonical `course_school → gias_school`
model, behind the existing `course_publishing_uses_new_school_model` flag. When the
flag is on, `Courses::Query` and `SavedCourses::Query` compute
`minimum_distance_to_search_location` from each school's single canonical coordinate
via `course_school`, instead of the per-provider-duplicated `course_site → site`
rows. When the flag is off, the legacy path is used unchanged.

This is stage one of two: it swaps the data source (canonical, deduplicated) while
keeping the query shape. A follow-up adds the spatial index (`geo_location` + GiST)
that turns location search into a 1–10 ms query.

### Performance


No spatial index yet, so both paths still scan and compute `ST_DistanceSphere` over
the course school / gias school set. The new path is currently **~3–13% faster** (canonical dedup +
one fewer join), e.g. London location-led 234 ms → 218 ms, Manchester 225 ms →
201 ms. The order-of-magnitude win lands with the GiST index in the follow-up.

A `location_search:bench` rake task is included in the commit history to reproduce the diff + `EXPLAIN
ANALYZE` timings on any database.

```
Fresh numbers (median of 7 EXPLAIN ANALYZE passes, Postgres time):

  ┌───────────────────────────┬────────┬────────┬──────────────┐
  │         Scenario          │ Old ms │ New ms │      Δ       │
  ├───────────────────────────┼────────┼────────┼──────────────┤
  │ London — location-led     │  234.1 │  217.9 │  −16.2 (−7%) │
  ├───────────────────────────┼────────┼────────┼──────────────┤
  │ London — filter-led       │  173.8 │  168.0 │   −5.8 (−3%) │
  ├───────────────────────────┼────────┼────────┼──────────────┤
  │ Manchester — location-led │  224.8 │  201.0 │ −23.8 (−11%) │
  ├───────────────────────────┼────────┼────────┼──────────────┤
  │ Manchester — filter-led   │  167.1 │  154.5 │  −12.6 (−8%) │
  ├───────────────────────────┼────────┼────────┼──────────────┤
  │ Penrith — location-led    │  208.0 │  181.9 │ −26.1 (−13%) │
  ├───────────────────────────┼────────┼────────┼──────────────┤
  │ Penrith — filter-led      │  164.4 │  158.3 │   −6.1 (−4%) │
  └───────────────────────────┴────────┴────────┴──────────────┘

  For now the new path is ~3–13% faster (roughly 5–25 ms). Modest — and expected. Both paths still
  sit at ~150–235 ms because there's no spatial index yet: both scan and compute ST_DistanceSphere
  over the candidate set. Stage A's gain comes only from the canonical dedup and dropping the
  course_site join.
```

## Behaviour change (measured on a prod-shaped dev DB, current cycle)

Non-location searches are unchanged. For location search the set of schools that
contribute distance moves from "running/published sites" to "all linked GIAS
schools", so results shift slightly. Measured whole-GB (all published current-cycle
courses):

- Old: 11,393 → New: 10,672 (**−721, ~6.3%**); 734 dropped, 13 added.
- **All 734 dropped courses are dropped because none of their sites map to a
  `gias_school`** (discarded sites, or URNs missing from `gias_school`) — i.e. a data
  gap, not a query-logic change. Concretely: of 380,872 findable course_sites on
  published current-cycle courses, only 1,627 (0.43%) have no `gias_school`.
- Courses taught only at non-school sites (no GIAS URN, e.g. a provider campus
  address) drop out of location search by design — they still appear in
  non-location search. (Product sign-off assumed.)

The residual narrowing shrinks as the `schools_backfill` is re-run and `gias_school`
URN coverage improves — see rollout.

## Testing

- New request specs for both queries under the flag: radius filtering, distance
  ordering, MIN across a course's schools, all-schools-outside-radius exclusion, the
  NULL-coordinate guard, duplicate edges to one school, cross-provider dedup, subject
  composition (filter-led), `#count`, and the non-school-site drop.
- Legacy specs stay green (flag off).

## Rollout / follow-ups

- **Next PR (same branch):** `geo_location` generated column + partial GiST index +  `ST_DWithin`;
