### PR TITLE
School experience - Add new fields to the API

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -4,6 +4,8 @@ module API
   module Public
     module V1
       class SerializableCourse < JSONAPI::Serializable::Resource
+        extend JSONAPI::Serializable::Resource::ConditionalFields
+
         COURSE_STATE_MAPPING = {
           published_with_unpublished_changes: :published,
         }.freeze
@@ -55,9 +57,15 @@ module API
                    :campaign_name,
                    :application_status,
                    :training_route,
-                   :degree_type,
-                   :school_experience_required,
-                   :school_experience_required_content
+                   :degree_type
+
+        attribute :school_experience_required, if: -> { @object.recruitment_cycle_after?(2026) } do
+          @object.school_experience_required
+        end
+
+        attribute :school_experience_required_content, if: -> { @object.recruitment_cycle_after?(2026) } do
+          @object.school_experience_required_content
+        end
 
         attribute :bursary_amount do
           course_incentive.bursary_amount

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -55,7 +55,9 @@ module API
                    :campaign_name,
                    :application_status,
                    :training_route,
-                   :degree_type
+                   :degree_type,
+                   :school_experience_required,
+                   :school_experience_required_content
 
         attribute :bursary_amount do
           course_incentive.bursary_amount

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe API::Public::V1::CoursesController do
     end
 
     context "when courses have school experience information" do
+      let(:provider) { create(:provider, recruitment_cycle: find_or_create(:recruitment_cycle, year: 2027)) }
+      let(:recruitment_cycle) { provider.recruitment_cycle }
+
       it "returns the school experience fields" do
         course_with_school_experience = create(:course, provider:)
         course_with_school_experience.update_columns(
@@ -68,6 +71,24 @@ RSpec.describe API::Public::V1::CoursesController do
           school_experience_required: nil,
           school_experience_required_content: nil,
         })
+      end
+
+      it "returns null school experience fields before the 2027 cycle" do
+        provider_in_2026 = create(:provider, recruitment_cycle: find_or_create(:recruitment_cycle, year: 2026))
+        course_with_school_experience = create(:course, provider: provider_in_2026)
+        course_with_school_experience.update_columns(
+          school_experience_required: true,
+          school_experience_required_content: "At least 2 weeks observing lessons.",
+        )
+
+        get :index, params: {
+          recruitment_cycle_year: provider_in_2026.recruitment_cycle.year,
+        }
+
+        attributes = json_response["data"].find { |course| course["id"] == course_with_school_experience.id.to_s }["attributes"]
+
+        expect(attributes).not_to have_key("school_experience_required")
+        expect(attributes).not_to have_key("school_experience_required_content")
       end
     end
 
@@ -405,8 +426,6 @@ RSpec.describe API::Public::V1::CoursesController do
                 other_requirements
                 personal_qualities
                 salary_details
-                school_experience_required
-                school_experience_required_content
                 can_sponsor_skilled_worker_visa
                 can_sponsor_student_visa
                 campaign_name

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -37,6 +37,40 @@ RSpec.describe API::Public::V1::CoursesController do
       end
     end
 
+    context "when courses have school experience information" do
+      it "returns the school experience fields" do
+        course_with_school_experience = create(:course, provider:)
+        course_with_school_experience.update_columns(
+          school_experience_required: true,
+          school_experience_required_content: "At least 2 weeks observing lessons.",
+        )
+        course_without_school_experience = create(:course, provider:)
+
+        get :index, params: {
+          recruitment_cycle_year: recruitment_cycle.year,
+        }
+
+        actual = json_response["data"].map do |data|
+          {
+            id: data["id"],
+            school_experience_required: data["attributes"]["school_experience_required"],
+            school_experience_required_content: data["attributes"]["school_experience_required_content"],
+          }
+        end
+
+        expect(actual).to include({
+          id: course_with_school_experience.id.to_s,
+          school_experience_required: true,
+          school_experience_required_content: "At least 2 weeks observing lessons.",
+        })
+        expect(actual).to include({
+          id: course_without_school_experience.id.to_s,
+          school_experience_required: nil,
+          school_experience_required_content: nil,
+        })
+      end
+    end
+
     context "when there are courses" do
       before do
         provider.courses << build_list(:course, 2, provider:)
@@ -371,6 +405,8 @@ RSpec.describe API::Public::V1::CoursesController do
                 other_requirements
                 personal_qualities
                 salary_details
+                school_experience_required
+                school_experience_required_content
                 can_sponsor_skilled_worker_visa
                 can_sponsor_student_visa
                 campaign_name

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -125,8 +125,6 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:required_qualifications_science).with_value("must_have_qualification_at_application_time") }
   it { is_expected.to have_attribute(:running).with_value(course.findable?) }
   it { is_expected.to have_attribute(:salary_details).with_value(course.latest_published_enrichment.salary_details) }
-  it { is_expected.to have_attribute(:school_experience_required).with_value(nil) }
-  it { is_expected.to have_attribute(:school_experience_required_content).with_value(nil) }
   it { is_expected.to have_attribute(:scholarship_amount).with_value(nil) }
   it { is_expected.to have_attribute(:can_sponsor_skilled_worker_visa) }
   it { is_expected.to have_attribute(:can_sponsor_student_visa) }
@@ -159,7 +157,17 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:accept_science_gcse_equivalency).with_value(course.accept_science_gcse_equivalency) }
   it { is_expected.to have_attribute(:additional_gcse_equivalencies).with_value(course.additional_gcse_equivalencies) }
 
-  context "when school experience information is present" do
+  context "when school experience information is present in the 2027 cycle or later" do
+    let(:course) do
+      create(
+        :course,
+        :with_accrediting_provider,
+        :salary,
+        enrichments: [enrichment],
+        provider: create(:provider, recruitment_cycle: find_or_create(:recruitment_cycle, year: 2027)),
+      )
+    end
+
     before do
       course.update_columns(
         school_experience_required: true,
@@ -169,6 +177,28 @@ RSpec.describe API::Public::V1::SerializableCourse do
 
     it { is_expected.to have_attribute(:school_experience_required).with_value(true) }
     it { is_expected.to have_attribute(:school_experience_required_content).with_value("At least 2 weeks observing lessons.") }
+  end
+
+  context "when school experience information is present before the 2027 cycle" do
+    let(:course) do
+      create(
+        :course,
+        :with_accrediting_provider,
+        :salary,
+        enrichments: [enrichment],
+        provider: create(:provider, recruitment_cycle: find_or_create(:recruitment_cycle, year: 2026)),
+      )
+    end
+
+    before do
+      course.update_columns(
+        school_experience_required: true,
+        school_experience_required_content: "At least 2 weeks observing lessons.",
+      )
+    end
+
+    it { is_expected.not_to have_attribute(:school_experience_required) }
+    it { is_expected.not_to have_attribute(:school_experience_required_content) }
   end
 
   context "when the latest published enrichment is version 1" do

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -125,6 +125,8 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:required_qualifications_science).with_value("must_have_qualification_at_application_time") }
   it { is_expected.to have_attribute(:running).with_value(course.findable?) }
   it { is_expected.to have_attribute(:salary_details).with_value(course.latest_published_enrichment.salary_details) }
+  it { is_expected.to have_attribute(:school_experience_required).with_value(nil) }
+  it { is_expected.to have_attribute(:school_experience_required_content).with_value(nil) }
   it { is_expected.to have_attribute(:scholarship_amount).with_value(nil) }
   it { is_expected.to have_attribute(:can_sponsor_skilled_worker_visa) }
   it { is_expected.to have_attribute(:can_sponsor_student_visa) }
@@ -156,6 +158,18 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:accept_maths_gcse_equivalency).with_value(course.accept_maths_gcse_equivalency) }
   it { is_expected.to have_attribute(:accept_science_gcse_equivalency).with_value(course.accept_science_gcse_equivalency) }
   it { is_expected.to have_attribute(:additional_gcse_equivalencies).with_value(course.additional_gcse_equivalencies) }
+
+  context "when school experience information is present" do
+    before do
+      course.update_columns(
+        school_experience_required: true,
+        school_experience_required_content: "At least 2 weeks observing lessons.",
+      )
+    end
+
+    it { is_expected.to have_attribute(:school_experience_required).with_value(true) }
+    it { is_expected.to have_attribute(:school_experience_required_content).with_value("At least 2 weeks observing lessons.") }
+  end
 
   context "when the latest published enrichment is version 1" do
     let(:enrichment) do

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -443,6 +443,19 @@
             "description": "Salary details about this course.",
             "example": "Successful applicants will be employed as unqualified teachers on at least Point 1 of the Unqualified Teachers' Pay Scale for the duration of the programme."
           },
+          "school_experience_required": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Whether school experience is required or strongly recommended for this course.",
+            "example": true
+          },
+          "school_experience_required_content": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Details of the school experience expected for this course.",
+            "example": "At least 2 weeks observing lessons in a UK secondary school."
+          },
           "scholarship_amount": {
             "type": "integer",
             "nullable": true,

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -446,14 +446,14 @@
           "school_experience_required": {
             "type": "boolean",
             "nullable": true,
-            "description": "Whether school experience is required or strongly recommended for this course.",
+            "description": "Whether school experience is required or strongly recommended for this course. Only included from the 2027 recruitment cycle onwards.",
             "example": true
           },
           "school_experience_required_content": {
             "type": "string",
             "nullable": true,
             "format": "markdown",
-            "description": "Details of the school experience expected for this course.",
+            "description": "Details of the school experience expected for this course. Only included from the 2027 recruitment cycle onwards.",
             "example": "At least 2 weeks observing lessons in a UK secondary school."
           },
           "scholarship_amount": {

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -295,6 +295,17 @@ properties:
       Successful applicants will be employed as unqualified teachers on
       at least Point 1 of the Unqualified Teachers' Pay Scale for the
       duration of the programme.
+  school_experience_required:
+    type: boolean
+    nullable: true
+    description: "Whether school experience is required or strongly recommended for this course."
+    example: true
+  school_experience_required_content:
+    type: string
+    nullable: true
+    format: markdown
+    description: "Details of the school experience expected for this course."
+    example: "At least 2 weeks observing lessons in a UK secondary school."
   scholarship_amount:
     type: integer
     nullable: true

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -298,13 +298,13 @@ properties:
   school_experience_required:
     type: boolean
     nullable: true
-    description: "Whether school experience is required or strongly recommended for this course."
+    description: "Whether school experience is required or strongly recommended for this course. Only included from the 2027 recruitment cycle onwards."
     example: true
   school_experience_required_content:
     type: string
     nullable: true
     format: markdown
-    description: "Details of the school experience expected for this course."
+    description: "Details of the school experience expected for this course. Only included from the 2027 recruitment cycle onwards."
     example: "At least 2 weeks observing lessons in a UK secondary school."
   scholarship_amount:
     type: integer


### PR DESCRIPTION
## Context

Publish now captures whether school experience is required or strongly recommended and any provider-entered details. These fields were not previously exposed through the public course API, preventing downstream services from consuming them.

## Changes proposed in this pull request

- Add `school_experience_required` to course API responses.
- Add `school_experience_required_content` to course API responses.
- Return `null` safely when school experience information is absent.
- Update serializer and controller coverage.
- Update and regenerate the OpenAPI documentation.
- No UI changes.

## Guidance to review

Confirm both fields are present for courses with and without school experience information.

Test locally at:

`http://api.localhost:3001/api/public/v1/recruitment_cycles/current/courses`

Run:

```sh
bundle exec rspec \
  spec/controllers/api/public/v1/courses_controller_spec.rb \
  spec/serializers/api/public/v1/serializable_course_spec.rb
```

## Checklist

- [x] I have moved hard-coded strings to locale files. (Not applicable—no UI strings added.)
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests. (Not applicable—no HTML changes.)