### PR TITLE
Change terraform db setup command to use db:prepare

### DIFF
--- a/terraform/aks/locals.tf
+++ b/terraform/aks/locals.tf
@@ -1,7 +1,7 @@
 locals {
   app_name_suffix             = var.app_name == null ? var.app_environment : "${var.app_environment}-${var.app_name}"
   review_additional_hostnames = var.app_environment == "review" ? ["find-${local.app_name_suffix}.${var.cluster}.teacherservices.cloud", "publish-${local.app_name_suffix}-api.${var.cluster}.teacherservices.cloud" ] : ["find-${local.app_name_suffix}.${var.cluster}.development.teacherservices.cloud"]
-  db_setup_command            = ["/bin/sh", "-c", "bundle exec rails db:setup && bundle exec rails server -b 0.0.0.0"]
+  db_setup_command            = ["/bin/sh", "-c", "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0"]
   worker_startup_command      = ["/bin/sh", "-c", "bundle exec sidekiq -c 5 -C config/sidekiq.yml"]
   postgres_extensions         = ["PG_BUFFERCACHE", "PG_STAT_STATEMENTS", "BTREE_GIN", "BTREE_GIST", "CITEXT", "UUID-OSSP", "POSTGIS"]
   app_secrets = merge(


### PR DESCRIPTION
## Context

 The DB setup command for terraform rails pods should be idempotent
 db:prepare:with_data only creates the database if it doesn't yet exist
 db:setup will error if the database already exists


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
