### PR TITLE
Fix db restore

### DIFF
--- a/.github/actions/restore/action.yml
+++ b/.github/actions/restore/action.yml
@@ -85,3 +85,4 @@ runs:
       shell: bash
       run: |
         bin/konduit.sh -n ${NAMESPACE} -i ${SANITISED_FILE_NAME}.sql.gz -c -t 7200 -x ${{ env.app_name }} -- psql
+        bin/konduit.sh -n ${NAMESPACE} -x -t 300 ${{ env.app_name }} -- psql -c 'drop publication airbyte_publication' || true

--- a/.github/actions/restore/action.yml
+++ b/.github/actions/restore/action.yml
@@ -84,4 +84,4 @@ runs:
     - name: Restore backup to aks env database
       shell: bash
       run: |
-        bin/konduit.sh -n ${NAMESPACE} -i ${SANITISED_FILE_NAME}.sql.gz -c -t 7200 ${{ env.app_name }} -- psql
+        bin/konduit.sh -n ${NAMESPACE} -i ${SANITISED_FILE_NAME}.sql.gz -c -t 7200 -x ${{ env.app_name }} -- psql


### PR DESCRIPTION
## Context

Adds alter table command to database backup action 

## Changes proposed in this pull request

Adds alter table command to the database back action to resolve issue with restores following Airbyte being enabled 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
