### PR TITLE
Bump QA worker resources to run rollover

### DIFF
--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -14,8 +14,8 @@
   },
   "worker_apps": {
     "worker": {
-      "replicas": 1,
-      "max_memory": "1.2Gi"
+      "replicas": 2,
+      "max_memory": "2Gi"
     }
   },
   "enable_find": true,


### PR DESCRIPTION
## Context

  We plan to run rollover in QA often until we rollover production

There are 5 threads per worker so this change will process 10 threads concurrently, 5 per 2Gi

## Changes proposed in this pull request

Increase QA worker replicas from 1 to 2
Increase memory per replica from 1.2Gi to 2Gi

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
