### PR TITLE
Update schools backfill to only run on cycles 2026 and later

### DIFF
--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -3,6 +3,10 @@
 module DataHub
   module SchoolsBackfill
     class Executor
+      # Only backfill the 2026 recruitment cycle onwards; earlier cycles are
+      # historic and are not being remodelled.
+      FROM_RECRUITMENT_CYCLE_YEAR = 2026
+
       def execute
         process_summary = DataHub::SchoolsBackfillProcessSummary.start!
 
@@ -41,8 +45,11 @@ module DataHub
           SELECT DISTINCT ON (site.provider_id, gias_school.id, site.code)
                  site.provider_id, gias_school.id, site.code, site.uuid, NOW(), NOW()
           FROM site
-          JOIN gias_school ON gias_school.urn = site.urn
-          WHERE site.site_type = 0
+          JOIN gias_school       ON gias_school.urn = site.urn
+          JOIN provider          ON provider.id = site.provider_id
+          JOIN recruitment_cycle ON recruitment_cycle.id = provider.recruitment_cycle_id
+          WHERE recruitment_cycle.year::int >= #{FROM_RECRUITMENT_CYCLE_YEAR}
+            AND site.site_type = 0
             AND site.discarded_at IS NULL
             AND site.urn IS NOT NULL
             AND site.urn <> ''
@@ -63,12 +70,15 @@ module DataHub
           SELECT DISTINCT ON (course_site.course_id, provider_school.id)
                  course_site.course_id, gias_school.id, provider_school.id, NOW(), NOW()
           FROM course_site
-          JOIN site            ON site.id = course_site.site_id
-          JOIN gias_school     ON gias_school.urn = site.urn
-          JOIN provider_school ON provider_school.provider_id = site.provider_id
-                              AND provider_school.gias_school_id = gias_school.id
-                              AND provider_school.site_code = site.code
-          WHERE site.site_type = 0
+          JOIN site              ON site.id = course_site.site_id
+          JOIN gias_school       ON gias_school.urn = site.urn
+          JOIN provider          ON provider.id = site.provider_id
+          JOIN recruitment_cycle ON recruitment_cycle.id = provider.recruitment_cycle_id
+          JOIN provider_school   ON provider_school.provider_id = site.provider_id
+                                AND provider_school.gias_school_id = gias_school.id
+                                AND provider_school.site_code = site.code
+          WHERE recruitment_cycle.year::int >= #{FROM_RECRUITMENT_CYCLE_YEAR}
+            AND site.site_type = 0
             AND site.discarded_at IS NULL
             AND site.urn IS NOT NULL
             AND site.urn <> ''
@@ -84,12 +94,15 @@ module DataHub
           SELECT DISTINCT ON (course_site.course_id, provider_school.id)
                  course_site.course_id, gias_school.id, provider_school.id, provider_school.site_code, NOW(), NOW()
           FROM course_site
-          JOIN site            ON site.id = course_site.site_id
-          JOIN gias_school     ON gias_school.urn = site.urn
-          JOIN provider_school ON provider_school.provider_id = site.provider_id
-                              AND provider_school.gias_school_id = gias_school.id
-                              AND provider_school.site_code = site.code
-          WHERE site.site_type = 0
+          JOIN site              ON site.id = course_site.site_id
+          JOIN gias_school       ON gias_school.urn = site.urn
+          JOIN provider          ON provider.id = site.provider_id
+          JOIN recruitment_cycle ON recruitment_cycle.id = provider.recruitment_cycle_id
+          JOIN provider_school   ON provider_school.provider_id = site.provider_id
+                                AND provider_school.gias_school_id = gias_school.id
+                                AND provider_school.site_code = site.code
+          WHERE recruitment_cycle.year::int >= #{FROM_RECRUITMENT_CYCLE_YEAR}
+            AND site.site_type = 0
             AND site.discarded_at IS NULL
             AND site.urn IS NOT NULL
             AND site.urn <> ''
@@ -115,8 +128,11 @@ module DataHub
                    ELSE 'urn_not_in_gias_school'
                  END AS reason
           FROM site
-          LEFT JOIN gias_school ON gias_school.urn = site.urn
-          WHERE site.site_type = 0
+          JOIN provider          ON provider.id = site.provider_id
+          JOIN recruitment_cycle ON recruitment_cycle.id = provider.recruitment_cycle_id
+          LEFT JOIN gias_school  ON gias_school.urn = site.urn
+          WHERE recruitment_cycle.year::int >= #{FROM_RECRUITMENT_CYCLE_YEAR}
+            AND site.site_type = 0
             AND site.discarded_at IS NULL
             AND (site.urn IS NULL OR site.urn = '' OR gias_school.id IS NULL)
           ORDER BY site.id
@@ -140,18 +156,22 @@ module DataHub
                    ELSE 'urn_not_in_gias_school'
                  END AS reason
           FROM course_site
+          JOIN course               ON course.id = course_site.course_id
+          JOIN provider             ON provider.id = course.provider_id
+          JOIN recruitment_cycle    ON recruitment_cycle.id = provider.recruitment_cycle_id
           LEFT JOIN site            ON site.id = course_site.site_id
           LEFT JOIN gias_school     ON gias_school.urn = site.urn
           LEFT JOIN provider_school ON provider_school.provider_id = site.provider_id
                                   AND provider_school.gias_school_id = gias_school.id
                                   AND provider_school.site_code = site.code
-          WHERE site.id IS NULL
+          WHERE recruitment_cycle.year::int >= #{FROM_RECRUITMENT_CYCLE_YEAR}
+            AND (site.id IS NULL
              OR site.site_type <> 0
              OR site.discarded_at IS NOT NULL
              OR site.urn IS NULL
              OR site.urn = ''
              OR gias_school.id IS NULL
-             OR provider_school.id IS NULL
+             OR provider_school.id IS NULL)
           ORDER BY course_site.course_id, course_site.site_id
         SQL
       end

--- a/spec/services/data_hub/schools_backfill/executor_spec.rb
+++ b/spec/services/data_hub/schools_backfill/executor_spec.rb
@@ -216,26 +216,44 @@ describe DataHub::SchoolsBackfill::Executor do
     end
 
     context "across multiple recruitment cycles" do
-      it "backfills sites and course_sites from every cycle" do
+      it "backfills the 2026 cycle onwards and ignores earlier cycles" do
         previous_cycle = create(:recruitment_cycle, :previous)
         current_cycle = find_or_create(:recruitment_cycle)
+        next_cycle = create(:recruitment_cycle, :next)
 
         previous_provider = create(:provider, recruitment_cycle: previous_cycle)
         current_provider = create(:provider, recruitment_cycle: current_cycle)
+        next_provider = create(:provider, recruitment_cycle: next_cycle)
         previous_gias_school = create(:gias_school, urn: "810008")
         current_gias_school = create(:gias_school, urn: "820008")
+        next_gias_school = create(:gias_school, urn: "830008")
 
         create(:site, provider: previous_provider, urn: previous_gias_school.urn, code: "P")
         create(:site, provider: current_provider, urn: current_gias_school.urn, code: "Q")
+        create(:site, provider: next_provider, urn: next_gias_school.urn, code: "R")
 
         executor.execute
 
         expect(
           Provider::School.where(provider_id: previous_provider.id, gias_school_id: previous_gias_school.id),
-        ).to exist
+        ).not_to exist
         expect(
           Provider::School.where(provider_id: current_provider.id, gias_school_id: current_gias_school.id),
         ).to exist
+        expect(
+          Provider::School.where(provider_id: next_provider.id, gias_school_id: next_gias_school.id),
+        ).to exist
+      end
+
+      it "does not report sites from earlier cycles as skipped" do
+        previous_cycle = create(:recruitment_cycle, :previous)
+        previous_provider = create(:provider, recruitment_cycle: previous_cycle)
+        site = create(:site, provider: previous_provider, urn: nil, code: "-")
+
+        summary = executor.execute
+
+        ids = summary.full_summary["skipped_sites"].map { |row| row["site_id"] }
+        expect(ids).not_to include(site.id)
       end
     end
   end


### PR DESCRIPTION
## Context

Update the Site => schools backfill migrator to only target sites from providers in the 2026 recruitment cycle and later. We have no interest in backfilling the schools for 2025 and earlier as their site data is poorly matched to gias schools.

It's unlikely that this will be run on the 2027 cycle, but it's not impossible.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
