### PR TITLE
Provider School Removal

### DIFF
--- a/app/components/courses/query_debug_header_component.html.erb
+++ b/app/components/courses/query_debug_header_component.html.erb
@@ -41,16 +41,20 @@
               <td class="govuk-table__cell"><%= result.name_and_code %></td>
               <td class="govuk-table__cell"><%= result.provider.name_and_code %></td>
               <td class="govuk-table__cell">
-                <%= govuk_link_to(
-                  result.location_name,
-                  "#{Settings.base_url}#{publish_provider_recruitment_cycle_school_path(
-                    result.provider.provider_code,
-                    result.provider.recruitment_cycle_year,
-                    school_uuid(result),
-                  )}",
-                  host: Settings.base_url,
-                  target: "_blank",
-                ) %>
+                <% if school_uuid(result).present? %>
+                  <%= govuk_link_to(
+                    result.location_name,
+                    "#{Settings.base_url}#{publish_provider_recruitment_cycle_school_path(
+                      result.provider.provider_code,
+                      result.provider.recruitment_cycle_year,
+                      school_uuid(result),
+                    )}",
+                    host: Settings.base_url,
+                    target: "_blank",
+                  ) %>
+                <% else %>
+                  <%= result.location_name %>
+                <% end %>
               </td>
               <td class="govuk-table__cell"><%= result.latitude %></td>
               <td class="govuk-table__cell"><%= result.longitude %></td>

--- a/app/components/courses/query_debug_header_component.html.erb
+++ b/app/components/courses/query_debug_header_component.html.erb
@@ -46,7 +46,7 @@
                   "#{Settings.base_url}#{publish_provider_recruitment_cycle_school_path(
                     result.provider.provider_code,
                     result.provider.recruitment_cycle_year,
-                    result.site_id,
+                    school_uuid(result),
                   )}",
                   host: Settings.base_url,
                   target: "_blank",

--- a/app/components/courses/query_debug_header_component.rb
+++ b/app/components/courses/query_debug_header_component.rb
@@ -48,5 +48,13 @@ module Courses
     def google_maps_direction_path_from_the_centre(result)
       "#{google_maps_directions_path}/#{result.latitude},#{result.longitude}"
     end
+
+    def school_uuid(result)
+      if result.provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
+        result.provider_school_uuid
+      else
+        result.site_uuid
+      end
+    end
   end
 end

--- a/app/components/publish/schools/newly_added_tag_component.rb
+++ b/app/components/publish/schools/newly_added_tag_component.rb
@@ -9,7 +9,7 @@ module Publish
       end
 
       def render?
-        @school.register_import? && @recruitment_cycle.rollover_period_2026?
+        @school.respond_to?(:register_import?) && @school.register_import? && @recruitment_cycle.rollover_period_2026?
       end
     end
   end

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Providers
     class SchoolsController < ApplicationController
-      before_action :site, only: %i[show delete]
+      before_action :site, only: %i[show delete destroy]
       before_action :reset_urn_form, only: %i[index]
 
       PER_PAGE = 20
@@ -27,11 +27,13 @@ module Publish
       def delete; end
 
       def destroy
-        school_removal.call
-        flash[:success] = "School removed"
-        redirect_to publish_provider_recruitment_cycle_schools_path
-      rescue ProviderSchools::Removal::CannotRemoveSchoolError
-        render :delete, status: :unprocessable_entity
+        if school_removal.call
+          flash[:success] = "School removed"
+          redirect_to publish_provider_recruitment_cycle_schools_path
+        else
+          redirect_to delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid),
+                      flash: { warning: t(".cannot_remove_school") }
+        end
       end
 
     private

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -9,7 +9,7 @@ module Publish
       PER_PAGE = 20
 
       def index
-        @pagy, @schools = pagy(provider.sites.order(:location_name), limit: PER_PAGE)
+        @pagy, @schools = pagy(ProviderSchools::Identity.visible_sites(provider:).order(:location_name), limit: PER_PAGE)
       end
 
       def show; end
@@ -27,15 +27,24 @@ module Publish
       def delete; end
 
       def destroy
-        site.destroy!
-        flash[:success] = "School removed"
-        redirect_to publish_provider_recruitment_cycle_schools_path
+        if school_removal.removable?
+          school_removal.call
+          flash[:success] = "School removed"
+          redirect_to publish_provider_recruitment_cycle_schools_path
+        else
+          render :delete, status: :unprocessable_entity
+        end
       end
 
     private
 
+      def school_removal
+        @school_removal ||= ProviderSchools::Removal.new(provider:, uuid: params[:uuid])
+      end
+      helper_method :school_removal
+
       def site
-        @site ||= provider.sites.find(params[:id])
+        @site ||= school_removal.site
       end
 
       def site_params(param_form_key)

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -9,7 +9,7 @@ module Publish
       PER_PAGE = 20
 
       def index
-        @pagy, @schools = pagy(ProviderSchools::Identity.visible_sites(provider:).order(:location_name), limit: PER_PAGE)
+        @pagy, @schools = pagy(ProviderSchools::Identity.ordered_school_scope(provider:), limit: PER_PAGE)
       end
 
       def show; end
@@ -27,13 +27,11 @@ module Publish
       def delete; end
 
       def destroy
-        if school_removal.removable?
-          school_removal.call
-          flash[:success] = "School removed"
-          redirect_to publish_provider_recruitment_cycle_schools_path
-        else
-          render :delete, status: :unprocessable_entity
-        end
+        school_removal.call
+        flash[:success] = "School removed"
+        redirect_to publish_provider_recruitment_cycle_schools_path
+      rescue ProviderSchools::Removal::CannotRemoveSchoolError
+        render :delete, status: :unprocessable_entity
       end
 
     private
@@ -44,7 +42,7 @@ module Publish
       helper_method :school_removal
 
       def site
-        @site ||= school_removal.site
+        @site ||= school_removal.school
       end
 
       def site_params(param_form_key)

--- a/app/controllers/support/providers/schools_controller.rb
+++ b/app/controllers/support/providers/schools_controller.rb
@@ -11,7 +11,7 @@ module Support
       PER_PAGE = 20
 
       def index
-        @pagy, @sites = pagy(provider.sites.order(:location_name), limit: PER_PAGE)
+        @pagy, @sites = pagy(ProviderSchools::Identity.visible_sites(provider:).order(:location_name), limit: PER_PAGE)
       end
 
       def show; end
@@ -30,9 +30,12 @@ module Support
       end
 
       def destroy
-        site.destroy!
-
-        redirect_to support_recruitment_cycle_provider_schools_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.deleted", resource: flash_resource) }
+        if school_removal.removable?
+          school_removal.call
+          redirect_to support_recruitment_cycle_provider_schools_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.deleted", resource: flash_resource) }
+        else
+          render :delete, status: :unprocessable_entity
+        end
       end
 
     private
@@ -59,12 +62,17 @@ module Support
       end
 
       def site
-        @site ||= provider.sites.find(params[:id])
+        @site ||= school_removal.site
       end
 
       def reset_urn_form
         URNForm.new(provider).clear_stash
       end
+
+      def school_removal
+        @school_removal ||= ProviderSchools::Removal.new(provider:, uuid: params[:uuid])
+      end
+      helper_method :school_removal
     end
   end
 end

--- a/app/controllers/support/providers/schools_controller.rb
+++ b/app/controllers/support/providers/schools_controller.rb
@@ -6,7 +6,7 @@ module Support
       before_action :build_site, only: %i[index create]
       before_action :new_form, only: %i[index]
       before_action :reset_urn_form, only: %i[index]
-      before_action :site, only: %i[show delete]
+      before_action :site, only: %i[show delete destroy]
 
       PER_PAGE = 20
 
@@ -30,10 +30,12 @@ module Support
       end
 
       def destroy
-        school_removal.call
-        redirect_to support_recruitment_cycle_provider_schools_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.deleted", resource: flash_resource) }
-      rescue ProviderSchools::Removal::CannotRemoveSchoolError
-        render :delete, status: :unprocessable_entity
+        if school_removal.call
+          redirect_to support_recruitment_cycle_provider_schools_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.deleted", resource: flash_resource) }
+        else
+          redirect_to delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site.uuid),
+                      flash: { warning: t(".cannot_remove_school") }
+        end
       end
 
     private

--- a/app/controllers/support/providers/schools_controller.rb
+++ b/app/controllers/support/providers/schools_controller.rb
@@ -11,7 +11,7 @@ module Support
       PER_PAGE = 20
 
       def index
-        @pagy, @sites = pagy(ProviderSchools::Identity.visible_sites(provider:).order(:location_name), limit: PER_PAGE)
+        @pagy, @sites = pagy(ProviderSchools::Identity.ordered_school_scope(provider:), limit: PER_PAGE)
       end
 
       def show; end
@@ -30,12 +30,10 @@ module Support
       end
 
       def destroy
-        if school_removal.removable?
-          school_removal.call
-          redirect_to support_recruitment_cycle_provider_schools_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.deleted", resource: flash_resource) }
-        else
-          render :delete, status: :unprocessable_entity
-        end
+        school_removal.call
+        redirect_to support_recruitment_cycle_provider_schools_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.deleted", resource: flash_resource) }
+      rescue ProviderSchools::Removal::CannotRemoveSchoolError
+        render :delete, status: :unprocessable_entity
       end
 
     private
@@ -62,7 +60,7 @@ module Support
       end
 
       def site
-        @site ||= school_removal.site
+        @site ||= school_removal.school
       end
 
       def reset_urn_form

--- a/app/decorators/provider/school_decorator.rb
+++ b/app/decorators/provider/school_decorator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Provider::SchoolDecorator < Draper::Decorator
+  include MarkdownHelper
+  delegate_all
+
+  def full_address_on_seperate_lines
+    smart_quotes(object.full_address("\n"))
+  end
+
+  def location_name
+    smart_quotes(object.location_name)
+  end
+end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -61,7 +61,7 @@ module BreadcrumbHelper
     path = publish_provider_recruitment_cycle_school_path(
       @provider.provider_code,
       @recruitment_cycle.year,
-      ProviderSchools::Identity.uuid_for(school: @site),
+      @site.uuid,
     )
     sites_breadcrumb.merge({ @site.location_name.dup => path })
   end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -61,7 +61,7 @@ module BreadcrumbHelper
     path = publish_provider_recruitment_cycle_school_path(
       @provider.provider_code,
       @recruitment_cycle.year,
-      ProviderSchools::Identity.uuid_for(site: @site),
+      ProviderSchools::Identity.uuid_for(school: @site),
     )
     sites_breadcrumb.merge({ @site.location_name.dup => path })
   end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -58,7 +58,11 @@ module BreadcrumbHelper
   end
 
   def edit_site_breadcrumb
-    path = edit_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @recruitment_cycle.year, @site.id)
+    path = publish_provider_recruitment_cycle_school_path(
+      @provider.provider_code,
+      @recruitment_cycle.year,
+      ProviderSchools::Identity.uuid_for(site: @site),
+    )
     sites_breadcrumb.merge({ @site.location_name.dup => path })
   end
 

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -15,6 +15,7 @@ class Provider::School < ApplicationRecord
   has_many :course_schools, class_name: "Course::School", inverse_of: :provider_school, dependent: :destroy
 
   delegate :recruitment_cycle, :provider_code, to: :provider, allow_nil: true
+  delegate :urn, :address1, :address2, :address3, :town, :postcode, to: :gias_school
 
   validates :site_code, presence: true
   validates :gias_school_id, uniqueness: { scope: %i[provider_id site_code] }
@@ -25,4 +26,23 @@ class Provider::School < ApplicationRecord
               message: :only_one_main_site_per_provider,
             },
             if: -> { site_code == MAIN_SITE_CODE }
+
+  def location_name
+    gias_school.name
+  end
+
+  def code
+    site_code
+  end
+
+  def full_address(join_on_separator = ", ")
+    [
+      gias_school.address1,
+      gias_school.address2,
+      gias_school.address3,
+      gias_school.town,
+      gias_school.county,
+      gias_school.postcode,
+    ].compact_blank.join(join_on_separator)
+  end
 end

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -28,7 +28,7 @@ class Provider::School < ApplicationRecord
             if: -> { site_code == MAIN_SITE_CODE }
 
   def location_name
-    return "#{gias_school.name} (Main Site)" if site_code == MAIN_SITE_CODE
+    return "#{gias_school.name} (Main site)" if site_code == MAIN_SITE_CODE
 
     gias_school.name
   end

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -28,6 +28,8 @@ class Provider::School < ApplicationRecord
             if: -> { site_code == MAIN_SITE_CODE }
 
   def location_name
+    return "#{gias_school.name} (Main Site)" if site_code == MAIN_SITE_CODE
+
     gias_school.name
   end
 

--- a/app/services/courses/nearest_school_query.rb
+++ b/app/services/courses/nearest_school_query.rb
@@ -13,6 +13,7 @@ module Courses
     def call
       subquery = Course
                  .joins(site_statuses: :site)
+                 .joins(school_identity_joins)
                  .where(id: @courses.map(&:id))
                  .where("site.longitude IS NOT NULL AND site.latitude IS NOT NULL")
                  .select(select_sql)
@@ -30,6 +31,8 @@ module Courses
         DISTINCT ON (course.id) course.id as course_id,
         course.*,
         site.id AS site_id,
+        site.uuid AS site_uuid,
+        provider_school.uuid AS provider_school_uuid,
         site.location_name,
         site.latitude,
         site.longitude,
@@ -37,6 +40,15 @@ module Courses
           ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
           ST_SetSRID(ST_MakePoint(#{Float(@longitude)}, #{Float(@latitude)}), 4326)
         ) / 1609.34 AS distance_to_search_location
+      SQL
+    end
+
+    def school_identity_joins
+      <<~SQL.squish
+        LEFT JOIN gias_school ON gias_school.urn = site.urn
+        LEFT JOIN provider_school ON provider_school.provider_id = site.provider_id
+          AND provider_school.gias_school_id = gias_school.id
+          AND provider_school.site_code = site.code
       SQL
     end
   end

--- a/app/services/provider_schools/identity.rb
+++ b/app/services/provider_schools/identity.rb
@@ -2,41 +2,34 @@
 
 module ProviderSchools
   class Identity
-    def self.uuid_for(site:)
-      new(provider: site.provider).uuid_for(site:)
+    def self.uuid_for(school:)
+      new(provider: school.provider).uuid_for(school:)
     end
 
-    def self.visible_sites(provider:)
-      new(provider:).visible_sites
+    def self.ordered_school_scope(provider:)
+      new(provider:).ordered_school_scope
     end
 
     def initialize(provider:)
       @provider = provider
     end
 
-    def uuid_for(site:)
-      schools_remodel_cycle? ? provider_school_for(site:).uuid : site.uuid
+    def uuid_for(school:)
+      school.uuid
     end
 
-    def visible_sites
-      return provider.sites unless schools_remodel_cycle?
-
-      provider
-        .sites
-        .joins("INNER JOIN gias_school ON gias_school.urn = site.urn")
-        .joins(
-          "INNER JOIN provider_school ON provider_school.provider_id = site.provider_id " \
-          "AND provider_school.gias_school_id = gias_school.id " \
-          "AND provider_school.site_code = site.code",
-        )
+    def school_scope
+      after_schools_remodel_cycle? ? provider.schools.includes(:gias_school) : provider.sites
     end
 
-    def site_for(uuid:)
-      if schools_remodel_cycle?
-        site_for_provider_school(provider_school: provider_school_for(uuid:))
-      else
-        provider.sites.find_by!(uuid:)
-      end
+    def ordered_school_scope
+      return provider.sites.order(:location_name) unless after_schools_remodel_cycle?
+
+      provider.schools.joins(:gias_school).includes(:gias_school).order("gias_school.name")
+    end
+
+    def school_for(uuid:)
+      after_schools_remodel_cycle? ? provider.schools.find_by!(uuid:) : provider.sites.find_by!(uuid:)
     end
 
     def provider_school_for(site: nil, uuid: nil)
@@ -48,16 +41,12 @@ module ProviderSchools
         .find_by!(gias_school: { urn: site.urn }, site_code: site.code)
     end
 
-    def schools_remodel_cycle?
+    def after_schools_remodel_cycle?
       provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
     end
 
   private
 
     attr_reader :provider
-
-    def site_for_provider_school(provider_school:)
-      provider.sites.find_by!(urn: provider_school.gias_school.urn, code: provider_school.site_code)
-    end
   end
 end

--- a/app/services/provider_schools/identity.rb
+++ b/app/services/provider_schools/identity.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module ProviderSchools
+  # This service determines which model should be used when creating, removing and in some instances viewing schools.
+  # The legacy data model uses Site, while the new data model uses Provider::School.
+  # During the rollover, both models are written to and their UUIDs may diverge, so we need a way to switch to the new data model.
+  # Because Publish supports both the old and new recruitment cycles during the rollover, this switch must be based on the recruitment cycle rather than a traditional feature flag.
   class Identity
     def self.ordered_school_scope(provider:)
       new(provider:).ordered_school_scope
@@ -19,7 +23,11 @@ module ProviderSchools
     end
 
     def school_for(uuid:)
-      after_schools_remodel_cycle? ? provider.schools.find_by!(uuid:) : provider.sites.find_by!(uuid:)
+      if after_schools_remodel_cycle?
+        provider.schools.find_by!(uuid:)
+      else
+        provider.sites.find_by!(uuid:)
+      end
     end
 
     def provider_school_for(site:)

--- a/app/services/provider_schools/identity.rb
+++ b/app/services/provider_schools/identity.rb
@@ -2,20 +2,12 @@
 
 module ProviderSchools
   class Identity
-    def self.uuid_for(school:)
-      new(provider: school.provider).uuid_for(school:)
-    end
-
     def self.ordered_school_scope(provider:)
       new(provider:).ordered_school_scope
     end
 
     def initialize(provider:)
       @provider = provider
-    end
-
-    def uuid_for(school:)
-      school.uuid
     end
 
     def school_scope

--- a/app/services/provider_schools/identity.rb
+++ b/app/services/provider_schools/identity.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module ProviderSchools
+  class Identity
+    def self.uuid_for(site:)
+      new(provider: site.provider).uuid_for(site:)
+    end
+
+    def self.visible_sites(provider:)
+      new(provider:).visible_sites
+    end
+
+    def initialize(provider:)
+      @provider = provider
+    end
+
+    def uuid_for(site:)
+      schools_remodel_cycle? ? provider_school_for(site:).uuid : site.uuid
+    end
+
+    def visible_sites
+      return provider.sites unless schools_remodel_cycle?
+
+      provider
+        .sites
+        .joins("INNER JOIN gias_school ON gias_school.urn = site.urn")
+        .joins(
+          "INNER JOIN provider_school ON provider_school.provider_id = site.provider_id " \
+          "AND provider_school.gias_school_id = gias_school.id " \
+          "AND provider_school.site_code = site.code",
+        )
+    end
+
+    def site_for(uuid:)
+      if schools_remodel_cycle?
+        site_for_provider_school(provider_school: provider_school_for(uuid:))
+      else
+        provider.sites.find_by!(uuid:)
+      end
+    end
+
+    def provider_school_for(site: nil, uuid: nil)
+      return provider.schools.find_by!(uuid:) if uuid.present?
+
+      provider
+        .schools
+        .joins(:gias_school)
+        .find_by!(gias_school: { urn: site.urn }, site_code: site.code)
+    end
+
+    def schools_remodel_cycle?
+      provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
+    end
+
+  private
+
+    attr_reader :provider
+
+    def site_for_provider_school(provider_school:)
+      provider.sites.find_by!(urn: provider_school.gias_school.urn, code: provider_school.site_code)
+    end
+  end
+end

--- a/app/services/provider_schools/identity.rb
+++ b/app/services/provider_schools/identity.rb
@@ -10,23 +10,19 @@ module ProviderSchools
       @provider = provider
     end
 
-    def school_scope
-      after_schools_remodel_cycle? ? provider.schools.includes(:gias_school) : provider.sites
-    end
-
     def ordered_school_scope
-      return provider.sites.order(:location_name) unless after_schools_remodel_cycle?
-
-      provider.schools.joins(:gias_school).includes(:gias_school).order("gias_school.name")
+      if after_schools_remodel_cycle?
+        provider.schools.joins(:gias_school).includes(:gias_school).order("gias_school.name")
+      else
+        provider.sites.order(:location_name)
+      end
     end
 
     def school_for(uuid:)
       after_schools_remodel_cycle? ? provider.schools.find_by!(uuid:) : provider.sites.find_by!(uuid:)
     end
 
-    def provider_school_for(site: nil, uuid: nil)
-      return provider.schools.find_by!(uuid:) if uuid.present?
-
+    def provider_school_for(site:)
       provider
         .schools
         .joins(:gias_school)

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -49,7 +49,7 @@ module ProviderSchools
     end
 
     def uuid_for_path
-      identity.uuid_for(school:)
+      school.uuid
     end
 
     def removable?

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -70,7 +70,7 @@ module ProviderSchools
 
     def destroy_records!
       provider_school.destroy!
-      site.destroy! if after_schools_remodel_cycle?
+      site.destroy! unless after_schools_remodel_cycle?
     end
 
     def provider_school_course_schools_empty?

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ProviderSchools
+  class Removal
+    class CannotRemoveSchoolError < StandardError; end
+
+    delegate :schools_remodel_cycle?, to: :identity
+
+    def initialize(provider:, uuid:)
+      @provider = provider
+      @uuid = uuid
+      @identity = Identity.new(provider:)
+    end
+
+    def call
+      raise CannotRemoveSchoolError unless removable?
+
+      ActiveRecord::Base.transaction do
+        if schools_remodel_cycle?
+          provider_school.destroy!
+        else
+          provider_school&.destroy!
+          site.destroy!
+        end
+      end
+    end
+
+    def site
+      @site ||= identity.site_for(uuid:)
+    end
+
+    def provider_school
+      @provider_school ||= if schools_remodel_cycle?
+                             identity.provider_school_for(uuid:)
+                           else
+                             identity.provider_school_for(site:)
+                           end
+    rescue ActiveRecord::RecordNotFound
+      raise if schools_remodel_cycle?
+
+      nil
+    end
+
+    def uuid_for_path
+      schools_remodel_cycle? ? provider_school.uuid : identity.uuid_for(site:)
+    end
+
+    def removable?
+      if schools_remodel_cycle?
+        provider_school.course_schools.none?
+      else
+        site.has_no_course? && provider_school_course_schools_empty?
+      end
+    end
+
+  private
+
+    attr_reader :provider, :uuid, :identity
+
+    def provider_school_course_schools_empty?
+      provider_school.nil? || provider_school.course_schools.none?
+    end
+  end
+end

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -2,8 +2,6 @@
 
 module ProviderSchools
   class Removal
-    class CannotRemoveSchoolError < StandardError; end
-
     delegate :after_schools_remodel_cycle?, to: :identity
 
     def initialize(provider:, uuid:)
@@ -16,14 +14,10 @@ module ProviderSchools
       ActiveRecord::Base.transaction do
         if provider_school.present?
           provider_school.with_lock do
-            raise CannotRemoveSchoolError unless removable?
-
-            destroy_records!
+            destroy_records_if_removable!
           end
         else
-          raise CannotRemoveSchoolError unless removable?
-
-          site.destroy!
+          destroy_site_if_removable!
         end
       end
     end
@@ -48,10 +42,6 @@ module ProviderSchools
       nil
     end
 
-    def uuid_for_path
-      school.uuid
-    end
-
     def removable?
       if after_schools_remodel_cycle?
         !provider_school.course_schools.exists?
@@ -63,6 +53,20 @@ module ProviderSchools
   private
 
     attr_reader :provider, :uuid, :identity
+
+    def destroy_records_if_removable!
+      return false unless removable?
+
+      destroy_records!
+      true
+    end
+
+    def destroy_site_if_removable!
+      return false unless removable?
+
+      site.destroy!
+      true
+    end
 
     def destroy_records!
       if after_schools_remodel_cycle?

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -69,12 +69,8 @@ module ProviderSchools
     end
 
     def destroy_records!
-      if after_schools_remodel_cycle?
-        provider_school.destroy!
-      else
-        provider_school.destroy!
-        site.destroy!
-      end
+      provider_school.destroy!
+      site.destroy! if after_schools_remodel_cycle?
     end
 
     def provider_school_course_schools_empty?

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -4,7 +4,7 @@ module ProviderSchools
   class Removal
     class CannotRemoveSchoolError < StandardError; end
 
-    delegate :schools_remodel_cycle?, to: :identity
+    delegate :after_schools_remodel_cycle?, to: :identity
 
     def initialize(provider:, uuid:)
       @provider = provider
@@ -13,41 +13,48 @@ module ProviderSchools
     end
 
     def call
-      raise CannotRemoveSchoolError unless removable?
-
       ActiveRecord::Base.transaction do
-        if schools_remodel_cycle?
-          provider_school.destroy!
+        if provider_school.present?
+          provider_school.with_lock do
+            raise CannotRemoveSchoolError unless removable?
+
+            destroy_records!
+          end
         else
-          provider_school&.destroy!
+          raise CannotRemoveSchoolError unless removable?
+
           site.destroy!
         end
       end
     end
 
     def site
-      @site ||= identity.site_for(uuid:)
+      @site ||= school if school.is_a?(Site)
+    end
+
+    def school
+      @school ||= identity.school_for(uuid:)
     end
 
     def provider_school
-      @provider_school ||= if schools_remodel_cycle?
-                             identity.provider_school_for(uuid:)
+      @provider_school ||= if after_schools_remodel_cycle?
+                             school
                            else
                              identity.provider_school_for(site:)
                            end
     rescue ActiveRecord::RecordNotFound
-      raise if schools_remodel_cycle?
+      raise if after_schools_remodel_cycle?
 
       nil
     end
 
     def uuid_for_path
-      schools_remodel_cycle? ? provider_school.uuid : identity.uuid_for(site:)
+      identity.uuid_for(school:)
     end
 
     def removable?
-      if schools_remodel_cycle?
-        provider_school.course_schools.none?
+      if after_schools_remodel_cycle?
+        !provider_school.course_schools.exists?
       else
         site.has_no_course? && provider_school_course_schools_empty?
       end
@@ -57,8 +64,17 @@ module ProviderSchools
 
     attr_reader :provider, :uuid, :identity
 
+    def destroy_records!
+      if after_schools_remodel_cycle?
+        provider_school.destroy!
+      else
+        provider_school.destroy!
+        site.destroy!
+      end
+    end
+
     def provider_school_course_schools_empty?
-      provider_school.nil? || provider_school.course_schools.none?
+      provider_school.nil? || !provider_school.course_schools.exists?
     end
   end
 end

--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row school-row">
   <th class="govuk-table__header name" scope="row">
-    <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.id) %>
+    <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, ProviderSchools::Identity.uuid_for(site: school)) %>
 
     <%= render Publish::Schools::NewlyAddedTagComponent.new(school:) %>
   </th>

--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row school-row">
   <th class="govuk-table__header name" scope="row">
-    <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, ProviderSchools::Identity.uuid_for(school: school)) %>
+    <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid) %>
 
     <%= render Publish::Schools::NewlyAddedTagComponent.new(school:) %>
   </th>

--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row school-row">
   <th class="govuk-table__header name" scope="row">
-    <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, ProviderSchools::Identity.uuid_for(site: school)) %>
+    <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, ProviderSchools::Identity.uuid_for(school: school)) %>
 
     <%= render Publish::Schools::NewlyAddedTagComponent.new(school:) %>
   </th>

--- a/app/views/publish/providers/schools/delete.html.erb
+++ b/app/views/publish/providers/schools/delete.html.erb
@@ -1,17 +1,17 @@
 <%= render PageTitle.new(title: "publish.providers.schools.delete") %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id)) %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, school_removal.uuid_for_path)) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l"><%= @site.location_name %></span>
-      <% if @site.has_no_course? %>
+      <% if school_removal.removable? %>
         <%= t("components.page_titles.publish.providers.schools.delete") %>
         </h1>
         <%= govuk_button_to "Remove school",
-          delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id),
+          delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, school_removal.uuid_for_path),
           method: :delete,
           class: "govuk-button--warning" %>
       <% else %>
@@ -25,7 +25,7 @@
       </p>
     <% end %>
     <p class="govuk-body">
-      <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id)) %>
+      <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, school_removal.uuid_for_path)) %>
     </p>
   </div>
 </div>

--- a/app/views/publish/providers/schools/delete.html.erb
+++ b/app/views/publish/providers/schools/delete.html.erb
@@ -1,6 +1,6 @@
 <%= render PageTitle.new(title: "publish.providers.schools.delete") %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, school_removal.uuid_for_path)) %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid)) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -11,7 +11,7 @@
         <%= t("components.page_titles.publish.providers.schools.delete") %>
         </h1>
         <%= govuk_button_to "Remove school",
-          delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, school_removal.uuid_for_path),
+          delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid),
           method: :delete,
           class: "govuk-button--warning" %>
       <% else %>
@@ -25,7 +25,7 @@
       </p>
     <% end %>
     <p class="govuk-body">
-      <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, school_removal.uuid_for_path)) %>
+        <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid)) %>
     </p>
   </div>
 </div>

--- a/app/views/publish/providers/schools/show.html.erb
+++ b/app/views/publish/providers/schools/show.html.erb
@@ -27,7 +27,7 @@
             end
           end %>
       <p class="govuk-body">
-        <%= govuk_link_to t(".remove", resource: "location"), delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, school_removal.uuid_for_path), class: "app-link--destructive" %>
+        <%= govuk_link_to t(".remove", resource: "location"), delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid), class: "app-link--destructive" %>
       </p>
     </fieldset>
   </div>

--- a/app/views/publish/providers/schools/show.html.erb
+++ b/app/views/publish/providers/schools/show.html.erb
@@ -27,7 +27,7 @@
             end
           end %>
       <p class="govuk-body">
-        <%= govuk_link_to t(".remove", resource: "location"), delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id), class: "app-link--destructive" %>
+        <%= govuk_link_to t(".remove", resource: "location"), delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, school_removal.uuid_for_path), class: "app-link--destructive" %>
       </p>
     </fieldset>
   </div>

--- a/app/views/support/providers/schools/delete.html.erb
+++ b/app/views/support/providers/schools/delete.html.erb
@@ -1,6 +1,6 @@
 <%= render PageTitle.new(title: "support.providers.schools.delete") %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, school_removal.uuid_for_path)) %>
+  <%= govuk_back_link_to(support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site.uuid)) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -11,7 +11,7 @@
     </h1>
     <% if school_removal.removable? %>
       <%= govuk_button_to "Remove school",
-          delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, school_removal.uuid_for_path),
+          delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site.uuid),
           method: :delete,
           class: "govuk-button--warning" %>
     <% else %>
@@ -21,7 +21,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to("Cancel", support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, school_removal.uuid_for_path)) %>
+      <%= govuk_link_to("Cancel", support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site.uuid)) %>
     </p>
   </div>
 </div>

--- a/app/views/support/providers/schools/delete.html.erb
+++ b/app/views/support/providers/schools/delete.html.erb
@@ -1,6 +1,6 @@
 <%= render PageTitle.new(title: "support.providers.schools.delete") %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site)) %>
+  <%= govuk_back_link_to(support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, school_removal.uuid_for_path)) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -9,13 +9,19 @@
       <span class="govuk-caption-l"><%= "#{@site.location_name} - #{@provider.decorate.name_and_code}" %></span>
         <%= t("components.page_titles.support.providers.schools.delete") %>
     </h1>
-    <%= govuk_button_to "Remove school",
-        delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site),
-        method: :delete,
-        class: "govuk-button--warning" %>
+    <% if school_removal.removable? %>
+      <%= govuk_button_to "Remove school",
+          delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, school_removal.uuid_for_path),
+          method: :delete,
+          class: "govuk-button--warning" %>
+    <% else %>
+      <p class="govuk-body">
+        <%= "#{@site.location_name} is a school for courses run by #{@provider.provider_name}." %>
+      </p>
+    <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to("Cancel", support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site)) %>
+      <%= govuk_link_to("Cancel", support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, school_removal.uuid_for_path)) %>
     </p>
   </div>
 </div>

--- a/app/views/support/providers/schools/index.html.erb
+++ b/app/views/support/providers/schools/index.html.erb
@@ -39,7 +39,7 @@
         <tr class="govuk-table__row school-row">
           <td class="govuk-table__cell name">
             <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-              <%= govuk_link_to site.location_name, support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, ProviderSchools::Identity.uuid_for(site: site)) %>
+              <%= govuk_link_to site.location_name, support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, ProviderSchools::Identity.uuid_for(school: site)) %>
             </span>
           </td>
           <td class="govuk-table__cell code">

--- a/app/views/support/providers/schools/index.html.erb
+++ b/app/views/support/providers/schools/index.html.erb
@@ -39,7 +39,7 @@
         <tr class="govuk-table__row school-row">
           <td class="govuk-table__cell name">
             <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-              <%= govuk_link_to site.location_name, support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, ProviderSchools::Identity.uuid_for(school: site)) %>
+              <%= govuk_link_to site.location_name, support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, site.uuid) %>
             </span>
           </td>
           <td class="govuk-table__cell code">

--- a/app/views/support/providers/schools/index.html.erb
+++ b/app/views/support/providers/schools/index.html.erb
@@ -39,7 +39,7 @@
         <tr class="govuk-table__row school-row">
           <td class="govuk-table__cell name">
             <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-              <%= govuk_link_to site.location_name, support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, site) %>
+              <%= govuk_link_to site.location_name, support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, ProviderSchools::Identity.uuid_for(site: site)) %>
             </span>
           </td>
           <td class="govuk-table__cell code">

--- a/app/views/support/providers/schools/show.html.erb
+++ b/app/views/support/providers/schools/show.html.erb
@@ -28,7 +28,7 @@
 
           <p class="govuk-body">
             <%= govuk_link_to t("support.actions.remove_school", resource: "location"),
-                delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, school_removal.uuid_for_path),
+                delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site.uuid),
                 class: "app-link--destructive" %>
           </p>
     </fieldset>

--- a/app/views/support/providers/schools/show.html.erb
+++ b/app/views/support/providers/schools/show.html.erb
@@ -28,7 +28,7 @@
 
           <p class="govuk-body">
             <%= govuk_link_to t("support.actions.remove_school", resource: "location"),
-                delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, @site),
+                delete_support_recruitment_cycle_provider_school_path(@provider.recruitment_cycle_year, @provider, school_removal.uuid_for_path),
                 class: "app-link--destructive" %>
           </p>
     </fieldset>

--- a/config/locales/en/publish/providers/schools.yml
+++ b/config/locales/en/publish/providers/schools.yml
@@ -15,3 +15,5 @@ en:
           urn: URN
           address: Address
           remove: Remove school
+        destroy:
+          cannot_remove_school: This school could not be removed because it is used by a course

--- a/config/locales/en/support.yml
+++ b/config/locales/en/support.yml
@@ -12,6 +12,8 @@ en:
         multiple: # file
         checks: # file
         search: # file
+        destroy:
+          cannot_remove_school: This school could not be removed because it is used by a course
       users:
         first_name: "First name"
         last_name: "Last name"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -347,7 +347,7 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
 
           resource :check, only: %i[show update]
         end
-        resources :schools, only: %i[index create show destroy] do
+        resources :schools, param: :uuid, only: %i[index create show destroy] do
           member do
             get :delete
             delete :delete, to: "schools#destroy"

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -52,7 +52,7 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
       namespace :schools, module: "providers/schools" do
         resource :check, only: %i[show update]
       end
-      resources :schools, except: %i[new edit update], module: "providers" do
+      resources :schools, param: :uuid, except: %i[new edit update], module: "providers" do
         member do
           get :delete
           delete :delete, to: "schools#destroy"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,8 @@ environment:
 
 support_email: becomingateacher@digital.education.gov.uk
 
+schools_remodel_cycle_year: 2026
+
 # The canonical URL of the Find service
 find_url: https://find.localhost
 

--- a/spec/components/courses/query_debug_header_component_spec.rb
+++ b/spec/components/courses/query_debug_header_component_spec.rb
@@ -100,4 +100,60 @@ RSpec.describe Courses::QueryDebugHeaderComponent, type: :component do
       expect(query_debug_header_component_content).not_to include("longitude")
     end
   end
+
+  context "when rendering nearest school links" do
+    let(:debug) { true }
+    let(:environment_name) { "qa" }
+    let(:latitude) { 51.5 }
+    let(:longitude) { -0.1 }
+    let(:results) { [course] }
+    let(:course) { create(:course, provider:) }
+    let(:site) do
+      create(
+        :site,
+        provider:,
+        urn: gias_school.urn,
+        code: site_code,
+        location_name: gias_school.name,
+        latitude:,
+        longitude:,
+      )
+    end
+    let(:site_code) { "A" }
+    let(:gias_school) { create(:gias_school, name: "Debug School") }
+
+    before do
+      create(:site_status, :findable, course:, site:)
+    end
+
+    context "in the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: 2026) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+
+      it "links to the school using the legacy site uuid" do
+        render_inline(component)
+
+        expect(page.find_link("Debug School", visible: :all)[:href]).to include("/schools/#{site.uuid}")
+      end
+    end
+
+    context "after the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: 2027) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+
+      it "links to the school using the provider school uuid" do
+        provider_school = create(:provider_school, provider:, gias_school:, site_code:)
+        render_inline(component)
+
+        expect(page.find_link("Debug School", visible: :all)[:href]).to include("/schools/#{provider_school.uuid}")
+      end
+
+      it "renders the school name without a school link when the provider school uuid is missing" do
+        render_inline(component)
+
+        expect(page).to have_content("Debug School")
+        expect(page).not_to have_link("Debug School", visible: :all)
+      end
+    end
+  end
 end

--- a/spec/components/publish/schools/newly_added_tag_component_spec.rb
+++ b/spec/components/publish/schools/newly_added_tag_component_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Publish::Schools::NewlyAddedTagComponent, type: :component do
+  it "does not render for provider school rows from the new model" do
+    provider_school = create(:provider_school)
+
+    render_inline(described_class.new(school: provider_school))
+
+    expect(page).not_to have_css(".newly-added-tag")
+  end
+end

--- a/spec/services/courses/nearest_school_query_spec.rb
+++ b/spec/services/courses/nearest_school_query_spec.rb
@@ -90,6 +90,13 @@ RSpec.describe Courses::NearestSchoolQuery do
     expect(result.provider_school_uuid).to eq(london_provider.schools.find_by!(gias_school: london_gias_school).uuid)
   end
 
+  it "returns a nil provider school uuid when there is no matching provider school" do
+    result = results.find { |course| course.id == manchester_course.id }
+
+    expect(result.site_uuid).to eq(manchester_school.uuid)
+    expect(result.provider_school_uuid).to be_nil
+  end
+
   it "orders results by distance from search location" do
     distances = results.map(&:distance_to_search_location)
     expect(distances).to eq(distances.sort)

--- a/spec/services/courses/nearest_school_query_spec.rb
+++ b/spec/services/courses/nearest_school_query_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Courses::NearestSchoolQuery do
   let(:edinburgh) { build(:location, :edinburgh) }
 
   let(:london_school) do
-    create(:site, latitude: london.latitude, longitude: london.longitude)
+    create(:site, provider: london_provider, urn: london_gias_school.urn, latitude: london.latitude, longitude: london.longitude)
   end
   let(:manchester_school) do
     create(:site, latitude: manchester.latitude, longitude: manchester.longitude)
@@ -62,8 +62,13 @@ RSpec.describe Courses::NearestSchoolQuery do
   let(:london_provider) { create(:provider, provider_name: "London Provider") }
   let(:manchester_provider) { create(:provider, provider_name: "Manchester Provider") }
   let(:cambridge_provider) { create(:provider, provider_name: "Cambridge Provider") }
+  let(:london_gias_school) { create(:gias_school) }
 
   let(:courses) { [london_course, manchester_course, cambridge_course] }
+
+  before do
+    create(:provider_school, provider: london_provider, gias_school: london_gias_school, site_code: london_school.code)
+  end
 
   it "returns only the nearest school for each course" do
     expect(results).to match_collection(
@@ -76,6 +81,13 @@ RSpec.describe Courses::NearestSchoolQuery do
     )
 
     expect(results.map(&:site_id)).to contain_exactly(london_school.id, cambridge_school.id, manchester_school.id)
+  end
+
+  it "returns the legacy site and provider school uuids for the nearest school" do
+    result = results.find { |course| course.id == london_course.id }
+
+    expect(result.site_uuid).to eq(london_school.uuid)
+    expect(result.provider_school_uuid).to eq(london_provider.schools.find_by!(gias_school: london_gias_school).uuid)
   end
 
   it "orders results by distance from search location" do

--- a/spec/services/provider_schools/identity_spec.rb
+++ b/spec/services/provider_schools/identity_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProviderSchools::Identity do
+  let(:remodel_cycle_year) { 2026 }
+  let(:gias_school) { create(:gias_school, urn: "123456") }
+  let(:site_uuid) { "11111111-1111-4111-8111-111111111111" }
+  let(:provider_school_uuid) { "22222222-2222-4222-8222-222222222222" }
+
+  before do
+    allow(Settings).to receive(:schools_remodel_cycle_year).and_return(remodel_cycle_year)
+  end
+
+  describe ".uuid_for" do
+    context "when the provider is in the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+
+      before do
+        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: provider_school_uuid)
+      end
+
+      it "uses the legacy site uuid" do
+        expect(described_class.uuid_for(site:)).to eq(site_uuid)
+      end
+    end
+
+    context "when the provider is after the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+
+      before do
+        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: provider_school_uuid)
+      end
+
+      it "uses the provider school uuid" do
+        expect(described_class.uuid_for(site:)).to eq(provider_school_uuid)
+      end
+    end
+  end
+
+  describe ".visible_sites" do
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
+    let!(:visible_site) { create(:site, provider:, urn: gias_school.urn, code: "A") }
+    let!(:removed_site) { create(:site, provider:, urn: "654321", code: "B") }
+
+    before do
+      create(:provider_school, provider:, gias_school:, site_code: visible_site.code)
+    end
+
+    it "only returns sites with a matching provider school after the remodel cycle" do
+      expect(described_class.visible_sites(provider:)).to contain_exactly(visible_site)
+    end
+  end
+
+  describe "#site_for" do
+    context "when the provider is in the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+
+      it "finds the site by site uuid" do
+        expect(described_class.new(provider:).site_for(uuid: site_uuid)).to eq(site)
+      end
+    end
+
+    context "when the provider is after the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+
+      before do
+        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: provider_school_uuid)
+      end
+
+      it "finds the legacy site via the provider school uuid" do
+        expect(described_class.new(provider:).site_for(uuid: provider_school_uuid)).to eq(site)
+      end
+    end
+  end
+end

--- a/spec/services/provider_schools/identity_spec.rb
+++ b/spec/services/provider_schools/identity_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe ProviderSchools::Identity do
   let(:remodel_cycle_year) { 2026 }
   let(:gias_school) { create(:gias_school, urn: "123456") }
-  let(:site_uuid) { "11111111-1111-4111-8111-111111111111" }
-  let(:provider_school_uuid) { "22222222-2222-4222-8222-222222222222" }
+  let(:site_uuid) { Faker::Internet.uuid }
+  let(:provider_school_uuid) { Faker::Internet.uuid }
 
   before do
     allow(Settings).to receive(:schools_remodel_cycle_year).and_return(remodel_cycle_year)

--- a/spec/services/provider_schools/identity_spec.rb
+++ b/spec/services/provider_schools/identity_spec.rb
@@ -12,32 +12,6 @@ RSpec.describe ProviderSchools::Identity do
     allow(Settings).to receive(:schools_remodel_cycle_year).and_return(remodel_cycle_year)
   end
 
-  describe ".uuid_for" do
-    context "when the provider is in the schools remodel cycle" do
-      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
-      let(:provider) { create(:provider, recruitment_cycle:) }
-      let(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
-
-      before do
-        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: provider_school_uuid)
-      end
-
-      it "uses the legacy site uuid" do
-        expect(described_class.uuid_for(school: site)).to eq(site_uuid)
-      end
-    end
-
-    context "when the provider is after the schools remodel cycle" do
-      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
-      let(:provider) { create(:provider, recruitment_cycle:) }
-      let(:provider_school) { create(:provider_school, provider:, gias_school:, uuid: provider_school_uuid) }
-
-      it "uses the provider school uuid" do
-        expect(described_class.uuid_for(school: provider_school)).to eq(provider_school_uuid)
-      end
-    end
-  end
-
   describe ".ordered_school_scope" do
     let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
     let(:provider) { create(:provider, recruitment_cycle:) }

--- a/spec/services/provider_schools/identity_spec.rb
+++ b/spec/services/provider_schools/identity_spec.rb
@@ -23,62 +23,50 @@ RSpec.describe ProviderSchools::Identity do
       end
 
       it "uses the legacy site uuid" do
-        expect(described_class.uuid_for(site:)).to eq(site_uuid)
+        expect(described_class.uuid_for(school: site)).to eq(site_uuid)
       end
     end
 
     context "when the provider is after the schools remodel cycle" do
       let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
       let(:provider) { create(:provider, recruitment_cycle:) }
-      let(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
-
-      before do
-        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: provider_school_uuid)
-      end
+      let(:provider_school) { create(:provider_school, provider:, gias_school:, uuid: provider_school_uuid) }
 
       it "uses the provider school uuid" do
-        expect(described_class.uuid_for(site:)).to eq(provider_school_uuid)
+        expect(described_class.uuid_for(school: provider_school)).to eq(provider_school_uuid)
       end
     end
   end
 
-  describe ".visible_sites" do
+  describe ".ordered_school_scope" do
     let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
     let(:provider) { create(:provider, recruitment_cycle:) }
-    let!(:visible_site) { create(:site, provider:, urn: gias_school.urn, code: "A") }
-    let!(:removed_site) { create(:site, provider:, urn: "654321", code: "B") }
+    let!(:legacy_site) { create(:site, provider:, urn: "654321", code: "B") }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:) }
 
-    before do
-      create(:provider_school, provider:, gias_school:, site_code: visible_site.code)
-    end
-
-    it "only returns sites with a matching provider school after the remodel cycle" do
-      expect(described_class.visible_sites(provider:)).to contain_exactly(visible_site)
+    it "returns provider schools after the remodel cycle and does not require a matching site" do
+      expect(described_class.ordered_school_scope(provider:)).to contain_exactly(provider_school)
     end
   end
 
-  describe "#site_for" do
+  describe "#school_for" do
     context "when the provider is in the schools remodel cycle" do
       let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
       let(:provider) { create(:provider, recruitment_cycle:) }
       let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
 
       it "finds the site by site uuid" do
-        expect(described_class.new(provider:).site_for(uuid: site_uuid)).to eq(site)
+        expect(described_class.new(provider:).school_for(uuid: site_uuid)).to eq(site)
       end
     end
 
     context "when the provider is after the schools remodel cycle" do
       let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
       let(:provider) { create(:provider, recruitment_cycle:) }
-      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:, uuid: provider_school_uuid) }
 
-      before do
-        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: provider_school_uuid)
-      end
-
-      it "finds the legacy site via the provider school uuid" do
-        expect(described_class.new(provider:).site_for(uuid: provider_school_uuid)).to eq(site)
+      it "finds the provider school by provider school uuid without requiring a legacy site" do
+        expect(described_class.new(provider:).school_for(uuid: provider_school_uuid)).to eq(provider_school)
       end
     end
   end

--- a/spec/services/provider_schools/removal_spec.rb
+++ b/spec/services/provider_schools/removal_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProviderSchools::Removal do
+  let(:remodel_cycle_year) { 2026 }
+  let(:gias_school) { create(:gias_school, urn: "123456") }
+  let(:site_uuid) { "11111111-1111-4111-8111-111111111111" }
+  let(:provider_school_uuid) { "22222222-2222-4222-8222-222222222222" }
+
+  before do
+    allow(Settings).to receive(:schools_remodel_cycle_year).and_return(remodel_cycle_year)
+  end
+
+  describe "#call" do
+    context "when the provider is in the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code) }
+
+      it "removes both the legacy site and provider school" do
+        described_class.new(provider:, uuid: site.uuid).call
+
+        expect(Site.where(id: site.id)).to be_empty
+        expect(Provider::School.where(id: provider_school.id)).to be_empty
+      end
+    end
+
+    context "when the provider is after the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: provider_school_uuid) }
+
+      it "removes only the provider school" do
+        described_class.new(provider:, uuid: provider_school.uuid).call
+
+        expect(Site.where(id: site.id)).to contain_exactly(site)
+        expect(Provider::School.where(id: provider_school.id)).to be_empty
+      end
+
+      it "does not remove provider schools that are attached to courses" do
+        create(:course_school, course: create(:course, provider:), provider_school:, gias_school:)
+
+        expect {
+          described_class.new(provider:, uuid: provider_school.uuid).call
+        }.to raise_error(described_class::CannotRemoveSchoolError)
+
+        expect(Site.where(id: site.id)).to contain_exactly(site)
+        expect(Provider::School.where(id: provider_school.id)).to contain_exactly(provider_school)
+      end
+    end
+  end
+end

--- a/spec/services/provider_schools/removal_spec.rb
+++ b/spec/services/provider_schools/removal_spec.rb
@@ -25,6 +25,37 @@ RSpec.describe ProviderSchools::Removal do
         expect(Site.where(id: site.id)).to be_empty
         expect(Provider::School.where(id: provider_school.id)).to be_empty
       end
+
+      it "does not remove either record when the site is attached to a legacy course site" do
+        course = create(:course, provider:)
+        course.sites << site
+
+        expect {
+          described_class.new(provider:, uuid: site.uuid).call
+        }.to raise_error(described_class::CannotRemoveSchoolError)
+
+        expect(Site.where(id: site.id)).to contain_exactly(site)
+        expect(Provider::School.where(id: provider_school.id)).to contain_exactly(provider_school)
+      end
+
+      it "does not remove either record when the provider school is attached to a course school" do
+        create(:course_school, course: create(:course, provider:), provider_school:, gias_school:)
+
+        expect {
+          described_class.new(provider:, uuid: site.uuid).call
+        }.to raise_error(described_class::CannotRemoveSchoolError)
+
+        expect(Site.where(id: site.id)).to contain_exactly(site)
+        expect(Provider::School.where(id: provider_school.id)).to contain_exactly(provider_school)
+      end
+
+      it "removes the legacy site when a matching provider school does not exist" do
+        provider_school.destroy!
+
+        described_class.new(provider:, uuid: site.uuid).call
+
+        expect(Site.where(id: site.id)).to be_empty
+      end
     end
 
     context "when the provider is after the schools remodel cycle" do
@@ -40,6 +71,14 @@ RSpec.describe ProviderSchools::Removal do
         expect(Provider::School.where(id: provider_school.id)).to be_empty
       end
 
+      it "removes a provider school without requiring a legacy site" do
+        provider_school_without_site = create(:provider_school, provider:)
+
+        described_class.new(provider:, uuid: provider_school_without_site.uuid).call
+
+        expect(Provider::School.where(id: provider_school_without_site.id)).to be_empty
+      end
+
       it "does not remove provider schools that are attached to courses" do
         create(:course_school, course: create(:course, provider:), provider_school:, gias_school:)
 
@@ -49,6 +88,16 @@ RSpec.describe ProviderSchools::Removal do
 
         expect(Site.where(id: site.id)).to contain_exactly(site)
         expect(Provider::School.where(id: provider_school.id)).to contain_exactly(provider_school)
+      end
+
+      it "does not remove a provider school belonging to another provider" do
+        other_provider_school = create(:provider_school, uuid: "33333333-3333-4333-8333-333333333333")
+
+        expect {
+          described_class.new(provider:, uuid: other_provider_school.uuid).call
+        }.to raise_error(ActiveRecord::RecordNotFound)
+
+        expect(Provider::School.where(id: other_provider_school.id)).to contain_exactly(other_provider_school)
       end
     end
   end

--- a/spec/services/provider_schools/removal_spec.rb
+++ b/spec/services/provider_schools/removal_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe ProviderSchools::Removal do
   let(:remodel_cycle_year) { 2026 }
   let(:gias_school) { create(:gias_school, urn: "123456") }
-  let(:site_uuid) { "11111111-1111-4111-8111-111111111111" }
-  let(:provider_school_uuid) { "22222222-2222-4222-8222-222222222222" }
+  let(:site_uuid) { Faker::Internet.uuid }
+  let(:provider_school_uuid) { Faker::Internet.uuid }
 
   before do
     allow(Settings).to receive(:schools_remodel_cycle_year).and_return(remodel_cycle_year)
@@ -20,7 +20,7 @@ RSpec.describe ProviderSchools::Removal do
       let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code) }
 
       it "removes both the legacy site and provider school" do
-        described_class.new(provider:, uuid: site.uuid).call
+        expect(described_class.new(provider:, uuid: site.uuid).call).to be(true)
 
         expect(Site.where(id: site.id)).to be_empty
         expect(Provider::School.where(id: provider_school.id)).to be_empty
@@ -30,9 +30,7 @@ RSpec.describe ProviderSchools::Removal do
         course = create(:course, provider:)
         course.sites << site
 
-        expect {
-          described_class.new(provider:, uuid: site.uuid).call
-        }.to raise_error(described_class::CannotRemoveSchoolError)
+        expect(described_class.new(provider:, uuid: site.uuid).call).to be(false)
 
         expect(Site.where(id: site.id)).to contain_exactly(site)
         expect(Provider::School.where(id: provider_school.id)).to contain_exactly(provider_school)
@@ -41,9 +39,7 @@ RSpec.describe ProviderSchools::Removal do
       it "does not remove either record when the provider school is attached to a course school" do
         create(:course_school, course: create(:course, provider:), provider_school:, gias_school:)
 
-        expect {
-          described_class.new(provider:, uuid: site.uuid).call
-        }.to raise_error(described_class::CannotRemoveSchoolError)
+        expect(described_class.new(provider:, uuid: site.uuid).call).to be(false)
 
         expect(Site.where(id: site.id)).to contain_exactly(site)
         expect(Provider::School.where(id: provider_school.id)).to contain_exactly(provider_school)
@@ -52,7 +48,7 @@ RSpec.describe ProviderSchools::Removal do
       it "removes the legacy site when a matching provider school does not exist" do
         provider_school.destroy!
 
-        described_class.new(provider:, uuid: site.uuid).call
+        expect(described_class.new(provider:, uuid: site.uuid).call).to be(true)
 
         expect(Site.where(id: site.id)).to be_empty
       end
@@ -65,7 +61,7 @@ RSpec.describe ProviderSchools::Removal do
       let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: provider_school_uuid) }
 
       it "removes only the provider school" do
-        described_class.new(provider:, uuid: provider_school.uuid).call
+        expect(described_class.new(provider:, uuid: provider_school.uuid).call).to be(true)
 
         expect(Site.where(id: site.id)).to contain_exactly(site)
         expect(Provider::School.where(id: provider_school.id)).to be_empty
@@ -74,7 +70,7 @@ RSpec.describe ProviderSchools::Removal do
       it "removes a provider school without requiring a legacy site" do
         provider_school_without_site = create(:provider_school, provider:)
 
-        described_class.new(provider:, uuid: provider_school_without_site.uuid).call
+        expect(described_class.new(provider:, uuid: provider_school_without_site.uuid).call).to be(true)
 
         expect(Provider::School.where(id: provider_school_without_site.id)).to be_empty
       end
@@ -82,16 +78,14 @@ RSpec.describe ProviderSchools::Removal do
       it "does not remove provider schools that are attached to courses" do
         create(:course_school, course: create(:course, provider:), provider_school:, gias_school:)
 
-        expect {
-          described_class.new(provider:, uuid: provider_school.uuid).call
-        }.to raise_error(described_class::CannotRemoveSchoolError)
+        expect(described_class.new(provider:, uuid: provider_school.uuid).call).to be(false)
 
         expect(Site.where(id: site.id)).to contain_exactly(site)
         expect(Provider::School.where(id: provider_school.id)).to contain_exactly(provider_school)
       end
 
       it "does not remove a provider school belonging to another provider" do
-        other_provider_school = create(:provider_school, uuid: "33333333-3333-4333-8333-333333333333")
+        other_provider_school = create(:provider_school, uuid: Faker::Internet.uuid)
 
         expect {
           described_class.new(provider:, uuid: other_provider_school.uuid).call

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -5,13 +5,11 @@ require_relative "provider_school_helper"
 
 RSpec.describe "Delete a provider's schools" do
   include ProviderSchoolHelper
-  before do
+
+  scenario "with no associated courses" do
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_schools_page
     then_i_see_a_list_of_schools
-  end
-
-  scenario "with no associated courses" do
     when_i_visit_the_publish_school_show_page
     and_i_click_remove_school_link
     then_i_am_on_the_school_delete_page
@@ -25,6 +23,9 @@ RSpec.describe "Delete a provider's schools" do
   end
 
   scenario "with associated course" do
+    given_i_am_authenticated_as_a_provider_user
+    when_i_visit_the_schools_page
+    then_i_see_a_list_of_schools
     given_there_is_an_associated_course
     when_i_visit_the_publish_school_show_page
     and_i_click_remove_school_link
@@ -32,7 +33,24 @@ RSpec.describe "Delete a provider's schools" do
     and_i_cannot_delete_the_school
   end
 
+  scenario "when the school becomes associated with a course before removal" do
+    given_i_am_authenticated_as_a_provider_user
+    when_i_visit_the_schools_page
+    then_i_see_a_list_of_schools
+    when_i_visit_the_publish_school_show_page
+    and_i_click_remove_school_link
+    then_i_am_on_the_school_delete_page
+
+    given_there_is_an_associated_course
+    when_i_click_remove_school_button
+    then_i_see_the_school_could_not_be_removed
+    and_the_school_is_not_deleted
+  end
+
   scenario "with discarded associated course" do
+    given_i_am_authenticated_as_a_provider_user
+    when_i_visit_the_schools_page
+    then_i_see_a_list_of_schools
     given_there_is_an_associated_course
     and_i_delete_the_course
     when_i_visit_the_publish_school_show_page
@@ -46,9 +64,76 @@ RSpec.describe "Delete a provider's schools" do
   end
 
   scenario "after the schools remodel cycle without a legacy site" do
-    recruitment_cycle = create(:recruitment_cycle, year: 2027)
-    future_provider = create(:provider, recruitment_cycle:)
-    gias_school = create(
+    given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
+    and_there_is_a_provider_school_without_a_legacy_site
+    when_i_visit_the_schools_page_after_the_schools_remodel_cycle
+    then_i_see_the_provider_school_listed_with_its_uuid
+
+    when_i_click_the_provider_school
+    then_i_see_the_provider_school_details
+
+    when_i_remove_the_provider_school
+    then_i_am_on_the_index_page
+    and_the_provider_school_is_deleted
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
+    given_i_am_authenticated(user: create(:user, providers: [future_provider]))
+  end
+
+  def and_there_is_a_provider_school_without_a_legacy_site
+    expect(Site.find_by_uuid(future_provider_school.uuid)).to be_nil
+  end
+
+  def when_i_visit_the_schools_page_after_the_schools_remodel_cycle
+    publish_schools_index_page.load(
+      provider_code: future_provider.provider_code,
+      recruitment_cycle_year: future_recruitment_cycle.year,
+    )
+  end
+
+  def then_i_see_the_provider_school_listed_with_its_uuid
+    expect(publish_schools_index_page.schools.first.name).to have_text(future_gias_school.name)
+    expect(publish_schools_index_page.schools.first.code).to have_text("- (dash)")
+    expect(publish_schools_index_page.schools.first.urn).to have_text(future_gias_school.urn)
+    expect(publish_schools_index_page.schools.first.edit_link[:href]).to include(future_provider_school.uuid)
+  end
+
+  def when_i_click_the_provider_school
+    publish_schools_index_page.schools.first.edit_link.click
+  end
+
+  def then_i_see_the_provider_school_details
+    expect(publish_school_show_page).to be_displayed
+    expect(page).to have_content("Future School (Main site)")
+    expect(page).to have_content("School code-", normalize_ws: true)
+    expect(page).to have_content("URN654321", normalize_ws: true)
+    expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)
+  end
+
+  def when_i_remove_the_provider_school
+    publish_school_show_page.remove_school_link.click
+    publish_school_delete_page.remove_school_button.click
+  end
+
+  def and_the_provider_school_is_deleted
+    expect(Provider::School.where(id: future_provider_school.id)).to be_empty
+  end
+
+  def future_recruitment_cycle
+    @future_recruitment_cycle ||= create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
+  end
+
+  def future_provider
+    @future_provider ||= create(:provider, recruitment_cycle: future_recruitment_cycle)
+  end
+
+  def future_provider_school
+    @future_provider_school ||= create(:provider_school, provider: future_provider, gias_school: future_gias_school, site_code: "-")
+  end
+
+  def future_gias_school
+    @future_gias_school ||= create(
       :gias_school,
       name: "Future School",
       urn: "654321",
@@ -59,29 +144,6 @@ RSpec.describe "Delete a provider's schools" do
       county: "Future County",
       postcode: "FT1 1AA",
     )
-    provider_school = create(:provider_school, provider: future_provider, gias_school:, site_code: "-")
-    given_i_am_authenticated(user: create(:user, providers: [future_provider]))
-
-    visit publish_provider_recruitment_cycle_schools_path(future_provider.provider_code, recruitment_cycle.year)
-
-    expect(page).to have_content("- (dash)")
-    expect(page).to have_link(
-      "Future School",
-      href: publish_provider_recruitment_cycle_school_path(future_provider.provider_code, recruitment_cycle.year, provider_school.uuid),
-    )
-
-    click_link_or_button "Future School"
-    expect(publish_school_show_page).to be_displayed
-    expect(page).to have_content("Future School (Main Site)")
-    expect(page).to have_content("School code-", normalize_ws: true)
-    expect(page).to have_content("URN654321", normalize_ws: true)
-    expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)
-
-    click_link_or_button "Remove school"
-    click_link_or_button "Remove school"
-
-    expect(publish_schools_index_page).to be_displayed
-    expect(Provider::School.where(id: provider_school.id)).to be_empty
   end
 
   def when_i_visit_the_publish_school_show_page
@@ -109,6 +171,10 @@ RSpec.describe "Delete a provider's schools" do
     expect(provider.sites.count).to eq 0
   end
 
+  def and_the_school_is_not_deleted
+    expect(provider.sites.count).to eq 1
+  end
+
   def given_there_is_an_associated_course
     @course = create(:course, provider:)
     @course.sites << @site
@@ -131,5 +197,10 @@ RSpec.describe "Delete a provider's schools" do
 
   def and_i_am_able_to_remove_the_school
     expect(page).to have_content("Remove school")
+  end
+
+  def then_i_see_the_school_could_not_be_removed
+    expect(publish_school_delete_page).to be_displayed
+    expect(page).to have_content("This school could not be removed because it is used by a course")
   end
 end

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -45,6 +45,31 @@ RSpec.describe "Delete a provider's schools" do
     and_the_school_is_deleted
   end
 
+  scenario "after the schools remodel cycle without a legacy site" do
+    recruitment_cycle = create(:recruitment_cycle, year: 2027)
+    future_provider = create(:provider, recruitment_cycle:)
+    gias_school = create(:gias_school, name: "Future School", urn: "654321")
+    provider_school = create(:provider_school, provider: future_provider, gias_school:, site_code: "F")
+    given_i_am_authenticated(user: create(:user, providers: [future_provider]))
+
+    visit publish_provider_recruitment_cycle_schools_path(future_provider.provider_code, recruitment_cycle.year)
+
+    expect(page).to have_link(
+      "Future School",
+      href: publish_provider_recruitment_cycle_school_path(future_provider.provider_code, recruitment_cycle.year, provider_school.uuid),
+    )
+
+    click_link_or_button "Future School"
+    expect(publish_school_show_page).to be_displayed
+    expect(page).to have_content("Future School")
+
+    click_link_or_button "Remove school"
+    click_link_or_button "Remove school"
+
+    expect(publish_schools_index_page).to be_displayed
+    expect(Provider::School.where(id: provider_school.id)).to be_empty
+  end
+
   def when_i_visit_the_publish_school_show_page
     publish_school_show_page.load(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, school_id: site.uuid)
   end

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -48,12 +48,23 @@ RSpec.describe "Delete a provider's schools" do
   scenario "after the schools remodel cycle without a legacy site" do
     recruitment_cycle = create(:recruitment_cycle, year: 2027)
     future_provider = create(:provider, recruitment_cycle:)
-    gias_school = create(:gias_school, name: "Future School", urn: "654321")
-    provider_school = create(:provider_school, provider: future_provider, gias_school:, site_code: "F")
+    gias_school = create(
+      :gias_school,
+      name: "Future School",
+      urn: "654321",
+      address1: "1 Future Road",
+      address2: "Future Building",
+      address3: "Future Quarter",
+      town: "Future Town",
+      county: "Future County",
+      postcode: "FT1 1AA",
+    )
+    provider_school = create(:provider_school, provider: future_provider, gias_school:, site_code: "-")
     given_i_am_authenticated(user: create(:user, providers: [future_provider]))
 
     visit publish_provider_recruitment_cycle_schools_path(future_provider.provider_code, recruitment_cycle.year)
 
+    expect(page).to have_content("- (dash)")
     expect(page).to have_link(
       "Future School",
       href: publish_provider_recruitment_cycle_school_path(future_provider.provider_code, recruitment_cycle.year, provider_school.uuid),
@@ -61,7 +72,10 @@ RSpec.describe "Delete a provider's schools" do
 
     click_link_or_button "Future School"
     expect(publish_school_show_page).to be_displayed
-    expect(page).to have_content("Future School")
+    expect(page).to have_content("Future School (Main Site)")
+    expect(page).to have_content("School code-", normalize_ws: true)
+    expect(page).to have_content("URN654321", normalize_ws: true)
+    expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)
 
     click_link_or_button "Remove school"
     click_link_or_button "Remove school"

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Delete a provider's schools" do
   end
 
   def when_i_visit_the_publish_school_show_page
-    publish_school_show_page.load(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, school_id: @site.id)
+    publish_school_show_page.load(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, school_id: site.uuid)
   end
 
   def and_i_click_remove_school_link

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -21,6 +21,30 @@ RSpec.describe "Delete school under provider as an admin" do
       then_i_am_on_the_index_page
       and_the_school_is_deleted
     end
+
+    scenario "after the schools remodel cycle without a legacy site" do
+      recruitment_cycle = create(:recruitment_cycle, year: 2027)
+      provider = create(:provider, provider_name: "Future Provider", recruitment_cycle:)
+      gias_school = create(:gias_school, name: "Future School", urn: "654321")
+      provider_school = create(:provider_school, provider:, gias_school:, site_code: "F")
+
+      support_provider_schools_index_page.load(recruitment_cycle_year: recruitment_cycle.year, provider_id: provider.id)
+
+      expect(page).to have_link(
+        "Future School",
+        href: support_recruitment_cycle_provider_school_path(recruitment_cycle.year, provider, provider_school.uuid),
+      )
+
+      click_link_or_button "Future School"
+      expect(support_provider_school_show_page).to be_displayed
+      expect(page).to have_content("Future School")
+
+      click_link_or_button "Remove school"
+      click_link_or_button "Remove school"
+
+      expect(support_provider_schools_index_page).to be_displayed
+      expect(Provider::School.where(id: provider_school.id)).to be_empty
+    end
   end
 
   def and_the_school_is_deleted

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -3,14 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Delete school under provider as an admin" do
-  before do
-    given_i_am_authenticated_as_an_admin_user
-    and_there_is_a_provider_site
-    and_i_visit_the_support_provider_school_show_page
-  end
-
   describe "Deleting a school" do
     scenario do
+      given_i_am_authenticated_as_an_admin_user
+      and_there_is_a_provider_site
+      and_i_visit_the_support_provider_school_show_page
       when_i_click_remove_school_link
       then_i_am_on_the_school_delete_page
       when_i_click_cancel
@@ -22,47 +19,105 @@ RSpec.describe "Delete school under provider as an admin" do
       and_the_school_is_deleted
     end
 
-    scenario "after the schools remodel cycle without a legacy site" do
-      recruitment_cycle = create(:recruitment_cycle, year: 2027)
-      provider = create(:provider, provider_name: "Future Provider", recruitment_cycle:)
-      gias_school = create(
-        :gias_school,
-        name: "Future School",
-        urn: "654321",
-        address1: "1 Future Road",
-        address2: "Future Building",
-        address3: "Future Quarter",
-        town: "Future Town",
-        county: "Future County",
-        postcode: "FT1 1AA",
-      )
-      provider_school = create(:provider_school, provider:, gias_school:, site_code: "-")
+    scenario "when the school becomes associated with a course before removal" do
+      given_i_am_authenticated_as_an_admin_user
+      and_there_is_a_provider_site
+      and_i_visit_the_support_provider_school_show_page
+      when_i_click_remove_school_link
+      then_i_am_on_the_school_delete_page
 
-      support_provider_schools_index_page.load(recruitment_cycle_year: recruitment_cycle.year, provider_id: provider.id)
-
-      expect(page).to have_content("- (dash)")
-      expect(page).to have_link(
-        "Future School",
-        href: support_recruitment_cycle_provider_school_path(recruitment_cycle.year, provider, provider_school.uuid),
-      )
-
-      click_link_or_button "Future School"
-      expect(support_provider_school_show_page).to be_displayed
-      expect(page).to have_content("Future School (Main Site)")
-      expect(page).to have_content("School code-", normalize_ws: true)
-      expect(page).to have_content("URN654321", normalize_ws: true)
-      expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)
-
-      click_link_or_button "Remove school"
-      click_link_or_button "Remove school"
-
-      expect(support_provider_schools_index_page).to be_displayed
-      expect(Provider::School.where(id: provider_school.id)).to be_empty
+      given_there_is_an_associated_course
+      and_i_click_remove_school_button
+      then_i_see_the_school_could_not_be_removed
+      and_the_school_is_not_deleted
     end
+
+    scenario "after the schools remodel cycle without a legacy site" do
+      given_i_am_authenticated_as_an_admin_user
+      and_there_is_a_provider_school_after_the_schools_remodel_cycle_without_a_legacy_site
+      when_i_visit_the_support_provider_schools_index_page_after_the_schools_remodel_cycle
+      then_i_see_the_provider_school_listed_with_its_uuid
+
+      when_i_click_the_provider_school
+      then_i_see_the_provider_school_details
+
+      when_i_remove_the_provider_school
+      then_i_am_on_the_index_page
+      and_the_provider_school_is_deleted
+    end
+  end
+
+  def and_there_is_a_provider_school_after_the_schools_remodel_cycle_without_a_legacy_site
+    expect(Site.find_by_uuid(future_provider_school.uuid)).to be_nil
+  end
+
+  def when_i_visit_the_support_provider_schools_index_page_after_the_schools_remodel_cycle
+    support_provider_schools_index_page.load(
+      recruitment_cycle_year: future_recruitment_cycle.year,
+      provider_id: future_provider.id,
+    )
+  end
+
+  def then_i_see_the_provider_school_listed_with_its_uuid
+    expect(support_provider_schools_index_page.schools.first.name).to have_text(future_gias_school.name)
+    expect(support_provider_schools_index_page.schools.first.code).to have_text("- (dash)")
+    expect(support_provider_schools_index_page.schools.first.urn).to have_text(future_gias_school.urn)
+    expect(support_provider_schools_index_page.schools.first.edit_link[:href]).to include(future_provider_school.uuid)
+  end
+
+  def when_i_click_the_provider_school
+    support_provider_schools_index_page.schools.first.edit_link.click
+  end
+
+  def then_i_see_the_provider_school_details
+    expect(support_provider_school_show_page).to be_displayed
+    expect(page).to have_content("Future School (Main site)")
+    expect(page).to have_content("School code-", normalize_ws: true)
+    expect(page).to have_content("URN654321", normalize_ws: true)
+    expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)
+  end
+
+  def when_i_remove_the_provider_school
+    support_provider_school_show_page.remove_school_link.click
+    support_provider_school_delete_page.remove_school_button.click
+  end
+
+  def and_the_provider_school_is_deleted
+    expect(Provider::School.where(id: future_provider_school.id)).to be_empty
+  end
+
+  def future_recruitment_cycle
+    @future_recruitment_cycle ||= create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
+  end
+
+  def future_provider
+    @future_provider ||= create(:provider, provider_name: "Future Provider", recruitment_cycle: future_recruitment_cycle)
+  end
+
+  def future_provider_school
+    @future_provider_school ||= create(:provider_school, provider: future_provider, gias_school: future_gias_school, site_code: "-")
+  end
+
+  def future_gias_school
+    @future_gias_school ||= create(
+      :gias_school,
+      name: "Future School",
+      urn: "654321",
+      address1: "1 Future Road",
+      address2: "Future Building",
+      address3: "Future Quarter",
+      town: "Future Town",
+      county: "Future County",
+      postcode: "FT1 1AA",
+    )
   end
 
   def and_the_school_is_deleted
     expect(@provider.sites.count).to eq 0
+  end
+
+  def and_the_school_is_not_deleted
+    expect(@provider.sites.count).to eq 1
   end
 
   def then_i_am_on_the_index_page
@@ -99,7 +154,17 @@ RSpec.describe "Delete school under provider as an admin" do
     @site = create(:site, provider: @provider)
   end
 
+  def given_there_is_an_associated_course
+    course = create(:course, provider: @provider)
+    course.sites << @site
+  end
+
   def given_i_am_authenticated_as_an_admin_user
     given_i_am_authenticated(user: create(:user, :admin))
+  end
+
+  def then_i_see_the_school_could_not_be_removed
+    expect(support_provider_school_delete_page).to be_displayed
+    expect(page).to have_content("This school could not be removed because it is used by a course")
   end
 end

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -25,11 +25,22 @@ RSpec.describe "Delete school under provider as an admin" do
     scenario "after the schools remodel cycle without a legacy site" do
       recruitment_cycle = create(:recruitment_cycle, year: 2027)
       provider = create(:provider, provider_name: "Future Provider", recruitment_cycle:)
-      gias_school = create(:gias_school, name: "Future School", urn: "654321")
-      provider_school = create(:provider_school, provider:, gias_school:, site_code: "F")
+      gias_school = create(
+        :gias_school,
+        name: "Future School",
+        urn: "654321",
+        address1: "1 Future Road",
+        address2: "Future Building",
+        address3: "Future Quarter",
+        town: "Future Town",
+        county: "Future County",
+        postcode: "FT1 1AA",
+      )
+      provider_school = create(:provider_school, provider:, gias_school:, site_code: "-")
 
       support_provider_schools_index_page.load(recruitment_cycle_year: recruitment_cycle.year, provider_id: provider.id)
 
+      expect(page).to have_content("- (dash)")
       expect(page).to have_link(
         "Future School",
         href: support_recruitment_cycle_provider_school_path(recruitment_cycle.year, provider, provider_school.uuid),
@@ -37,7 +48,10 @@ RSpec.describe "Delete school under provider as an admin" do
 
       click_link_or_button "Future School"
       expect(support_provider_school_show_page).to be_displayed
-      expect(page).to have_content("Future School")
+      expect(page).to have_content("Future School (Main Site)")
+      expect(page).to have_content("School code-", normalize_ws: true)
+      expect(page).to have_content("URN654321", normalize_ws: true)
+      expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)
 
       click_link_or_button "Remove school"
       click_link_or_button "Remove school"

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Delete school under provider as an admin" do
   end
 
   def and_i_visit_the_support_provider_school_show_page
-    support_provider_school_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id, id: @site.id)
+    support_provider_school_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id, id: @site.uuid)
   end
 
   def and_there_is_a_provider_site


### PR DESCRIPTION
## Context

Provider school removal currently identifies schools using the legacy site.id route parameter. As part of the schools remodel, provider schools now also exist in the new provider_school model with their own UUID.
For the 2026 remodel cycle, migrated site.uuid and provider_school.uuid values match, so provider-school removal should continue to use the legacy site UUID. After the remodel cycle, rollover will create new rows in both models and those UUIDs will drift, so provider-school removal needs to identify and delete the new Provider::School record by its own UUID.
This PR only changes provider-level school removal and identification. It does not change adding provider schools, or assigning/removing schools from courses.

## Changes proposed in this pull request

- Adds schools_remodel_cycle_year: 2026 to settings.
- Changes Publish and Support provider-school member routes to use :uuid instead of the legacy :id.
- Adds ProviderSchools::Identity to centralise cycle-aware provider-school identity logic:
	- resolves the matching legacy Site and new Provider::School records
	- filters visible provider-school rows after the remodel cycle through existing provider_school rows
- Adds ProviderSchools::Removal for deletion behaviour:
	- in the 2026 cycle, removes both the legacy Site and matching Provider::School
	- after 2026, removes only the Provider::School
	- blocks removal when the provider school is attached to course schools
- Updates Publish and Support provider-school show/delete/index links to pass the correct UUID.
- Updates the course query debug school link to use UUIDs selected by Courses::NearestSchoolQuery, avoiding an extra Site.find.

## Guidance to review

- We can do a bug party overall for rollover, check if the current functionality for this cycle breaks.
- Confirm provider-school show/delete URLs now contain UUIDs rather than site.id.
- In a 2026 recruitment cycle, remove a provider school and confirm both site and matching provider_school rows are removed.
- Confirm provider schools attached to course schools cannot be removed.
- Confirm add-school flows still behave unchanged.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
