### PR TITLE
Change sanitise workflow to use postgis

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -56,7 +56,7 @@ jobs:
       BACKUP_FILE: ${{ inputs.backup-file || 'schedule'  }}
     services:
       postgres:
-        image: postgres:14.7
+        image: postgis/postgis:17-3.6-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## Context

Sanitise restore failing since https://github.com/DFE-Digital/publish-teacher-training/pull/6235 was merged.
The restore into the postgres container used for sanitise began failing with
ERROR:  type "public.geography" does not exist
  LINE 26:     geo_location public.geography(Point,4326) GENERATED ALWA...
                            ^
  CREATE SEQUENCE
  ERROR:  relation "public.gias_school" does not exist
Which is due to it using postgres and not postgis.
The sanitise restore stopped at this point, so not all tables had data (like schema_migrations) but the process continued all the way to qa and staging restore.

## Changes proposed in this pull request

Changed sanitise container to use postgis

## Guidance to review

see https://github.com/DFE-Digital/publish-teacher-training/actions/runs/30073596676/job/89419451035 

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
