### PR TITLE
Remove N+1 lookups from rollover school and site copiers

### DIFF
--- a/app/models/concerns/touch_course.rb
+++ b/app/models/concerns/touch_course.rb
@@ -10,6 +10,8 @@ module TouchCourse
 private
 
   def touch_course
+    return if TouchSuppression.suppressed?
+
     course.update_changed_at
   end
 end

--- a/app/models/concerns/touch_provider.rb
+++ b/app/models/concerns/touch_provider.rb
@@ -10,6 +10,8 @@ module TouchProvider
 private
 
   def touch_provider
+    return if TouchSuppression.suppressed?
+
     provider.update_changed_at
   end
 end

--- a/app/models/concerns/touch_suppression.rb
+++ b/app/models/concerns/touch_suppression.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Bulk copies such as rollover create thousands of child records, each of which
+# fires an `after_save` touch on its parent provider or course. Suppress those
+# for the duration of the copy and update each parent once at the end instead.
+#
+# The flag is fiber-local, so suppressing it in one Sidekiq thread leaves
+# concurrent work in other threads untouched.
+module TouchSuppression
+  KEY = :touch_suppressed
+
+  def self.suppress
+    previously_suppressed = suppressed?
+    ActiveSupport::IsolatedExecutionState[KEY] = true
+    yield
+  ensure
+    ActiveSupport::IsolatedExecutionState[KEY] = previously_suppressed
+  end
+
+  def self.suppressed?
+    ActiveSupport::IsolatedExecutionState[KEY] || false
+  end
+end

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -87,11 +87,20 @@ module Courses
     end
 
     def copy_study_sites(course:, new_provider:, new_course:)
+      lookup = new_provider_study_sites(new_provider)
+
       course.study_sites.each do |site|
-        new_site = new_provider.study_sites.find_by(code: site.code)
+        new_site = lookup[site.code]
 
         @sites_copy_to_course.call(new_site:, new_course:) if new_site.present?
       end
+    end
+
+    # Every study site belonging to the new provider is created before any
+    # course is copied, so load them once per provider rather than per course.
+    def new_provider_study_sites(new_provider)
+      @new_provider_study_sites ||= {}
+      @new_provider_study_sites[new_provider.id] ||= new_provider.study_sites.index_by(&:code)
     end
 
     def next_cycle

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -15,12 +15,19 @@ module Providers
 
       if provider_eligible?(provider)
         ActiveRecord::Base.transaction do
-          rolled_over_provider = find_or_create_provider_in_cycle(provider, new_recruitment_cycle, result)
+          # Each copied site, school, enrichment and site status would otherwise
+          # touch its parent provider and course on every save. Suppress that and
+          # stamp the parents once, below.
+          TouchSuppression.suppress do
+            rolled_over_provider = find_or_create_provider_in_cycle(provider, new_recruitment_cycle, result)
 
-          copy_schools(provider, rolled_over_provider, result)
-          copy_study_sites(provider, rolled_over_provider, result)
-          copy_courses(provider, rolled_over_provider, course_codes, result)
-          result[:partnerships] = copy_partnerships(provider, rolled_over_provider, new_recruitment_cycle)
+            copy_schools(provider, rolled_over_provider, result)
+            copy_study_sites(provider, rolled_over_provider, result)
+            copy_courses(provider, rolled_over_provider, course_codes, result)
+            result[:partnerships] = copy_partnerships(provider, rolled_over_provider, new_recruitment_cycle)
+
+            touch_copied_records(rolled_over_provider)
+          end
         end
       end
 
@@ -125,6 +132,16 @@ module Providers
       rescue StandardError => e
         result[:courses_failed] << { course_code: course.course_code, error_message: e.message }
       end
+    end
+
+    # Stands in for the per-record touches suppressed during the copy.
+    #
+    # Only the provider needs stamping. Every course here is newly inserted, and
+    # Rails sets `changed_at` on create, so re-stamping them would be redundant
+    # and would risk colliding on its unique index. The provider may already have
+    # existed in the destination cycle, in which case nothing else updates it.
+    def touch_copied_records(rolled_over_provider)
+      rolled_over_provider.update_changed_at
     end
 
     def copy_partnerships(provider, rolled_over_provider, new_recruitment_cycle)

--- a/app/services/rollover/schools/course_copier.rb
+++ b/app/services/rollover/schools/course_copier.rb
@@ -4,16 +4,37 @@ module Rollover
   module Schools
     class CourseCopier
       def call(course:, new_provider:, new_course:)
-        course.schools.includes(:provider_school).find_each do |course_school|
-          new_provider_school = new_provider.schools.find_by!(
-            gias_school_id: course_school.provider_school.gias_school_id,
-            site_code: course_school.provider_school.site_code,
-          )
+        lookup = new_provider_schools(new_provider)
+        existing = new_course.schools.index_by(&:provider_school_id)
 
-          new_course.schools.find_or_create_by!(provider_school: new_provider_school) do |new_course_school|
-            new_course_school.gias_school_id = new_provider_school.gias_school_id
+        course.schools.includes(:provider_school).find_each do |course_school|
+          old_provider_school = course_school.provider_school
+          new_provider_school = lookup[[old_provider_school.gias_school_id, old_provider_school.site_code]]
+
+          if new_provider_school.nil?
+            raise ActiveRecord::RecordNotFound,
+                  "Couldn't find Provider::School for provider #{new_provider.id} " \
+                  "with gias_school_id #{old_provider_school.gias_school_id} " \
+                  "and site_code #{old_provider_school.site_code}"
           end
+
+          next if existing.key?(new_provider_school.id)
+
+          existing[new_provider_school.id] = new_course.schools.create!(
+            provider_school: new_provider_school,
+            gias_school_id: new_provider_school.gias_school_id,
+          )
         end
+      end
+
+    private
+
+      # Every school belonging to the new provider is created before any course
+      # is copied, so load them once per provider rather than once per course.
+      def new_provider_schools(new_provider)
+        @new_provider_schools ||= {}
+        @new_provider_schools[new_provider.id] ||=
+          new_provider.schools.index_by { |school| [school.gias_school_id, school.site_code] }
       end
     end
   end

--- a/app/services/rollover/schools/legacy_course_copier.rb
+++ b/app/services/rollover/schools/legacy_course_copier.rb
@@ -8,8 +8,10 @@ module Rollover
       end
 
       def call(course:, new_provider:, new_course:)
+        lookup = new_provider_sites(new_provider)
+
         course.sites.each do |site|
-          new_site = new_provider.sites.find_by(code: site.code)
+          new_site = lookup[site.code]
           site_copier.call(new_site:, new_course:) if new_site.present?
         end
       end
@@ -17,6 +19,13 @@ module Rollover
     private
 
       attr_reader :site_copier
+
+      # Every site belonging to the new provider is created before any course is
+      # copied, so load them once per provider rather than once per course.
+      def new_provider_sites(new_provider)
+        @new_provider_sites ||= {}
+        @new_provider_sites[new_provider.id] ||= new_provider.sites.index_by(&:code)
+      end
     end
   end
 end

--- a/app/services/rollover/schools/provider_copier.rb
+++ b/app/services/rollover/schools/provider_copier.rb
@@ -4,8 +4,13 @@ module Rollover
   module Schools
     class ProviderCopier
       def execute(provider:, new_provider:)
+        existing = new_provider.schools.index_by { |school| [school.gias_school_id, school.site_code] }
+
         provider.schools.each do |provider_school|
-          new_provider.schools.find_or_create_by!(
+          key = [provider_school.gias_school_id, provider_school.site_code]
+          next if existing.key?(key)
+
+          existing[key] = new_provider.schools.create!(
             gias_school_id: provider_school.gias_school_id,
             site_code: provider_school.site_code,
           )

--- a/spec/models/concerns/touch_suppression_spec.rb
+++ b/spec/models/concerns/touch_suppression_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TouchSuppression do
+  it "is not suppressed by default" do
+    expect(described_class).not_to be_suppressed
+  end
+
+  it "suppresses within the block and restores afterwards" do
+    described_class.suppress do
+      expect(described_class).to be_suppressed
+    end
+
+    expect(described_class).not_to be_suppressed
+  end
+
+  it "restores when the block raises" do
+    expect { described_class.suppress { raise "boom" } }.to raise_error("boom")
+
+    expect(described_class).not_to be_suppressed
+  end
+
+  it "stays suppressed until the outermost block ends when nested" do
+    described_class.suppress do
+      described_class.suppress { nil }
+
+      expect(described_class).to be_suppressed
+    end
+
+    expect(described_class).not_to be_suppressed
+  end
+
+  describe "a suppressed record" do
+    let(:provider) { create(:provider) }
+    let(:site) { create(:site, provider:) }
+
+    it "does not touch its provider" do
+      site
+      provider.update_columns(changed_at: 2.years.ago)
+
+      described_class.suppress { site.update!(location_name: "Renamed") }
+
+      expect(provider.reload.changed_at).to be_within(1.minute).of(2.years.ago)
+    end
+
+    it "touches its provider when not suppressed" do
+      site
+      provider.update_columns(changed_at: 2.years.ago)
+
+      site.update!(location_name: "Renamed")
+
+      expect(provider.reload.changed_at).to be_within(1.minute).of(Time.zone.now)
+    end
+  end
+end

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -195,6 +195,36 @@ describe Providers::CopyToRecruitmentCycleService do
       expect(mocked_copy_course_service).to have_received(:execute).with(course: course, new_provider: new_provider)
     end
 
+    # Per-record touches are suppressed during the copy, so the parents are
+    # stamped once at the end instead. Newly created records get `changed_at`
+    # from Rails' timestamp handling, so the case that needs covering is a
+    # provider that already existed in the destination cycle.
+    context "when the provider already exists in the new recruitment cycle" do
+      let(:new_provider) do
+        create(:provider, recruitment_cycle: create(:recruitment_cycle, :previous), provider_code: provider.provider_code)
+      end
+      let(:new_recruitment_cycle) { create(:recruitment_cycle, :next, providers: [new_provider]) }
+
+      before do
+        new_recruitment_cycle # attaching the provider to it updates changed_at, so stamp it afterwards
+        new_provider.update_columns(changed_at: 2.years.ago)
+      end
+
+      it "stamps changed_at on the existing provider" do
+        service.execute(provider:, new_recruitment_cycle:)
+
+        expect(new_provider.reload.changed_at).to be_within(1.minute).of(Time.zone.now)
+      end
+
+      it "leaves the original provider untouched" do
+        provider.update_columns(changed_at: 2.years.ago)
+
+        service.execute(provider:, new_recruitment_cycle:)
+
+        expect(provider.reload.changed_at).to be_within(1.minute).of(2.years.ago)
+      end
+    end
+
     it "returns a hash of the counts of copied objects" do
       output = service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
 


### PR DESCRIPTION
## Context

Rollover runs many unnecessary queries N+1 and callbacks. We can optimise the service by removing these unnecessary queries.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Rollover completed successfully and  relatively quickly

<img width="1113" height="708" alt="image" src="https://github.com/user-attachments/assets/2b3e9c6e-db07-47e9-ab9f-5d7f8515e23c" />


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
