### PR TITLE
Add identity service for Course::School.

### DIFF
--- a/app/services/course_schools/identity.rb
+++ b/app/services/course_schools/identity.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module CourseSchools
+  # This service determines which model should be used when creating, removing and in some instances viewing schools.
+  # The legacy data model uses Site, while the new data model uses Course::School.
+  # During the rollover, both models are written to and their UUIDs may diverge, so we need a way to switch to the new data model.
+  # Because Publish supports both the old and new recruitment cycles during the rollover, this switch must be based on the recruitment cycle rather than a traditional feature flag.
+  class Identity
+    delegate :after_schools_remodel_cycle?, to: :provider_identity
+    delegate :count, to: :available_schools, prefix: true
+
+    def initialize(provider:, course: nil)
+      @provider = provider
+      @course = course
+      @provider_identity = ProviderSchools::Identity.new(provider:)
+    end
+
+    def available_schools
+      provider_identity.ordered_school_scope.to_a
+    end
+
+    def current_school_uuids
+      if after_schools_remodel_cycle?
+        course.schools.includes(:provider_school).map { |course_school| course_school.provider_school.uuid.to_s }
+      else
+        course.sites.map { |site| site.uuid.to_s }
+      end
+    end
+
+    def school_records_for(school_uuids:)
+      school_uuids = normalize_uuids(school_uuids)
+
+      ordered_records_for(school_uuids, school_records_by_uuid(school_uuids))
+    end
+
+  private
+
+    attr_reader :provider, :course, :provider_identity
+
+    def school_records_by_uuid(school_uuids)
+      if after_schools_remodel_cycle?
+        provider_schools_by_uuid(school_uuids)
+      elsif school_uuids.all? { |uuid| uuid?(uuid) }
+        provider.sites.where(uuid: school_uuids).index_by { |site| site.uuid.to_s }
+      else
+        provider.sites.where(id: school_uuids).index_by { |site| site.id.to_s }
+      end
+    end
+
+    def provider_schools_by_uuid(school_uuids)
+      provider.schools.where(uuid: normalize_uuids(school_uuids)).index_by { |school| school.uuid.to_s }
+    end
+
+    def ordered_records_for(school_uuids, records_by_uuid)
+      school_uuids.filter_map { |uuid| records_by_uuid[uuid] }
+    end
+
+    def normalize_uuids(school_uuids)
+      Array(school_uuids).compact_blank.map(&:to_s)
+    end
+
+    def uuid?(identifier)
+      identifier.to_s.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
+    end
+  end
+end

--- a/app/services/course_schools/identity.rb
+++ b/app/services/course_schools/identity.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 module CourseSchools
-  # This service determines which model should be used when creating, removing and in some instances viewing schools.
-  # The legacy data model uses Site, while the new data model uses Course::School.
-  # During the rollover, both models are written to and their UUIDs may diverge, so we need a way to switch to the new data model.
-  # Because Publish supports both the old and new recruitment cycles during the rollover, this switch must be based on the recruitment cycle rather than a traditional feature flag.
+  # Chooses the school model for a provider's recruitment cycle.
+  # Current and rollover cycles use legacy Site records; cycles after the remodel
+  # use Provider::School records because Site and Provider::School UUIDs diverge
+  # after rollover.
   class Identity
+    LEGACY_SITE_ID_PATTERN = /\A\d+\z/
+    UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
+
     delegate :after_schools_remodel_cycle?, to: :provider_identity
     delegate :count, to: :available_schools, prefix: true
 
@@ -20,6 +23,8 @@ module CourseSchools
     end
 
     def current_school_uuids
+      require_course!
+
       if after_schools_remodel_cycle?
         course.schools.includes(:provider_school).map { |course_school| course_school.provider_school.uuid.to_s }
       else
@@ -27,40 +32,91 @@ module CourseSchools
       end
     end
 
-    def school_records_for(school_uuids:)
-      school_uuids = normalize_uuids(school_uuids)
+    def school_records_for(school_identifiers:)
+      school_identifiers = normalize_school_identifiers(school_identifiers)
+      records_by_identifier = school_records_by_identifier(school_identifiers)
 
-      ordered_records_for(school_uuids, school_records_by_uuid(school_uuids))
+      validate_all_identifiers_resolved!(school_identifiers, records_by_identifier)
+      ordered_records_for(school_identifiers, records_by_identifier)
     end
 
   private
 
     attr_reader :provider, :course, :provider_identity
 
-    def school_records_by_uuid(school_uuids)
+    def school_records_by_identifier(school_identifiers)
       if after_schools_remodel_cycle?
-        provider_schools_by_uuid(school_uuids)
-      elsif school_uuids.all? { |uuid| uuid?(uuid) }
-        provider.sites.where(uuid: school_uuids).index_by { |site| site.uuid.to_s }
+        validate_uuid_identifiers!(school_identifiers)
+        provider_schools_by_uuid(school_identifiers)
       else
-        provider.sites.where(id: school_uuids).index_by { |site| site.id.to_s }
+        legacy_sites_by_identifier(school_identifiers)
       end
     end
 
-    def provider_schools_by_uuid(school_uuids)
-      provider.schools.where(uuid: normalize_uuids(school_uuids)).index_by { |school| school.uuid.to_s }
+    def legacy_sites_by_identifier(school_identifiers)
+      if uuid_identifiers?(school_identifiers)
+        sites_by_uuid(site_uuids: school_identifiers)
+      elsif legacy_site_id_identifiers?(school_identifiers)
+        sites_by_id(site_ids: school_identifiers)
+      else
+        raise ArgumentError, "School identifiers must not mix legacy Site IDs and UUIDs"
+      end
     end
 
-    def ordered_records_for(school_uuids, records_by_uuid)
-      school_uuids.filter_map { |uuid| records_by_uuid[uuid] }
+    def sites_by_uuid(site_uuids:)
+      provider.sites.where(uuid: site_uuids).index_by { |site| site.uuid.to_s }
     end
 
-    def normalize_uuids(school_uuids)
-      Array(school_uuids).compact_blank.map(&:to_s)
+    def sites_by_id(site_ids:)
+      provider.sites.where(id: site_ids).index_by { |site| site.id.to_s }
+    end
+
+    def provider_schools_by_uuid(provider_school_uuids)
+      provider.schools.where(uuid: provider_school_uuids).index_by { |school| school.uuid.to_s }
+    end
+
+    def uuid_identifiers?(school_identifiers)
+      school_identifiers.all? { |identifier| uuid?(identifier) }
+    end
+
+    def legacy_site_id_identifiers?(school_identifiers)
+      school_identifiers.all? { |identifier| legacy_site_id?(identifier) }
+    end
+
+    def ordered_records_for(school_identifiers, records_by_identifier)
+      school_identifiers.map { |identifier| records_by_identifier.fetch(identifier) }
+    end
+
+    def normalize_school_identifiers(school_identifiers)
+      Array(school_identifiers).compact_blank.map(&:to_s).uniq
+    end
+
+    def require_course!
+      return if course.present?
+
+      raise ArgumentError, "CourseSchools::Identity requires a course for current_school_uuids"
+    end
+
+    def validate_uuid_identifiers!(school_identifiers)
+      invalid_identifiers = school_identifiers.reject { |identifier| uuid?(identifier) }
+      return if invalid_identifiers.empty?
+
+      raise ArgumentError, "School identifiers must be Provider::School UUIDs after the schools remodel cycle"
+    end
+
+    def validate_all_identifiers_resolved!(school_identifiers, records_by_identifier)
+      unresolved_identifiers = school_identifiers - records_by_identifier.keys
+      return if unresolved_identifiers.empty?
+
+      raise ArgumentError, "Could not resolve school identifiers for provider #{provider.id}: #{unresolved_identifiers.join(', ')}"
     end
 
     def uuid?(identifier)
-      identifier.to_s.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
+      identifier.to_s.match?(UUID_PATTERN)
+    end
+
+    def legacy_site_id?(identifier)
+      identifier.to_s.match?(LEGACY_SITE_ID_PATTERN)
     end
   end
 end

--- a/app/services/course_schools/identity.rb
+++ b/app/services/course_schools/identity.rb
@@ -18,7 +18,7 @@ module CourseSchools
     end
 
     def available_schools
-      provider_identity.ordered_school_scope.to_a
+      provider_identity.ordered_school_scope
     end
 
     def current_school_uuids

--- a/app/services/course_schools/identity.rb
+++ b/app/services/course_schools/identity.rb
@@ -6,7 +6,6 @@ module CourseSchools
   # use Provider::School records because Site and Provider::School UUIDs diverge
   # after rollover.
   class Identity
-    LEGACY_SITE_ID_PATTERN = /\A\d+\z/
     UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
 
     delegate :after_schools_remodel_cycle?, to: :provider_identity
@@ -32,34 +31,24 @@ module CourseSchools
       end
     end
 
-    def school_records_for(school_identifiers:)
-      school_identifiers = normalize_school_identifiers(school_identifiers)
-      records_by_identifier = school_records_by_identifier(school_identifiers)
+    def school_records_for(school_uuids:)
+      school_uuids = normalize_school_uuids(school_uuids)
+      validate_uuid_values!(school_uuids)
 
-      validate_all_identifiers_resolved!(school_identifiers, records_by_identifier)
-      ordered_records_for(school_identifiers, records_by_identifier)
+      records_by_uuid = school_records_by_uuid(school_uuids)
+      validate_all_uuids_resolved!(school_uuids, records_by_uuid)
+      ordered_records_for(school_uuids, records_by_uuid)
     end
 
   private
 
     attr_reader :provider, :course, :provider_identity
 
-    def school_records_by_identifier(school_identifiers)
+    def school_records_by_uuid(school_uuids)
       if after_schools_remodel_cycle?
-        validate_uuid_identifiers!(school_identifiers)
-        provider_schools_by_uuid(school_identifiers)
+        provider_schools_by_uuid(provider_school_uuids: school_uuids)
       else
-        legacy_sites_by_identifier(school_identifiers)
-      end
-    end
-
-    def legacy_sites_by_identifier(school_identifiers)
-      if uuid_identifiers?(school_identifiers)
-        sites_by_uuid(site_uuids: school_identifiers)
-      elsif legacy_site_id_identifiers?(school_identifiers)
-        sites_by_id(site_ids: school_identifiers)
-      else
-        raise ArgumentError, "School identifiers must not mix legacy Site IDs and UUIDs"
+        sites_by_uuid(site_uuids: school_uuids)
       end
     end
 
@@ -67,28 +56,16 @@ module CourseSchools
       provider.sites.where(uuid: site_uuids).index_by { |site| site.uuid.to_s }
     end
 
-    def sites_by_id(site_ids:)
-      provider.sites.where(id: site_ids).index_by { |site| site.id.to_s }
-    end
-
-    def provider_schools_by_uuid(provider_school_uuids)
+    def provider_schools_by_uuid(provider_school_uuids:)
       provider.schools.where(uuid: provider_school_uuids).index_by { |school| school.uuid.to_s }
     end
 
-    def uuid_identifiers?(school_identifiers)
-      school_identifiers.all? { |identifier| uuid?(identifier) }
+    def ordered_records_for(school_uuids, records_by_uuid)
+      school_uuids.map { |uuid| records_by_uuid.fetch(uuid) }
     end
 
-    def legacy_site_id_identifiers?(school_identifiers)
-      school_identifiers.all? { |identifier| legacy_site_id?(identifier) }
-    end
-
-    def ordered_records_for(school_identifiers, records_by_identifier)
-      school_identifiers.map { |identifier| records_by_identifier.fetch(identifier) }
-    end
-
-    def normalize_school_identifiers(school_identifiers)
-      Array(school_identifiers).compact_blank.map(&:to_s).uniq
+    def normalize_school_uuids(school_uuids)
+      Array(school_uuids).compact_blank.map(&:to_s).uniq
     end
 
     def require_course!
@@ -97,26 +74,22 @@ module CourseSchools
       raise ArgumentError, "CourseSchools::Identity requires a course for current_school_uuids"
     end
 
-    def validate_uuid_identifiers!(school_identifiers)
-      invalid_identifiers = school_identifiers.reject { |identifier| uuid?(identifier) }
-      return if invalid_identifiers.empty?
+    def validate_uuid_values!(school_uuids)
+      invalid_uuids = school_uuids.reject { |uuid| uuid?(uuid) }
+      return if invalid_uuids.empty?
 
-      raise ArgumentError, "School identifiers must be Provider::School UUIDs after the schools remodel cycle"
+      raise ArgumentError, "School UUIDs must be valid UUIDs"
     end
 
-    def validate_all_identifiers_resolved!(school_identifiers, records_by_identifier)
-      unresolved_identifiers = school_identifiers - records_by_identifier.keys
-      return if unresolved_identifiers.empty?
+    def validate_all_uuids_resolved!(school_uuids, records_by_uuid)
+      unresolved_uuids = school_uuids - records_by_uuid.keys
+      return if unresolved_uuids.empty?
 
-      raise ArgumentError, "Could not resolve school identifiers for provider #{provider.id}: #{unresolved_identifiers.join(', ')}"
+      raise ArgumentError, "Could not resolve school UUIDs for provider #{provider.id}: #{unresolved_uuids.join(', ')}"
     end
 
-    def uuid?(identifier)
-      identifier.to_s.match?(UUID_PATTERN)
-    end
-
-    def legacy_site_id?(identifier)
-      identifier.to_s.match?(LEGACY_SITE_ID_PATTERN)
+    def uuid?(uuid)
+      uuid.to_s.match?(UUID_PATTERN)
     end
   end
 end

--- a/spec/services/course_schools/identity_spec.rb
+++ b/spec/services/course_schools/identity_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe CourseSchools::Identity do
       expect(identity.current_school_uuids).to eq([site_uuid])
       expect(identity.school_records_for(school_uuids: [site_uuid])).to eq([site])
     end
+
+    it "does not load all available schools before they are needed" do
+      identity = described_class.new(provider:, course:)
+      available_schools = identity.available_schools
+
+      expect(available_schools).to be_a(ActiveRecord::Relation)
+      expect(available_schools).not_to be_loaded
+      expect(identity.available_schools_count).to eq(1)
+      expect(available_schools).not_to be_loaded
+    end
   end
 
   context "when the provider is in the schools remodel cycle" do
@@ -153,7 +163,7 @@ RSpec.describe CourseSchools::Identity do
     it "supports provider-only school lists" do
       identity = described_class.new(provider:)
 
-      expect(identity.available_schools).to eq([site])
+      expect(identity.available_schools).to contain_exactly(site)
     end
 
     it "raises a descriptive error for course-specific school UUIDs" do

--- a/spec/services/course_schools/identity_spec.rb
+++ b/spec/services/course_schools/identity_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseSchools::Identity do
+  let(:remodel_cycle_year) { 2026 }
+  let(:gias_school) { create(:gias_school, urn: "123456") }
+  let(:site_uuid) { Faker::Internet.uuid }
+  let(:provider_school_uuid) { Faker::Internet.uuid }
+
+  before do
+    allow(Settings).to receive(:schools_remodel_cycle_year).and_return(remodel_cycle_year)
+  end
+
+  context "when the provider is in the schools remodel cycle" do
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
+    let(:course) { create(:course, provider:) }
+    let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+
+    before do
+      create(:site_status, course:, site:)
+    end
+
+    it "uses legacy site records and site UUIDs" do
+      identity = described_class.new(provider:, course:)
+
+      expect(identity.available_schools).to contain_exactly(site)
+      expect(identity.current_school_uuids).to eq([site_uuid])
+      expect(identity.school_records_for(school_uuids: [site_uuid])).to eq([site])
+    end
+
+    it "still resolves legacy site IDs for old add-course paths" do
+      identity = described_class.new(provider:, course:)
+
+      expect(identity.school_records_for(school_uuids: [site.id])).to eq([site])
+    end
+  end
+
+  context "when the provider is after the schools remodel cycle" do
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
+    let(:course) { create(:course, provider:) }
+    let!(:legacy_site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+    let!(:provider_school) do
+      create(:provider_school, provider:, gias_school:, site_code: legacy_site.code, uuid: provider_school_uuid)
+    end
+
+    before do
+      create(:course_school, course:, provider_school:, gias_school:)
+    end
+
+    it "uses provider school records and provider school UUIDs" do
+      identity = described_class.new(provider:, course:)
+
+      expect(identity.available_schools).to contain_exactly(provider_school)
+      expect(identity.current_school_uuids).to eq([provider_school_uuid])
+      expect(identity.school_records_for(school_uuids: [provider_school_uuid])).to eq([provider_school])
+    end
+
+    it "does not resolve a diverged legacy site UUID" do
+      identity = described_class.new(provider:, course:)
+
+      expect(identity.school_records_for(school_uuids: [site_uuid])).to be_empty
+    end
+  end
+end

--- a/spec/services/course_schools/identity_spec.rb
+++ b/spec/services/course_schools/identity_spec.rb
@@ -7,9 +7,29 @@ RSpec.describe CourseSchools::Identity do
   let(:gias_school) { create(:gias_school, urn: "123456") }
   let(:site_uuid) { Faker::Internet.uuid }
   let(:provider_school_uuid) { Faker::Internet.uuid }
+  let(:unknown_school_uuid) { Faker::Internet.uuid }
 
   before do
     allow(Settings).to receive(:schools_remodel_cycle_year).and_return(remodel_cycle_year)
+  end
+
+  context "when the provider is before the schools remodel cycle" do
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year - 1) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
+    let(:course) { create(:course, provider:) }
+    let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+
+    before do
+      create(:site_status, course:, site:)
+    end
+
+    it "uses legacy site records and site UUIDs" do
+      identity = described_class.new(provider:, course:)
+
+      expect(identity.available_schools).to contain_exactly(site)
+      expect(identity.current_school_uuids).to eq([site_uuid])
+      expect(identity.school_records_for(school_identifiers: [site_uuid])).to eq([site])
+    end
   end
 
   context "when the provider is in the schools remodel cycle" do
@@ -27,13 +47,49 @@ RSpec.describe CourseSchools::Identity do
 
       expect(identity.available_schools).to contain_exactly(site)
       expect(identity.current_school_uuids).to eq([site_uuid])
-      expect(identity.school_records_for(school_uuids: [site_uuid])).to eq([site])
+      expect(identity.school_records_for(school_identifiers: [site_uuid])).to eq([site])
     end
 
     it "still resolves legacy site IDs for old add-course paths" do
       identity = described_class.new(provider:, course:)
 
-      expect(identity.school_records_for(school_uuids: [site.id])).to eq([site])
+      expect(identity.school_records_for(school_identifiers: [site.id])).to eq([site])
+    end
+
+    it "rejects an unknown legacy site UUID" do
+      identity = described_class.new(provider:, course:)
+
+      expect { identity.school_records_for(school_identifiers: [unknown_school_uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+    end
+
+    it "rejects a legacy site belonging to another provider" do
+      other_provider = create(:provider, recruitment_cycle:)
+      other_site = create(:site, provider: other_provider, uuid: unknown_school_uuid)
+      identity = described_class.new(provider:, course:)
+
+      expect { identity.school_records_for(school_identifiers: [other_site.uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+    end
+
+    it "rejects a mixture of valid and invalid identifiers" do
+      identity = described_class.new(provider:, course:)
+
+      expect { identity.school_records_for(school_identifiers: [site_uuid, unknown_school_uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+    end
+
+    it "rejects mixed legacy site IDs and UUIDs" do
+      identity = described_class.new(provider:, course:)
+
+      expect { identity.school_records_for(school_identifiers: [site.id, site_uuid]) }
+        .to raise_error(ArgumentError, /must not mix legacy Site IDs and UUIDs/)
+    end
+
+    it "deduplicates duplicate identifiers" do
+      identity = described_class.new(provider:, course:)
+
+      expect(identity.school_records_for(school_identifiers: [site_uuid, site_uuid])).to eq([site])
     end
   end
 
@@ -55,13 +111,62 @@ RSpec.describe CourseSchools::Identity do
 
       expect(identity.available_schools).to contain_exactly(provider_school)
       expect(identity.current_school_uuids).to eq([provider_school_uuid])
-      expect(identity.school_records_for(school_uuids: [provider_school_uuid])).to eq([provider_school])
+      expect(identity.school_records_for(school_identifiers: [provider_school_uuid])).to eq([provider_school])
+    end
+
+    it "rejects an unknown provider school UUID" do
+      identity = described_class.new(provider:, course:)
+
+      expect { identity.school_records_for(school_identifiers: [unknown_school_uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+    end
+
+    it "rejects a provider school belonging to another provider" do
+      other_provider = create(:provider, recruitment_cycle:)
+      other_provider_school = create(:provider_school, provider: other_provider, uuid: unknown_school_uuid)
+      identity = described_class.new(provider:, course:)
+
+      expect { identity.school_records_for(school_identifiers: [other_provider_school.uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
     end
 
     it "does not resolve a diverged legacy site UUID" do
       identity = described_class.new(provider:, course:)
 
-      expect(identity.school_records_for(school_uuids: [site_uuid])).to be_empty
+      expect { identity.school_records_for(school_identifiers: [site_uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+    end
+
+    it "rejects legacy site IDs" do
+      identity = described_class.new(provider:, course:)
+
+      expect { identity.school_records_for(school_identifiers: [legacy_site.id]) }
+        .to raise_error(ArgumentError, /must be Provider::School UUIDs/)
+    end
+
+    it "deduplicates duplicate identifiers" do
+      identity = described_class.new(provider:, course:)
+
+      expect(identity.school_records_for(school_identifiers: [provider_school_uuid, provider_school_uuid])).to eq([provider_school])
+    end
+  end
+
+  context "when initialized without a course" do
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
+    let!(:site) { create(:site, provider:) }
+
+    it "supports provider-only school lists" do
+      identity = described_class.new(provider:)
+
+      expect(identity.available_schools).to eq([site])
+    end
+
+    it "raises a descriptive error for course-specific school UUIDs" do
+      identity = described_class.new(provider:)
+
+      expect { identity.current_school_uuids }
+        .to raise_error(ArgumentError, /requires a course for current_school_uuids/)
     end
   end
 end

--- a/spec/services/course_schools/identity_spec.rb
+++ b/spec/services/course_schools/identity_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CourseSchools::Identity do
 
       expect(identity.available_schools).to contain_exactly(site)
       expect(identity.current_school_uuids).to eq([site_uuid])
-      expect(identity.school_records_for(school_identifiers: [site_uuid])).to eq([site])
+      expect(identity.school_records_for(school_uuids: [site_uuid])).to eq([site])
     end
   end
 
@@ -47,20 +47,14 @@ RSpec.describe CourseSchools::Identity do
 
       expect(identity.available_schools).to contain_exactly(site)
       expect(identity.current_school_uuids).to eq([site_uuid])
-      expect(identity.school_records_for(school_identifiers: [site_uuid])).to eq([site])
-    end
-
-    it "still resolves legacy site IDs for old add-course paths" do
-      identity = described_class.new(provider:, course:)
-
-      expect(identity.school_records_for(school_identifiers: [site.id])).to eq([site])
+      expect(identity.school_records_for(school_uuids: [site_uuid])).to eq([site])
     end
 
     it "rejects an unknown legacy site UUID" do
       identity = described_class.new(provider:, course:)
 
-      expect { identity.school_records_for(school_identifiers: [unknown_school_uuid]) }
-        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+      expect { identity.school_records_for(school_uuids: [unknown_school_uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school UUIDs/)
     end
 
     it "rejects a legacy site belonging to another provider" do
@@ -68,28 +62,28 @@ RSpec.describe CourseSchools::Identity do
       other_site = create(:site, provider: other_provider, uuid: unknown_school_uuid)
       identity = described_class.new(provider:, course:)
 
-      expect { identity.school_records_for(school_identifiers: [other_site.uuid]) }
-        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+      expect { identity.school_records_for(school_uuids: [other_site.uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school UUIDs/)
     end
 
-    it "rejects a mixture of valid and invalid identifiers" do
+    it "rejects a mixture of valid and unknown UUIDs" do
       identity = described_class.new(provider:, course:)
 
-      expect { identity.school_records_for(school_identifiers: [site_uuid, unknown_school_uuid]) }
-        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+      expect { identity.school_records_for(school_uuids: [site_uuid, unknown_school_uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school UUIDs/)
     end
 
-    it "rejects mixed legacy site IDs and UUIDs" do
+    it "rejects legacy site IDs" do
       identity = described_class.new(provider:, course:)
 
-      expect { identity.school_records_for(school_identifiers: [site.id, site_uuid]) }
-        .to raise_error(ArgumentError, /must not mix legacy Site IDs and UUIDs/)
+      expect { identity.school_records_for(school_uuids: [site.id]) }
+        .to raise_error(ArgumentError, /School UUIDs must be valid UUIDs/)
     end
 
-    it "deduplicates duplicate identifiers" do
+    it "deduplicates duplicate UUIDs" do
       identity = described_class.new(provider:, course:)
 
-      expect(identity.school_records_for(school_identifiers: [site_uuid, site_uuid])).to eq([site])
+      expect(identity.school_records_for(school_uuids: [site_uuid, site_uuid])).to eq([site])
     end
   end
 
@@ -111,14 +105,14 @@ RSpec.describe CourseSchools::Identity do
 
       expect(identity.available_schools).to contain_exactly(provider_school)
       expect(identity.current_school_uuids).to eq([provider_school_uuid])
-      expect(identity.school_records_for(school_identifiers: [provider_school_uuid])).to eq([provider_school])
+      expect(identity.school_records_for(school_uuids: [provider_school_uuid])).to eq([provider_school])
     end
 
     it "rejects an unknown provider school UUID" do
       identity = described_class.new(provider:, course:)
 
-      expect { identity.school_records_for(school_identifiers: [unknown_school_uuid]) }
-        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+      expect { identity.school_records_for(school_uuids: [unknown_school_uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school UUIDs/)
     end
 
     it "rejects a provider school belonging to another provider" do
@@ -126,28 +120,28 @@ RSpec.describe CourseSchools::Identity do
       other_provider_school = create(:provider_school, provider: other_provider, uuid: unknown_school_uuid)
       identity = described_class.new(provider:, course:)
 
-      expect { identity.school_records_for(school_identifiers: [other_provider_school.uuid]) }
-        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+      expect { identity.school_records_for(school_uuids: [other_provider_school.uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school UUIDs/)
     end
 
     it "does not resolve a diverged legacy site UUID" do
       identity = described_class.new(provider:, course:)
 
-      expect { identity.school_records_for(school_identifiers: [site_uuid]) }
-        .to raise_error(ArgumentError, /Could not resolve school identifiers/)
+      expect { identity.school_records_for(school_uuids: [site_uuid]) }
+        .to raise_error(ArgumentError, /Could not resolve school UUIDs/)
     end
 
     it "rejects legacy site IDs" do
       identity = described_class.new(provider:, course:)
 
-      expect { identity.school_records_for(school_identifiers: [legacy_site.id]) }
-        .to raise_error(ArgumentError, /must be Provider::School UUIDs/)
+      expect { identity.school_records_for(school_uuids: [legacy_site.id]) }
+        .to raise_error(ArgumentError, /School UUIDs must be valid UUIDs/)
     end
 
-    it "deduplicates duplicate identifiers" do
+    it "deduplicates duplicate UUIDs" do
       identity = described_class.new(provider:, course:)
 
-      expect(identity.school_records_for(school_identifiers: [provider_school_uuid, provider_school_uuid])).to eq([provider_school])
+      expect(identity.school_records_for(school_uuids: [provider_school_uuid, provider_school_uuid])).to eq([provider_school])
     end
   end
 


### PR DESCRIPTION
## Context

This is the first, preparatory PR for creating and removing course_schools.

This PR does not wire the service into course creation or course school updates yet. It only introduces the switching contract and its coverage.

## Changes proposed in this pull request

- Adds `CourseSchools::Identity`.
- Uses `Site` records for recruitment cycles before and during the schools remodel cycle.
- Uses `Provider::School` records for recruitment cycles after the schools remodel cycle.
- Adds strict validation when resolving submitted school identifiers:
  - unknown identifiers raise an error, only uuid permitted
  - identifiers from another provider raise an error
  - duplicate identifiers are deduplicated
- Adds a clear error when course-specific methods are called without a course.
- Adds specs for the before, during, and after remodel cycle boundaries.

No UI changes.

## Guidance to review

I suggest reviewing this PR in two parts:

1. `app/services/course_schools/identity.rb`
   - Check whether the cycle boundary reads correctly:
     - before remodel cycle: `Site`
     - remodel cycle: `Site`
     - after remodel cycle: `Provider::School`
   - Check whether the method naming is clear

2. `spec/services/course_schools/identity_spec.rb`
   - Check the edge-case coverage for unresolved identifiers, another provider’s schools, duplicate identifiers, mixed ID/UUID input, and missing course usage.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
