### PR TITLE
Add specs to make sure our sanitisation & restore scripts are current

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -153,7 +153,11 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Integration setup"
-          psql -d ${DATABASE_NAME} -f db/scripts/integration_setup.sql
+          psql -d ${DATABASE_NAME} -v ON_ERROR_STOP=1 -f db/scripts/integration_setup.sql
+            if [ $? -ne 0 ]; then
+              echo "db/scripts/integration_setup.sql failed" >&2
+              exit 1
+            fi
           echo "::endgroup::"
 
           echo "::debug::Remove ${{ env.BACKUP_FILE }}.sql.gz"

--- a/db/scripts/integration_setup.sql
+++ b/db/scripts/integration_setup.sql
@@ -27,16 +27,14 @@ INSERT INTO "user" (email,
 INSERT INTO "provider" (provider_code,
                         provider_name,
                         recruitment_cycle_id,
-                        scheme_member,
                         provider_type,
-                        accrediting_provider)
+                        accredited)
             VALUES ('B1T',
                     'bat 1',
                     (SELECT id FROM "recruitment_cycle"
                                ORDER BY year DESC limit 1),
-                    'N',
                     'O',
-                    'Y')
+                    true)
             ON CONFLICT (provider_code, recruitment_cycle_id) DO nothing;
 
 INSERT INTO "organisation"

--- a/spec/db/scripts_spec.rb
+++ b/spec/db/scripts_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+# These scripts are hand-written SQL run by the database-restore workflow
+# (.github/workflows/database-restore.yml) against a restored production dump.
+# They reference tables and columns by name, so a migration that renames or
+# removes one silently rots them until the nightly restore fails. Running them
+# against the current schema here turns that drift into a PR-time failure.
+#
+# Inserts run inside the per-example transaction and roll back automatically.
+RSpec.describe "db/scripts" do
+  def run_script(name)
+    sql = Rails.root.join("db/scripts/#{name}.sql").read
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  it "sanitise.sql runs cleanly against the current schema" do
+    expect { run_script("sanitise") }.not_to raise_error
+  end
+
+  it "integration_setup.sql runs cleanly against the current schema" do
+    # The provider insert requires a recruitment cycle (recruitment_cycle_id is NOT NULL).
+    create(:recruitment_cycle)
+
+    expect { run_script("integration_setup") }.not_to raise_error
+  end
+end

--- a/spec/db/scripts_spec.rb
+++ b/spec/db/scripts_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe "db/scripts" do
 
     expect { run_script("integration_setup") }.not_to raise_error
   end
+
+  it "surfaces a reference to a dropped column as a raised error" do
+    # Guards the guard: proves the clean-run assertions above would fail on
+    # schema drift rather than passing vacuously. A script referencing a
+    # column that no longer exists must raise, not fail silently.
+    dropped_column_sql = %(INSERT INTO "provider" (provider_code, scheme_member) VALUES ('B1T', 'N'))
+
+    expect { ActiveRecord::Base.connection.execute(dropped_column_sql) }
+      .to raise_error(ActiveRecord::StatementInvalid, /scheme_member/)
+  end
 end


### PR DESCRIPTION
## Context

We risk restoring PII if our sanitisation and integration scripts are not
working properly. We need to make sure the scripts are kept in line with
the current schema

## Changes proposed in this pull request

Add a test for each of the sql scripts that run on our production backups to make sure they don't error
Update the integration script to remove and replace non-existing columns 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
