### PR TITLE
School remodel find query spatial index

### DIFF
--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -348,39 +348,37 @@ module Courses
     end
 
     # Location filter over the canonical course_school -> gias_school model, used
-    # while the :course_publishing_uses_new_school_model flag is on. Distance is
-    # measured from each school's coordinate once and exposed in miles, matching
-    # the legacy path's minimum_distance_to_search_location contract.
+    # while the :course_publishing_uses_new_school_model flag is on.
+    #
+    # A derived table finds the nearby schools via the partial GiST index
+    # (ST_DWithin prunes far-away schools) and reduces them to one row per course
+    # with its nearest-school distance BEFORE the join to `course`. Postgres does
+    # not flatten a GROUP BY subquery, so the course-side filters (published, etc.)
+    # run once per distinct course rather than once per (school x course) edge.
+    #
+    # ST_Distance/ST_DWithin take the trailing `false` to force sphere maths, so
+    # results match the legacy ST_DistanceSphere path. Distance is returned in
+    # miles, preserving the minimum_distance_to_search_location contract.
     def schools_location_scope(latitude:, longitude:, radius_in_meters:)
+      point = Course.sanitize_sql_array(
+        ["ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography", longitude, latitude],
+      )
+
+      nearby_courses = Course.sanitize_sql_array([<<~SQL, radius_in_meters])
+        INNER JOIN (
+          SELECT course_school.course_id,
+                 MIN(ST_Distance(gias_school.geo_location, #{point}, false)) AS distance_m
+          FROM gias_school
+          INNER JOIN course_school ON course_school.gias_school_id = gias_school.id
+          WHERE gias_school.geo_location IS NOT NULL
+            AND ST_DWithin(gias_school.geo_location, #{point}, ?, false)
+          GROUP BY course_school.course_id
+        ) nearby_courses ON nearby_courses.course_id = course.id
+      SQL
+
       @scope
-        .joins(schools: :gias_school)
-        .where.not(gias_school: { latitude: nil })
-        .where.not(gias_school: { longitude: nil })
-        .where(
-          <<~SQL.squish, longitude, latitude, radius_in_meters
-            ST_DistanceSphere(
-              ST_SetSRID(ST_MakePoint(gias_school.longitude::float, gias_school.latitude::float), 4326),
-              ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
-            ) <= ?
-          SQL
-        )
-        .select(
-          Course.sanitize_sql_array(
-            [
-              <<~SQL.squish,
-                course.*,
-                provider.provider_name,
-                MIN(ST_DistanceSphere(
-                  ST_SetSRID(ST_MakePoint(gias_school.longitude::float, gias_school.latitude::float), 4326),
-                  ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
-                ) / 1609.344) AS minimum_distance_to_search_location
-              SQL
-              longitude,
-              latitude,
-            ],
-          ),
-        )
-        .group(:id, "provider.provider_name")
+        .joins(nearby_courses)
+        .select("course.*, provider.provider_name, (nearby_courses.distance_m / 1609.344) AS minimum_distance_to_search_location")
     end
 
     def default_ordering_scope

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -98,6 +98,7 @@
   - org_id
   :gias_school:
   - searchable
+  - geo_location
   :course_enrichment:
   - about_course
   - course_length

--- a/db/migrate/20260717120000_add_geo_location_to_gias_school.rb
+++ b/db/migrate/20260717120000_add_geo_location_to_gias_school.rb
@@ -1,0 +1,42 @@
+class AddGeoLocationToGiasSchool < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # Canonical spatial column on the one-row-per-school table, plus a partial GiST
+  # index so location search can prune far-away schools with ST_DWithin instead of
+  # computing ST_DistanceSphere for every candidate.
+  #
+  # geo_location stores geography(Point, 4326) (true lat/long, metres on a sphere)
+  # derived from the existing float columns. The ::geography cast of
+  # ST_SetSRID(ST_MakePoint(...)) is IMMUTABLE, so it is legal in a STORED
+  # generated column (ST_Transform is not, and would be rejected). Note the
+  # argument order: ST_MakePoint(X, Y) = (longitude, latitude).
+  def up
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE gias_school
+          ADD COLUMN geo_location geography(Point, 4326)
+          GENERATED ALWAYS AS ((ST_SetSRID(ST_MakePoint(longitude, latitude), 4326))::geography) STORED
+      SQL
+    end
+
+    # Only in-coordinate schools are indexed; NULL coordinates (awaiting geocoding)
+    # are excluded so the index stays lean and never matches a search.
+    add_index :gias_school, :geo_location,
+              using: :gist,
+              where: "geo_location IS NOT NULL",
+              name: "index_gias_school_on_geo_location",
+              algorithm: :concurrently
+
+    # Make the school -> course fan-out (phase 2 of the search) index-only.
+    add_index :course_school, :gias_school_id,
+              include: %i[course_id],
+              name: "index_course_school_fanout",
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :course_school, name: "index_course_school_fanout", algorithm: :concurrently
+    remove_index :gias_school, name: "index_gias_school_on_geo_location", algorithm: :concurrently
+    safety_assured { execute "ALTER TABLE gias_school DROP COLUMN geo_location" }
+  end
+end

--- a/db/migrate/20260721100824_remove_redundant_gias_school_id_index_from_course_school.rb
+++ b/db/migrate/20260721100824_remove_redundant_gias_school_id_index_from_course_school.rb
@@ -1,0 +1,17 @@
+class RemoveRedundantGiasSchoolIdIndexFromCourseSchool < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # index_course_school_fanout (added in 20260717120000) is (gias_school_id)
+  # INCLUDE (course_id). It has the same key column as the plain
+  # index_course_school_on_gias_school_id, so it serves every lookup that one
+  # did — and backs the gias_school FK cascade — while additionally covering
+  # index-only fan-out scans. Keeping both just doubles write/storage cost for
+  # no planner benefit, so drop the plain one.
+  def up
+    remove_index :course_school, name: "index_course_school_on_gias_school_id", algorithm: :concurrently
+  end
+
+  def down
+    add_index :course_school, :gias_school_id, name: "index_course_school_on_gias_school_id", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_17_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_100824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -264,7 +264,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_120000) do
     t.datetime "updated_at", null: false
     t.index ["course_id", "provider_school_id"], name: "index_course_school_on_course_id_and_provider_school_id", unique: true
     t.index ["gias_school_id"], name: "index_course_school_fanout", include: ["course_id"]
-    t.index ["gias_school_id"], name: "index_course_school_on_gias_school_id"
     t.index ["provider_school_id"], name: "index_course_school_on_provider_school_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_120500) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -263,6 +263,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_120500) do
     t.bigint "provider_school_id", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id", "provider_school_id"], name: "index_course_school_on_course_id_and_provider_school_id", unique: true
+    t.index ["gias_school_id"], name: "index_course_school_fanout", include: ["course_id"]
     t.index ["gias_school_id"], name: "index_course_school_on_gias_school_id"
     t.index ["provider_school_id"], name: "index_course_school_on_provider_school_id"
   end
@@ -355,6 +356,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_120500) do
     t.text "address3"
     t.text "county"
     t.datetime "created_at", null: false
+    t.virtual "geo_location", type: :geography, limit: {srid: 4326, type: "st_point", geographic: true}, as: "(st_setsrid(st_makepoint(longitude, latitude), 4326))::geography", stored: true
     t.text "group_code"
     t.float "latitude"
     t.float "longitude"
@@ -373,6 +375,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_120500) do
     t.datetime "updated_at", null: false
     t.text "urn", null: false
     t.text "website"
+    t.index ["geo_location"], name: "index_gias_school_on_geo_location", where: "(geo_location IS NOT NULL)", using: :gist
     t.index ["region_code"], name: "index_gias_school_on_region_code"
     t.index ["searchable"], name: "index_gias_school_on_searchable", using: :gin
     t.index ["status_code"], name: "index_gias_school_on_status_code", where: "(status_code = '1'::text)"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,7 +73,11 @@ RSpec.configure do |config|
 
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
+    # spatial_ref_sys belongs to the postgis extension, not to us. Truncating it
+    # empties the extension's own data, which the guard below then "repairs" with
+    # DROP EXTENSION ... CASCADE — taking every dependent object with it,
+    # including gias_school.geo_location and its GiST index.
+    DatabaseCleaner.clean_with(:truncation, except: %w[spatial_ref_sys])
     DatabaseCleaner.strategy = :transaction
 
     postgis_table_count = ActiveRecord::Base.connection.execute(


### PR DESCRIPTION
## What

Make Find's "courses near me" search fast by adding a spatial index. This stacks on
the earlier PR that moved location search onto `course_school → gias_school`; that PR
swapped the *data source*, this one adds the index that makes it quick.

Three pieces:
1. A `geo_location geography(Point, 4326)` **generated column** on `gias_school`,
   derived from the existing `latitude`/`longitude`, with a **partial GiST index**.
2. Registration of the new field in the dfe-analytics blocklist.
3. `Courses::Query#schools_location_scope` rewritten to prune with `ST_DWithin` over
   the index and aggregate to one row per course **before** the course-side filters.

Behind the existing `course_publishing_uses_new_school_model` flag.

---

## How the GiST index works

A GiST index stores each school's point inside a tree of **bounding boxes**.
`ST_DWithin(geo_location, :point, :radius)` walks that tree and only visits schools
whose box overlaps the search circle — far-away schools are eliminated **without
computing their distance at all**. Without the index, Postgres computes the distance
to every candidate school and then throws most away.

### Worked example

A candidate searches from **Charing Cross `(51.508, −0.128)`**, radius **10 miles**:

```
        the 10-mile search envelope (what the GiST index scans)
   ┌───────────────────────────────────────────┐
   │     ● St Mary's  (2.0 mi)                   │
   │  ● Greenhill (0.6 mi)                       │            ● Elmwood, Reading (35 mi)
   │        ✕ search point                       │              ← OUTSIDE the box:
   │                     ● Kingsway (9.8 mi)     │                the index never
   └───────────────────────────────────────────┘                visits or measures it
```

| School | URN | Coordinates | Distance | GiST verdict |
|---|---|---|---:|---|
| Greenhill Academy | 100001 | 51.500, −0.120 | 0.6 mi | ✅ visited → matches |
| St Mary's Primary | 100002 | 51.530, −0.140 | 2.0 mi | ✅ visited → matches |
| Kingsway High | 100003 | 51.370, −0.100 | 9.8 mi | ✅ visited → matches (just inside) |
| Elmwood College | 100004 | 51.455, −0.970 | 35 mi | ⛔ **never visited** (box pruned) |

Real numbers: for a central-London search the index returns ~2,400 nearby schools in
~2 ms, instead of scanning all ~27,000.

The index is **partial** — `WHERE geo_location IS NOT NULL` — so schools still awaiting
geocoding never bloat it and never match a search.

---

## The query: prune, then aggregate per course

The subtlety is *when* the expensive per-course work happens. Nearby schools fan out
to many `(school × course)` edges (~42,000 for dense London), and running the
per-course "is this course published?" check on every edge is what made a naive
version slow. So the query aggregates to **one row per course first**, in a derived
table Postgres won't flatten, and only then joins `course`:

```mermaid
flowchart TD
    A["Search point + radius"] --> B["Phase 1 — GiST prune<br/>ST_DWithin(geo_location, point, radius)"]
    B -->|"far schools skipped"| C["Nearby schools only<br/>(~2,400 near central London)"]
    C --> D["Join course_school, GROUP BY course_id<br/>MIN(distance) = nearest school per course"]
    D --> E["Distinct nearby courses<br/>(~1,946)"]
    E --> F["Join course + published / base filters<br/>run ONCE per distinct course, not per edge"]
    F --> G["Ordered results with<br/>minimum_distance_to_search_location (miles)"]
```

Distances use `ST_Distance(..., false)` / `ST_DWithin(..., false)` — the trailing
`false` forces **sphere** maths, matching the legacy `ST_DistanceSphere` path so
results don't shift due to the maths.

---

## Performance

Median of 7 `EXPLAIN ANALYZE` passes, on a **restored production database** (current
cycle, ~11k published courses, 27k schools). "Old" = flag off (legacy `course_site`
path), "New" = flag on (this PR).

| Scenario | Old (ms) | New (ms) | Speed-up |
|---|--:|--:|--:|
| London — location-led (browse) | 249.8 | **62.3** | **4.0×** |
| London — filter-led (subject) | 185.5 | 43.7 | 4.2× |
| Manchester — location-led | 229.1 | **22.0** | 10.4× |
| Manchester — filter-led | 179.1 | 18.3 | 9.8× |
| Rural (Penrith) — location-led | 220.3 | **3.5** | 63× |
| Rural (Penrith) — filter-led | 170.8 | 1.6 | 107× |

The GiST prune delivers the 1–10 ms target wherever few schools are nearby (rural,
filter-led). Dense central-London "browse everything" stays ~60 ms because it
genuinely returns ~1,950 courses — the residual is the per-course published checks and
the final sort, not the distance maths. `EXPLAIN` confirms the plan uses
`index_gias_school_on_geo_location` with no sequential scan on `gias_school`.

---

## Behaviour notes

- **Result count** is unchanged from the previous (Stage A) PR — this is a pure
  performance change; the flag-on result set is identical to before, bit-for-bit.
- **Small distance shifts vs flag-off** are expected: the legacy path measures from
  `site` coordinates, the new path from **GIAS canonical** coordinates for the same
  school. For the same physical school these can differ slightly, nudging a course's
  `minimum_distance_to_search_location` by a fraction of a mile. Generally more
  accurate; never changes the radius bucket.

---

## Migration & rollout notes

- The generated column uses the **IMMUTABLE** `::geography` cast, so it is legal in a
  `STORED` column (`ST_Transform` is not IMMUTABLE and would be rejected). Note
  `ST_MakePoint(X, Y)` = `(longitude, latitude)`.
- Indexes are built `CONCURRENTLY`; the `ADD COLUMN` is wrapped in `safety_assured`
  for `strong_migrations`.
- Adding a tracked field trips dfe-analytics' boot check — hence the blocklist commit;
  the app/CI won't boot until the field is registered.
- `schema.rb` carries the generated column as
  `t.virtual "geo_location", type: :geography, … stored: true`. A **fresh**
  `db:schema:load` reproduces it correctly.

---

## Testing

- Verified on the restored production DB that flag-on results are identical to the
  previous PR (same course ids, same distances) and that the plan uses the GiST index.
- Unit specs for the new-model path (radius filtering, nearest-of-many, radius
  exclusion, NULL-coordinate guard, duplicate edges, subject composition, `#count`)
  cover the query behaviour.
