### PR TITLE
Filter discarded sites from location search

### DIFF
--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -303,7 +303,10 @@ module Courses
             AND site_statuses.status = 'R'
             AND site_statuses.publish = 'Y'
           )
-          INNER JOIN site ON site.id = site_statuses.site_id
+          INNER JOIN site ON (
+            site.id = site_statuses.site_id
+            AND site.discarded_at IS NULL
+          )
         SQL
         .where("(site.longitude IS NOT NULL OR site.latitude IS NOT NULL)")
         .where(

--- a/app/services/saved_courses/query.rb
+++ b/app/services/saved_courses/query.rb
@@ -42,7 +42,10 @@ module SavedCourses
             AND course_site.status = 'R'
             AND course_site.publish = 'Y'
           )
-          INNER JOIN site ON site.id = course_site.site_id
+          INNER JOIN site ON (
+            site.id = course_site.site_id
+            AND site.discarded_at IS NULL
+          )
         SQL
         .where("(site.longitude IS NOT NULL OR site.latitude IS NOT NULL)")
         .select(

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
       urn { nil }
     end
 
+    trait :discarded do
+      discarded_at { Time.zone.now }
+    end
+
     after(:build) do |site, evaluator|
       if evaluator.age.present?
         site.created_at = evaluator.age

--- a/spec/services/courses/query/location_params_spec.rb
+++ b/spec/services/courses/query/location_params_spec.rb
@@ -443,6 +443,82 @@ RSpec.describe Courses::Query do # rubocop:disable RSpec/SpecFilePathFormat
     end
   end
 
+  context "when a placement school has been discarded" do
+    let(:london) { build(:location, :london) }
+    let(:canary_wharf) { build(:location, :canary_wharf) }
+    let(:lewisham) { build(:location, :lewisham) }
+
+    let(:params) { { latitude: london.latitude, longitude: london.longitude, radius: 10 } }
+
+    let!(:course_with_kept_site_only) do
+      test_search_result_wrapper_klass.new(
+        create(
+          :course,
+          :published,
+          name: "Mathematics (kept school)",
+          provider: create(:provider, provider_name: "Apple University"),
+          site_statuses: [
+            create(
+              :site_status,
+              :findable,
+              site: create(:site, latitude: lewisham.latitude, longitude: lewisham.longitude),
+            ),
+          ],
+        ),
+        minimum_distance_to_search_location: 6.07,
+      )
+    end
+
+    it "excludes a course whose only placement school is discarded" do
+      create(
+        :course,
+        :published,
+        name: "Science (discarded school)",
+        site_statuses: [
+          create(
+            :site_status,
+            :findable,
+            site: create(:site, :discarded, latitude: lewisham.latitude, longitude: lewisham.longitude),
+          ),
+        ],
+      )
+
+      expect(described_class.call(params:)).to match_collection(
+        [course_with_kept_site_only],
+        attribute_names: %w[name minimum_distance_to_search_location],
+      )
+    end
+
+    it "measures distance from the kept school when a course also has a discarded one" do
+      course_with_both = test_search_result_wrapper_klass.new(
+        create(
+          :course,
+          :published,
+          name: "Chemistry (one discarded, one kept)",
+          provider: create(:provider, provider_name: "Zebra University"),
+          site_statuses: [
+            create(
+              :site_status,
+              :findable,
+              site: create(:site, :discarded, latitude: canary_wharf.latitude, longitude: canary_wharf.longitude),
+            ),
+            create(
+              :site_status,
+              :findable,
+              site: create(:site, latitude: lewisham.latitude, longitude: lewisham.longitude),
+            ),
+          ],
+        ),
+        minimum_distance_to_search_location: 6.07,
+      )
+
+      expect(described_class.call(params:)).to match_collection(
+        [course_with_kept_site_only, course_with_both],
+        attribute_names: %w[name minimum_distance_to_search_location],
+      )
+    end
+  end
+
   describe "SQL injection tests for location search" do
     let(:london) { build(:location, :london) }
     let(:valid_latitude) { 51.5074 }

--- a/spec/services/saved_courses/query_spec.rb
+++ b/spec/services/saved_courses/query_spec.rb
@@ -110,6 +110,52 @@ RSpec.describe SavedCourses::Query do
       end
     end
 
+    context "when a placement school has been discarded" do
+      let(:params) { { latitude: london.latitude, longitude: london.longitude } }
+
+      it "excludes a saved course whose only placement school is discarded" do
+        create(
+          :saved_course,
+          candidate:,
+          course: create(
+            :course,
+            name: "Discarded School Course",
+            provider: create(:provider, provider_name: "Discarded University"),
+            site_statuses: [create(:site_status, :findable, site: create(:site, :discarded, latitude: london.latitude, longitude: london.longitude))],
+          ),
+        )
+
+        expect(results).to match_collection(
+          [london_saved_result, lewisham_saved_result, cambridge_saved_result],
+          attribute_names: %w[minimum_distance_to_search_location],
+        )
+      end
+
+      it "measures distance from the kept school when a saved course also has a discarded one" do
+        mixed_saved_result = test_saved_course_wrapper_klass.new(
+          create(
+            :saved_course,
+            candidate:,
+            course: create(
+              :course,
+              name: "Mixed Course",
+              provider: create(:provider, provider_name: "Mixed University"),
+              site_statuses: [
+                create(:site_status, :findable, site: create(:site, :discarded, latitude: london.latitude, longitude: london.longitude)),
+                create(:site_status, :findable, site: create(:site, latitude: cambridge.latitude, longitude: cambridge.longitude)),
+              ],
+            ),
+          ),
+          minimum_distance_to_search_location: 49.38,
+        )
+
+        expect(results).to match_collection(
+          [london_saved_result, lewisham_saved_result, cambridge_saved_result, mixed_saved_result],
+          attribute_names: %w[minimum_distance_to_search_location],
+        )
+      end
+    end
+
     context "when distance ordering requested but no location given" do
       let(:params) { { order: "distance" } }
 


### PR DESCRIPTION
## Context

When a training provider removes a placement school, Find kept using that removed school to place the course on the map. So a course could appear in a location search because of a school that isn't there anymore.

Location search (Find results + saved courses) was positioning courses using placement schools the provider had already removed.

Both `Courses::Query#location_scope` and `SavedCourses::Query#location_scope` build their location filter in raw SQL and join `site` with no `discarded_at IS NULL` predicate. `Site` includes `Discard::Model` but discard adds no `default_scope`, and raw SQL bypasses AR scopes anyway. Discarding a site also doesn't detach its `course_site` rows — they survive with `status='R'`, `publish='Y'`, so they keep satisfying the join.

**Impact (2026 cycle, measured):** 180 discarded sites still attached to 700 live published courses; 147 of those are findable *only* via discarded schools.

## Change

Added `AND site.discarded_at IS NULL` to the `site` join in both query objects:

```sql
INNER JOIN site ON (
  site.id = site_statuses.site_id
  AND site.discarded_at IS NULL
)
```

Courses are now positioned only by schools that still exist; courses propped up solely by a discarded school drop out of location results (the correct behaviour).

