### PR TITLE
Safely removing site_code allowed

### DIFF
--- a/db/migrate/20260714120000_remove_site_code_from_course_school.rb
+++ b/db/migrate/20260714120000_remove_site_code_from_course_school.rb
@@ -2,6 +2,6 @@
 
 class RemoveSiteCodeFromCourseSchool < ActiveRecord::Migration[8.1]
   def change
-    remove_column :course_school, :site_code, :text
+    safety_assured { remove_column :course_school, :site_code, :text }
   end
 end


### PR DESCRIPTION
## Context

In my previous PR I removed the site_code. Due to the strong_migrations gem the deploy is blocked. This will unblock the migrations and deploys

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
