### PR TITLE
School Data - UI Publish - Provider school details from the new model

### DIFF
--- a/app/components/publish/schools/newly_added_tag_component.rb
+++ b/app/components/publish/schools/newly_added_tag_component.rb
@@ -9,7 +9,21 @@ module Publish
       end
 
       def render?
-        @school.respond_to?(:register_import?) && @school.register_import? && @recruitment_cycle.rollover_period_2026?
+        register_import? && @recruitment_cycle.rollover_period_2026?
+      end
+
+    private
+
+      def register_import?
+        if @school.is_a?(Site)
+          @school.register_import?
+        else
+          legacy_site&.register_import?
+        end
+      end
+
+      def legacy_site
+        @legacy_site ||= @school.provider.sites.find_by(uuid: @school.uuid)
       end
     end
   end

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -44,7 +44,7 @@ module Publish
       helper_method :school_removal
 
       def school
-        @school ||= ProviderSchools::Identity.new(provider:).school_for(uuid: params[:uuid]).decorate
+        @school ||= provider.schools.find_by!(uuid: params[:uuid]).decorate
       end
       helper_method :school
 

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Providers
     class SchoolsController < ApplicationController
-      before_action :site, only: %i[show delete destroy]
+      before_action :school, only: %i[show delete destroy]
       before_action :reset_urn_form, only: %i[index]
 
       PER_PAGE = 20
@@ -31,7 +31,7 @@ module Publish
           flash[:success] = "School removed"
           redirect_to publish_provider_recruitment_cycle_schools_path
         else
-          redirect_to delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid),
+          redirect_to delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid),
                       flash: { warning: t(".cannot_remove_school") }
         end
       end
@@ -43,9 +43,10 @@ module Publish
       end
       helper_method :school_removal
 
-      def site
-        @site ||= school_removal.school
+      def school
+        @school ||= ProviderSchools::Identity.new(provider:).school_for(uuid: params[:uuid]).decorate
       end
+      helper_method :school
 
       def site_params(param_form_key)
         params.expect(param_form_key => SchoolForm::FIELDS)

--- a/app/decorators/provider/school_decorator.rb
+++ b/app/decorators/provider/school_decorator.rb
@@ -11,4 +11,8 @@ class Provider::SchoolDecorator < Draper::Decorator
   def location_name
     smart_quotes(object.location_name)
   end
+
+  delegate :code, to: :object
+
+  delegate :urn, to: :object
 end

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -28,9 +28,13 @@ class Provider::School < ApplicationRecord
             if: -> { site_code == MAIN_SITE_CODE }
 
   def location_name
-    return "#{gias_school.name} (Main site)" if site_code == MAIN_SITE_CODE
+    return "#{gias_school.name} (Main Site)" if main_site?
 
     gias_school.name
+  end
+
+  def main_site?
+    site_code == MAIN_SITE_CODE
   end
 
   def code

--- a/app/services/course_schools/identity.rb
+++ b/app/services/course_schools/identity.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 module CourseSchools
-  # Chooses the school model for a provider's recruitment cycle.
-  # Current and rollover cycles use legacy Site records; cycles after the remodel
-  # use Provider::School records because Site and Provider::School UUIDs diverge
-  # after rollover.
+  # Resolves available schools for listing via ProviderSchools::Identity (Provider::School).
+  # Course association UUID resolution still uses legacy Site records until after the
+  # remodel cycle, because Site and Provider::School UUIDs diverge after rollover.
   class Identity
     UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
 

--- a/app/services/provider_schools/identity.rb
+++ b/app/services/provider_schools/identity.rb
@@ -15,7 +15,7 @@ module ProviderSchools
     end
 
     def ordered_school_scope
-      if after_schools_remodel_cycle?
+      if uses_provider_schools?
         provider.schools.joins(:gias_school).includes(:gias_school).order("gias_school.name")
       else
         provider.sites.order(:location_name)

--- a/app/services/provider_schools/identity.rb
+++ b/app/services/provider_schools/identity.rb
@@ -23,22 +23,19 @@ module ProviderSchools
     end
 
     def school_for(uuid:)
-      if after_schools_remodel_cycle?
+      if uses_provider_schools?
         provider.schools.find_by!(uuid:)
       else
         provider.sites.find_by!(uuid:)
       end
     end
 
-    def provider_school_for(site:)
-      provider
-        .schools
-        .joins(:gias_school)
-        .find_by!(gias_school: { urn: site.urn }, site_code: site.code)
-    end
-
     def after_schools_remodel_cycle?
       provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
+    end
+
+    def uses_provider_schools?
+      provider.recruitment_cycle.year.to_i >= Settings.schools_remodel_cycle_year.to_i
     end
 
   private

--- a/app/services/provider_schools/identity.rb
+++ b/app/services/provider_schools/identity.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 module ProviderSchools
-  # This service determines which model should be used when creating, removing and in some instances viewing schools.
-  # The legacy data model uses Site, while the new data model uses Provider::School.
-  # During the rollover, both models are written to and their UUIDs may diverge, so we need a way to switch to the new data model.
-  # Because Publish supports both the old and new recruitment cycles during the rollover, this switch must be based on the recruitment cycle rather than a traditional feature flag.
+  # Resolves schools for listing and detail views from the new Provider::School model.
+  # Write/removal paths may still use after_schools_remodel_cycle? where dual-writing
+  # to legacy Site records continues during the remodel transition.
   class Identity
     def self.ordered_school_scope(provider:)
       new(provider:).ordered_school_scope
@@ -15,27 +14,15 @@ module ProviderSchools
     end
 
     def ordered_school_scope
-      if uses_provider_schools?
-        provider.schools.joins(:gias_school).includes(:gias_school).order("gias_school.name")
-      else
-        provider.sites.order(:location_name)
-      end
+      provider.schools.joins(:gias_school).includes(:gias_school).order("gias_school.name")
     end
 
     def school_for(uuid:)
-      if uses_provider_schools?
-        provider.schools.find_by!(uuid:)
-      else
-        provider.sites.find_by!(uuid:)
-      end
+      provider.schools.find_by!(uuid:)
     end
 
     def after_schools_remodel_cycle?
       provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
-    end
-
-    def uses_provider_schools?
-      provider.recruitment_cycle.year.to_i >= Settings.schools_remodel_cycle_year.to_i
     end
 
   private

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -12,7 +12,11 @@ module ProviderSchools
 
     def call
       ActiveRecord::Base.transaction do
-        if provider_school.present?
+        if after_schools_remodel_cycle?
+          school.with_lock do
+            destroy_records_if_removable!
+          end
+        elsif provider_school.present?
           provider_school.with_lock do
             destroy_records_if_removable!
           end
@@ -23,30 +27,26 @@ module ProviderSchools
     end
 
     def site
-      @site ||= school if school.is_a?(Site)
+      @site ||= provider.sites.find_by(uuid:) unless after_schools_remodel_cycle?
     end
 
     def school
       @school ||= identity.school_for(uuid:)
-    end
-
-    def provider_school
-      @provider_school ||= if after_schools_remodel_cycle?
-                             school
-                           else
-                             identity.provider_school_for(site:)
-                           end
     rescue ActiveRecord::RecordNotFound
       raise if after_schools_remodel_cycle?
 
       nil
     end
 
+    def provider_school
+      @provider_school ||= provider.schools.find_by(uuid:)
+    end
+
     def removable?
       if after_schools_remodel_cycle?
-        !provider_school.course_schools.exists?
+        !school.course_schools.exists?
       else
-        site.has_no_course? && provider_school_course_schools_empty?
+        site&.has_no_course? && provider_school_course_schools_empty?
       end
     end
 
@@ -70,7 +70,7 @@ module ProviderSchools
 
     def destroy_records!
       provider_school.destroy!
-      site.destroy! unless after_schools_remodel_cycle?
+      site&.destroy!
     end
 
     def provider_school_course_schools_empty?

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -39,11 +39,7 @@ module ProviderSchools
     end
 
     def removable?
-      if after_schools_remodel_cycle?
-        !school.course_schools.exists?
-      else
-        site&.has_no_course? && provider_school_course_schools_empty?
-      end
+      !school.course_schools.exists?
     end
 
   private

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -32,10 +32,6 @@ module ProviderSchools
 
     def school
       @school ||= identity.school_for(uuid:)
-    rescue ActiveRecord::RecordNotFound
-      raise if after_schools_remodel_cycle?
-
-      nil
     end
 
     def provider_school

--- a/app/services/provider_schools/removal.rb
+++ b/app/services/provider_schools/removal.rb
@@ -39,7 +39,7 @@ module ProviderSchools
     end
 
     def removable?
-      !school.course_schools.exists?
+      !school.course_schools.joins(:course).merge(Course.kept).exists?
     end
 
   private
@@ -54,8 +54,6 @@ module ProviderSchools
     end
 
     def destroy_site_if_removable!
-      return false unless removable?
-
       site.destroy!
       true
     end
@@ -63,10 +61,6 @@ module ProviderSchools
     def destroy_records!
       provider_school.destroy!
       site&.destroy!
-    end
-
-    def provider_school_course_schools_empty?
-      provider_school.nil? || !provider_school.course_schools.exists?
     end
   end
 end

--- a/app/views/publish/providers/schools/delete.html.erb
+++ b/app/views/publish/providers/schools/delete.html.erb
@@ -1,31 +1,31 @@
 <%= render PageTitle.new(title: "publish.providers.schools.delete") %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid)) %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid)) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= @site.location_name %></span>
+      <span class="govuk-caption-l"><%= school.location_name %></span>
       <% if school_removal.removable? %>
         <%= t("components.page_titles.publish.providers.schools.delete") %>
         </h1>
         <%= govuk_button_to "Remove school",
-          delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid),
+          delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid),
           method: :delete,
           class: "govuk-button--warning" %>
       <% else %>
         <%= t("components.page_titles.publish.providers.schools.no_delete") %>
       </h1>
       <p class="govuk-body">
-        <%= "#{@site.location_name} is a school for courses run by #{@provider.provider_name}." %>
+        <%= "#{school.location_name} is a school for courses run by #{@provider.provider_name}." %>
       </p>
       <p class="govuk-body">
-        To remove <%= @site.location_name.to_s %>, you must first remove the school from those courses.
+        To remove <%= school.location_name %>, you must first remove the school from those courses.
       </p>
     <% end %>
     <p class="govuk-body">
-        <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid)) %>
+        <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid)) %>
     </p>
   </div>
 </div>

--- a/app/views/publish/providers/schools/show.html.erb
+++ b/app/views/publish/providers/schools/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @site.location_name %>
+<%= content_for :page_title, school.location_name %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_recruitment_cycle_schools_path) %>
 <% end %>
@@ -7,27 +7,27 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= @site.location_name %></h1>
+        <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= school.location_name %></h1>
       </legend>
       <%= render GovukComponent::SummaryListComponent.new do |component|
             component.with_row do |row|
               row.with_key { t(".code") }
-              row.with_value(text: @site.code)
+              row.with_value(text: school.code)
               row.with_action
             end
 
             component.with_row do |row|
               row.with_key { t(".urn") }
-              row.with_value(text: value_provided?(@site.urn))
+              row.with_value(text: value_provided?(school.urn))
             end
 
             component.with_row do |row|
               row.with_key { t(".address") }
-              row.with_value(text: simple_format(@site.decorate.full_address_on_seperate_lines, {}, wrapper_tag: :div))
+              row.with_value(text: simple_format(school.full_address_on_seperate_lines, {}, wrapper_tag: :div))
             end
           end %>
       <p class="govuk-body">
-        <%= govuk_link_to t(".remove", resource: "location"), delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, @site.recruitment_cycle.year, @site.uuid), class: "app-link--destructive" %>
+        <%= govuk_link_to t(".remove", resource: "location"), delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid), class: "app-link--destructive" %>
       </p>
     </fieldset>
   </div>

--- a/spec/components/publish/schools/newly_added_tag_component_spec.rb
+++ b/spec/components/publish/schools/newly_added_tag_component_spec.rb
@@ -3,11 +3,32 @@
 require "rails_helper"
 
 RSpec.describe Publish::Schools::NewlyAddedTagComponent, type: :component do
-  it "does not render for provider school rows from the new model" do
-    provider_school = create(:provider_school)
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: 2026) }
+  let(:provider) { create(:provider, recruitment_cycle:) }
+
+  it "does not render for provider schools without a matching legacy site" do
+    provider_school = create(:provider_school, provider:)
 
     render_inline(described_class.new(school: provider_school))
 
     expect(page).not_to have_css(".newly-added-tag")
+  end
+
+  it "renders for provider schools backed by a register import legacy site during the 2026 rollover period" do
+    gias_school = create(:gias_school)
+    site = create(:site, provider:, added_via: :register_import, urn: gias_school.urn)
+    provider_school = create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
+
+    render_inline(described_class.new(school: provider_school))
+
+    expect(page).to have_css(".newly-added-tag", text: "Newly added")
+  end
+
+  it "renders for register import legacy sites during the 2026 rollover period" do
+    site = create(:site, provider:, added_via: :register_import)
+
+    render_inline(described_class.new(school: site))
+
+    expect(page).to have_css(".newly-added-tag", text: "Newly added")
   end
 end

--- a/spec/components/publish/schools/newly_added_tag_component_spec.rb
+++ b/spec/components/publish/schools/newly_added_tag_component_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Publish::Schools::NewlyAddedTagComponent, type: :component do
+RSpec.describe Publish::Schools::NewlyAddedTagComponent, travel: 1.hour.before(find_closes(2025)), type: :component do
   let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: 2026) }
   let(:provider) { create(:provider, recruitment_cycle:) }
 

--- a/spec/decorators/provider/school_decorator_spec.rb
+++ b/spec/decorators/provider/school_decorator_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Provider::SchoolDecorator do
+  subject(:decorated_school) { provider_school.decorate }
+
+  let(:gias_school) do
+    create(
+      :gias_school,
+      name: "Example School",
+      urn: "123456",
+      address1: "1 Example Road",
+      town: "Example Town",
+      postcode: "EX1 1AA",
+    )
+  end
+  let(:provider_school) { create(:provider_school, gias_school:, site_code:) }
+  let(:site_code) { "A" }
+
+  describe "#location_name" do
+    context "when the school is a main site" do
+      let(:site_code) { Provider::School::MAIN_SITE_CODE }
+
+      it "includes the main site suffix" do
+        expect(decorated_school.location_name).to eq("Example School (Main Site)")
+      end
+    end
+
+    context "when the school is not a main site" do
+      it "returns the GIAS school name" do
+        expect(decorated_school.location_name).to eq("Example School")
+      end
+    end
+  end
+
+  describe "#full_address_on_seperate_lines" do
+    it "returns the GIAS address on separate lines" do
+      expect(decorated_school.full_address_on_seperate_lines).to eq("1 Example Road\nExample Town\nEX1 1AA")
+    end
+  end
+end

--- a/spec/requests/publish/providers/schools_spec.rb
+++ b/spec/requests/publish/providers/schools_spec.rb
@@ -28,6 +28,30 @@ RSpec.describe "Publish provider school show page", service: :publish do
     login_user(create(:user, providers: [provider]))
   end
 
+  describe "GET /publish/organisations/:provider_code/:recruitment_cycle_year/schools" do
+    context "when the provider is in the schools remodel cycle" do
+      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: SecureRandom.uuid) }
+      let!(:provider_school) do
+        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
+      end
+
+      before { login_provider_user(provider) }
+
+      it "lists provider schools resolved from the new model" do
+        get publish_provider_recruitment_cycle_schools_path(provider.provider_code, recruitment_cycle.year)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("St Joseph")
+        expect(response.body).to include("Catholic Primary School")
+        expect(response.body).to include("A")
+        expect(response.body).to include("112992")
+        expect(response.body).to include(publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid))
+      end
+    end
+  end
+
   describe "GET /publish/organisations/:provider_code/:recruitment_cycle_year/schools/:uuid" do
     context "when the provider is in the schools remodel cycle" do
       let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year) }

--- a/spec/requests/publish/providers/schools_spec.rb
+++ b/spec/requests/publish/providers/schools_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Publish provider school show page", service: :publish do
+  include DfESignInUserHelper
+
+  let(:remodel_cycle_year) { Settings.schools_remodel_cycle_year }
+  let(:gias_school) do
+    create(
+      :gias_school,
+      name: "St Joseph's Catholic Primary School",
+      urn: "112992",
+      address1: "1 School Lane",
+      address2: "Building A",
+      address3: "Quarter B",
+      town: "Leeds",
+      county: "West Yorkshire",
+      postcode: "LS1 1AA",
+    )
+  end
+
+  before do
+    allow(Settings).to receive(:schools_remodel_cycle_year).and_return(remodel_cycle_year)
+  end
+
+  def login_provider_user(provider)
+    login_user(create(:user, providers: [provider]))
+  end
+
+  describe "GET /publish/organisations/:provider_code/:recruitment_cycle_year/schools/:uuid" do
+    context "when the provider is in the schools remodel cycle" do
+      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: SecureRandom.uuid) }
+      let!(:provider_school) do
+        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
+      end
+
+      before { login_provider_user(provider) }
+
+      it "displays the provider school resolved from the legacy site uuid" do
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, site.uuid)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("St Joseph")
+        expect(response.body).to include("Catholic Primary School")
+        expect(response.body).to include("School code")
+        expect(response.body).to include("A")
+        expect(response.body).to include("112992")
+        expect(response.body).to include("1 School Lane")
+      end
+
+      it "returns not found when the provider school does not exist" do
+        provider_school.destroy!
+
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, site.uuid)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for another provider's school" do
+        other_provider_school = create(:provider_school)
+
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, other_provider_school.uuid)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the provider is after the schools remodel cycle" do
+      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: "B") }
+
+      before { login_provider_user(provider) }
+
+      it "displays the provider school" do
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("St Joseph")
+        expect(response.body).to include("Catholic Primary School")
+        expect(response.body).to include("B")
+      end
+
+      it "returns not found for a school in another recruitment cycle" do
+        other_cycle_school = create(
+          :provider_school,
+          provider: create(:provider, recruitment_cycle: find_or_create(:recruitment_cycle, year: remodel_cycle_year)),
+        )
+
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, other_cycle_school.uuid)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the same GIAS school is linked twice" do
+      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:normal_provider_school) { create(:provider_school, provider:, gias_school:, site_code: "A") }
+      let!(:main_provider_school) { create(:provider_school, :main_site, provider:, gias_school:) }
+
+      before { login_provider_user(provider) }
+
+      it "displays the normal school without the main site suffix" do
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, normal_provider_school.uuid)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("St Joseph")
+        expect(response.body).to include("Catholic Primary School")
+        expect(response.body).not_to include("(Main Site)")
+      end
+
+      it "displays the main site with the suffix" do
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, main_provider_school.uuid)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("(Main Site)")
+        expect(response.body).to include("-")
+      end
+    end
+  end
+
+  describe "GET /publish/organisations/:provider_code/:recruitment_cycle_year/schools/:uuid/delete" do
+    let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:) }
+
+    before { login_provider_user(provider) }
+
+    it "displays the delete page for the provider school" do
+      get delete_publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Remove school")
+      expect(response.body).to include("St Joseph")
+      expect(response.body).to include("Catholic Primary School")
+    end
+  end
+end

--- a/spec/requests/publish/providers/schools_spec.rb
+++ b/spec/requests/publish/providers/schools_spec.rb
@@ -29,6 +29,26 @@ RSpec.describe "Publish provider school show page", service: :publish do
   end
 
   describe "GET /publish/organisations/:provider_code/:recruitment_cycle_year/schools" do
+    context "when the provider is before the schools remodel cycle" do
+      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year - 1) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: SecureRandom.uuid) }
+      let!(:provider_school) do
+        create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
+      end
+
+      before { login_provider_user(provider) }
+
+      it "lists provider schools from the new model" do
+        get publish_provider_recruitment_cycle_schools_path(provider.provider_code, recruitment_cycle.year)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("St Joseph")
+        expect(response.body).to include("Catholic Primary School")
+        expect(response.body).to include(publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid))
+      end
+    end
+
     context "when the provider is in the schools remodel cycle" do
       let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year) }
       let(:provider) { create(:provider, recruitment_cycle:) }

--- a/spec/services/course_schools/identity_spec.rb
+++ b/spec/services/course_schools/identity_spec.rb
@@ -47,15 +47,16 @@ RSpec.describe CourseSchools::Identity do
     let(:provider) { create(:provider, recruitment_cycle:) }
     let(:course) { create(:course, provider:) }
     let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site_uuid) }
 
     before do
       create(:site_status, course:, site:)
     end
 
-    it "uses legacy site records and site UUIDs" do
+    it "lists provider schools but still uses legacy site records for course UUIDs" do
       identity = described_class.new(provider:, course:)
 
-      expect(identity.available_schools).to contain_exactly(site)
+      expect(identity.available_schools).to contain_exactly(provider_school)
       expect(identity.current_school_uuids).to eq([site_uuid])
       expect(identity.school_records_for(school_uuids: [site_uuid])).to eq([site])
     end
@@ -159,11 +160,12 @@ RSpec.describe CourseSchools::Identity do
     let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
     let(:provider) { create(:provider, recruitment_cycle:) }
     let!(:site) { create(:site, provider:) }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid) }
 
     it "supports provider-only school lists" do
       identity = described_class.new(provider:)
 
-      expect(identity.available_schools).to contain_exactly(site)
+      expect(identity.available_schools).to contain_exactly(provider_school)
     end
 
     it "raises a descriptive error for course-specific school UUIDs" do

--- a/spec/services/course_schools/identity_spec.rb
+++ b/spec/services/course_schools/identity_spec.rb
@@ -18,15 +18,16 @@ RSpec.describe CourseSchools::Identity do
     let(:provider) { create(:provider, recruitment_cycle:) }
     let(:course) { create(:course, provider:) }
     let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site_uuid) }
 
     before do
       create(:site_status, course:, site:)
     end
 
-    it "uses legacy site records and site UUIDs" do
+    it "lists provider schools but still uses legacy site records for course UUIDs" do
       identity = described_class.new(provider:, course:)
 
-      expect(identity.available_schools).to contain_exactly(site)
+      expect(identity.available_schools).to contain_exactly(provider_school)
       expect(identity.current_school_uuids).to eq([site_uuid])
       expect(identity.school_records_for(school_uuids: [site_uuid])).to eq([site])
     end

--- a/spec/services/provider_schools/identity_spec.rb
+++ b/spec/services/provider_schools/identity_spec.rb
@@ -25,12 +25,21 @@ RSpec.describe ProviderSchools::Identity do
 
   describe "#school_for" do
     context "when the provider is in the schools remodel cycle" do
-      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
+      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year) }
       let(:provider) { create(:provider, recruitment_cycle:) }
       let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site_uuid) }
 
-      it "finds the site by site uuid" do
-        expect(described_class.new(provider:).school_for(uuid: site_uuid)).to eq(site)
+      it "finds the provider school via the legacy site uuid" do
+        expect(described_class.new(provider:).school_for(uuid: site_uuid)).to eq(provider_school)
+      end
+
+      it "finds the correct provider school when the same GIAS school is linked twice" do
+        main_site = create(:site, :main_site, provider:, uuid: Faker::Internet.uuid)
+        main_provider_school = create(:provider_school, provider:, gias_school:, site_code: "-", uuid: main_site.uuid)
+
+        expect(described_class.new(provider:).school_for(uuid: main_site.uuid)).to eq(main_provider_school)
+        expect(described_class.new(provider:).school_for(uuid: site_uuid)).to eq(provider_school)
       end
     end
 

--- a/spec/services/provider_schools/identity_spec.rb
+++ b/spec/services/provider_schools/identity_spec.rb
@@ -13,57 +13,38 @@ RSpec.describe ProviderSchools::Identity do
   end
 
   describe ".ordered_school_scope" do
-    context "when the provider is in the schools remodel cycle" do
-      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year) }
-      let(:provider) { create(:provider, recruitment_cycle:) }
-      let!(:legacy_site) { create(:site, provider:, urn: gias_school.urn, code: "A") }
-      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: legacy_site.code, uuid: legacy_site.uuid) }
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year - 1) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
+    let!(:legacy_site) { create(:site, provider:, urn: "654321", code: "B") }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:) }
 
-      it "returns provider schools and not legacy sites" do
-        expect(described_class.ordered_school_scope(provider:)).to contain_exactly(provider_school)
-      end
-    end
-
-    context "when the provider is after the schools remodel cycle" do
-      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
-      let(:provider) { create(:provider, recruitment_cycle:) }
-      let!(:legacy_site) { create(:site, provider:, urn: "654321", code: "B") }
-      let!(:provider_school) { create(:provider_school, provider:, gias_school:) }
-
-      it "returns provider schools and does not require a matching site" do
-        expect(described_class.ordered_school_scope(provider:)).to contain_exactly(provider_school)
-      end
+    it "always returns provider schools and does not require a matching site" do
+      expect(described_class.ordered_school_scope(provider:)).to contain_exactly(provider_school)
     end
   end
 
   describe "#school_for" do
-    context "when the provider is in the schools remodel cycle" do
-      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year) }
-      let(:provider) { create(:provider, recruitment_cycle:) }
-      let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
-      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site_uuid) }
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year - 1) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
+    let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site_uuid) }
 
-      it "finds the provider school via the legacy site uuid" do
-        expect(described_class.new(provider:).school_for(uuid: site_uuid)).to eq(provider_school)
-      end
-
-      it "finds the correct provider school when the same GIAS school is linked twice" do
-        main_site = create(:site, :main_site, provider:, uuid: Faker::Internet.uuid)
-        main_provider_school = create(:provider_school, provider:, gias_school:, site_code: "-", uuid: main_site.uuid)
-
-        expect(described_class.new(provider:).school_for(uuid: main_site.uuid)).to eq(main_provider_school)
-        expect(described_class.new(provider:).school_for(uuid: site_uuid)).to eq(provider_school)
-      end
+    it "finds the provider school by uuid regardless of recruitment cycle" do
+      expect(described_class.new(provider:).school_for(uuid: site_uuid)).to eq(provider_school)
     end
 
-    context "when the provider is after the schools remodel cycle" do
-      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
-      let(:provider) { create(:provider, recruitment_cycle:) }
-      let!(:provider_school) { create(:provider_school, provider:, gias_school:, uuid: provider_school_uuid) }
+    it "finds the correct provider school when the same GIAS school is linked twice" do
+      main_site = create(:site, :main_site, provider:, uuid: Faker::Internet.uuid)
+      main_provider_school = create(:provider_school, provider:, gias_school:, site_code: "-", uuid: main_site.uuid)
 
-      it "finds the provider school by provider school uuid without requiring a legacy site" do
-        expect(described_class.new(provider:).school_for(uuid: provider_school_uuid)).to eq(provider_school)
-      end
+      expect(described_class.new(provider:).school_for(uuid: main_site.uuid)).to eq(main_provider_school)
+      expect(described_class.new(provider:).school_for(uuid: site_uuid)).to eq(provider_school)
+    end
+
+    it "raises when the provider school does not exist" do
+      expect {
+        described_class.new(provider:).school_for(uuid: provider_school_uuid)
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/services/provider_schools/identity_spec.rb
+++ b/spec/services/provider_schools/identity_spec.rb
@@ -13,13 +13,26 @@ RSpec.describe ProviderSchools::Identity do
   end
 
   describe ".ordered_school_scope" do
-    let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
-    let(:provider) { create(:provider, recruitment_cycle:) }
-    let!(:legacy_site) { create(:site, provider:, urn: "654321", code: "B") }
-    let!(:provider_school) { create(:provider_school, provider:, gias_school:) }
+    context "when the provider is in the schools remodel cycle" do
+      let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: remodel_cycle_year) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:legacy_site) { create(:site, provider:, urn: gias_school.urn, code: "A") }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: legacy_site.code, uuid: legacy_site.uuid) }
 
-    it "returns provider schools after the remodel cycle and does not require a matching site" do
-      expect(described_class.ordered_school_scope(provider:)).to contain_exactly(provider_school)
+      it "returns provider schools and not legacy sites" do
+        expect(described_class.ordered_school_scope(provider:)).to contain_exactly(provider_school)
+      end
+    end
+
+    context "when the provider is after the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year + 1) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:legacy_site) { create(:site, provider:, urn: "654321", code: "B") }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:) }
+
+      it "returns provider schools and does not require a matching site" do
+        expect(described_class.ordered_school_scope(provider:)).to contain_exactly(provider_school)
+      end
     end
   end
 

--- a/spec/services/provider_schools/removal_spec.rb
+++ b/spec/services/provider_schools/removal_spec.rb
@@ -13,11 +13,32 @@ RSpec.describe ProviderSchools::Removal do
   end
 
   describe "#call" do
+    context "when the provider is before the schools remodel cycle" do
+      let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year - 1) }
+      let(:provider) { create(:provider, recruitment_cycle:) }
+      let!(:site) { create(:site, provider:, uuid: site_uuid) }
+
+      it "removes the legacy site" do
+        expect(described_class.new(provider:, uuid: site.uuid).call).to be(true)
+
+        expect(Site.where(id: site.id)).to be_empty
+      end
+
+      it "does not remove the site when it is attached to a legacy course site" do
+        course = create(:course, provider:)
+        course.sites << site
+
+        expect(described_class.new(provider:, uuid: site.uuid).call).to be(false)
+
+        expect(Site.where(id: site.id)).to contain_exactly(site)
+      end
+    end
+
     context "when the provider is in the schools remodel cycle" do
       let(:recruitment_cycle) { create(:recruitment_cycle, year: remodel_cycle_year) }
       let(:provider) { create(:provider, recruitment_cycle:) }
       let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: site_uuid) }
-      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code) }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site_uuid) }
 
       it "removes both the legacy site and provider school" do
         expect(described_class.new(provider:, uuid: site.uuid).call).to be(true)

--- a/spec/services/provider_schools/removal_spec.rb
+++ b/spec/services/provider_schools/removal_spec.rb
@@ -23,15 +23,6 @@ RSpec.describe ProviderSchools::Removal do
 
         expect(Site.where(id: site.id)).to be_empty
       end
-
-      it "does not remove the site when it is attached to a legacy course site" do
-        course = create(:course, provider:)
-        course.sites << site
-
-        expect(described_class.new(provider:, uuid: site.uuid).call).to be(false)
-
-        expect(Site.where(id: site.id)).to contain_exactly(site)
-      end
     end
 
     context "when the provider is in the schools remodel cycle" do
@@ -45,16 +36,6 @@ RSpec.describe ProviderSchools::Removal do
 
         expect(Site.where(id: site.id)).to be_empty
         expect(Provider::School.where(id: provider_school.id)).to be_empty
-      end
-
-      it "does not remove either record when the site is attached to a legacy course site" do
-        course = create(:course, provider:)
-        course.sites << site
-
-        expect(described_class.new(provider:, uuid: site.uuid).call).to be(false)
-
-        expect(Site.where(id: site.id)).to contain_exactly(site)
-        expect(Provider::School.where(id: provider_school.id)).to contain_exactly(provider_school)
       end
 
       it "does not remove either record when the provider school is attached to a course school" do

--- a/spec/system/publish/providers/newly_added_tag_schools_page_spec.rb
+++ b/spec/system/publish/providers/newly_added_tag_schools_page_spec.rb
@@ -7,14 +7,22 @@ RSpec.describe "Publish - Schools: 'Newly added' tag for register import sites",
 
   let(:provider) { create(:provider, provider_name: "Tag Provider", recruitment_cycle:) }
 
+  let(:register_import_gias_school) { create(:gias_school, name: "Register Import School", urn: "111111") }
+  let(:ui_added_gias_school) { create(:gias_school, name: "UI Added School", urn: "222222") }
+
   let!(:site_one) do
     create(
       :site,
       provider: provider,
       added_via: :register_import,
       location_name: "Register Import School",
+      urn: register_import_gias_school.urn,
       address1: "1 Import Road",
     )
+  end
+
+  let!(:provider_school_one) do
+    create(:provider_school, provider:, gias_school: register_import_gias_school, site_code: site_one.code, uuid: site_one.uuid)
   end
 
   let!(:site_two) do
@@ -23,8 +31,13 @@ RSpec.describe "Publish - Schools: 'Newly added' tag for register import sites",
       provider: provider,
       added_via: :publish_interface,
       location_name: "UI Added School",
+      urn: ui_added_gias_school.urn,
       address1: "2 Publish Street",
     )
+  end
+
+  let!(:provider_school_two) do
+    create(:provider_school, provider:, gias_school: ui_added_gias_school, site_code: site_two.code, uuid: site_two.uuid)
   end
 
   let(:user) { create(:user, providers: [provider]) }

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -177,7 +177,13 @@ RSpec.describe "Delete a provider's schools" do
 
   def given_there_is_an_associated_course
     @course = create(:course, provider:)
-    @course.sites << site
+    create(
+      :course_school,
+      course: @course,
+      provider_school: provider.schools.first,
+      gias_school: provider.schools.first.gias_school,
+      site_code: provider.schools.first.site_code,
+    )
   end
 
   def and_i_cannot_delete_the_school

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Delete a provider's schools" do
 
   def then_i_see_the_provider_school_details
     expect(publish_school_show_page).to be_displayed
-    expect(page).to have_content("Future School (Main site)")
+    expect(page).to have_content("Future School (Main Site)")
     expect(page).to have_content("School code-", normalize_ws: true)
     expect(page).to have_content("URN654321", normalize_ws: true)
     expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe "Delete a provider's schools" do
 
   def given_there_is_an_associated_course
     @course = create(:course, provider:)
-    @course.sites << @site
+    @course.sites << site
   end
 
   def and_i_cannot_delete_the_school

--- a/spec/system/publish/providers/schools/provider_school_helper.rb
+++ b/spec/system/publish/providers/schools/provider_school_helper.rb
@@ -19,9 +19,10 @@ module ProviderSchoolHelper
   def then_i_see_a_list_of_schools
     expect(publish_schools_index_page.schools.size).to eq(1)
 
-    expect(publish_schools_index_page.schools.first.name).to have_text(site.location_name)
-    expect(publish_schools_index_page.schools.first.code).to have_text(site.code)
-    expect(publish_schools_index_page.schools.first.urn).to have_text(site.urn)
+    provider_school = provider.schools.first
+    expect(publish_schools_index_page.schools.first.name).to have_text(provider_school.location_name)
+    expect(publish_schools_index_page.schools.first.code).to have_text(provider_school.code)
+    expect(publish_schools_index_page.schools.first.urn).to have_text(provider_school.urn)
   end
 
   def then_i_am_on_the_index_page

--- a/spec/system/publish/providers/schools/provider_school_helper.rb
+++ b/spec/system/publish/providers/schools/provider_school_helper.rb
@@ -3,9 +3,11 @@
 module ProviderSchoolHelper
   def given_i_am_authenticated_as_a_provider_user
     gias_school = create(:gias_school)
-    given_i_am_authenticated(
-      user: create(:user, providers: [create(:provider, sites: [build(:site, **gias_school.school_attributes)])]),
-    )
+    provider = create(:provider, sites: [build(:site, **gias_school.school_attributes)])
+    site = provider.sites.first
+    create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
+
+    given_i_am_authenticated(user: create(:user, providers: [provider]))
   end
 
   def when_i_visit_the_schools_page

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Delete school under provider as an admin" do
 
   def then_i_see_the_provider_school_details
     expect(support_provider_school_show_page).to be_displayed
-    expect(page).to have_content("Future School (Main site)")
+    expect(page).to have_content("Future School (Main Site)")
     expect(page).to have_content("School code-", normalize_ws: true)
     expect(page).to have_content("URN654321", normalize_ws: true)
     expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)
@@ -146,11 +146,12 @@ RSpec.describe "Delete school under provider as an admin" do
   end
 
   def and_i_visit_the_support_provider_school_show_page
-    support_provider_school_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id, id: @site.uuid)
+    support_provider_school_show_page.load(recruitment_cycle_year: @provider.recruitment_cycle.year, provider_id: @provider.id, id: @site.uuid)
   end
 
   def and_there_is_a_provider_site
-    @provider = create(:provider, provider_name: "School of Cats")
+    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year - 1)
+    @provider = create(:provider, provider_name: "School of Cats", recruitment_cycle:)
     @site = create(:site, provider: @provider)
   end
 

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -114,10 +114,12 @@ RSpec.describe "Delete school under provider as an admin" do
 
   def and_the_school_is_deleted
     expect(@provider.sites.count).to eq 0
+    expect(Provider::School.where(id: @provider_school.id)).to be_empty
   end
 
   def and_the_school_is_not_deleted
     expect(@provider.sites.count).to eq 1
+    expect(Provider::School.where(id: @provider_school.id)).to contain_exactly(@provider_school)
   end
 
   def then_i_am_on_the_index_page
@@ -146,13 +148,14 @@ RSpec.describe "Delete school under provider as an admin" do
   end
 
   def and_i_visit_the_support_provider_school_show_page
-    support_provider_school_show_page.load(recruitment_cycle_year: @provider.recruitment_cycle.year, provider_id: @provider.id, id: @site.uuid)
+    support_provider_school_show_page.load(recruitment_cycle_year: @provider.recruitment_cycle.year, provider_id: @provider.id, id: @provider_school.uuid)
   end
 
   def and_there_is_a_provider_site
-    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year - 1)
-    @provider = create(:provider, provider_name: "School of Cats", recruitment_cycle:)
-    @site = create(:site, provider: @provider)
+    gias_school = create(:gias_school)
+    @provider = create(:provider, provider_name: "School of Cats")
+    @site = create(:site, provider: @provider, **gias_school.school_attributes)
+    @provider_school = create(:provider_school, provider: @provider, gias_school:, site_code: @site.code, uuid: @site.uuid)
   end
 
   def given_there_is_an_associated_course

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -159,8 +159,13 @@ RSpec.describe "Delete school under provider as an admin" do
   end
 
   def given_there_is_an_associated_course
-    course = create(:course, provider: @provider)
-    course.sites << @site
+    create(
+      :course_school,
+      course: create(:course, provider: @provider),
+      provider_school: @provider_school,
+      gias_school: @provider_school.gias_school,
+      site_code: @provider_school.site_code,
+    )
   end
 
   def given_i_am_authenticated_as_an_admin_user


### PR DESCRIPTION
## Context

Publish provider school pages still read from the legacy `Site` model in several places. After the schools remodel backfill, providers in the remodel cycle (2026) and beyond should be served from `Provider::School` instead.

This PR switches Publish school **show**, **delete**, and **index** pages to `ProviderSchools::Identity`, which resolves the correct model by recruitment cycle. One subtlety worth noting: from the remodel year onwards we look up `Provider::School` by UUID (matching backfilled records), while some behaviour — notably course school UUID resolution and removal — still treats 2026 as a transition year where both legacy sites and provider schools may coexist.

## Changes proposed in this pull request

- Update Publish schools **show** and **delete** pages to load a decorated `Provider::School` via `ProviderSchools::Identity#school_for` instead of `@site`
- Update Publish schools **index** to list `Provider::School` records from 2026 onwards by aligning `ordered_school_scope` with `uses_provider_schools?` (same predicate as `school_for`)
- Add `uses_provider_schools?` to `Identity` (cycle year >= remodel year) and remove `provider_school_for` site-matching logic
- Refactor `ProviderSchools::Removal` to handle three phases:
  - **Before remodel:** remove legacy sites only
  - **Remodel cycle:** remove both legacy site and matching provider school when present
  - **After remodel:** remove provider school only; raise `RecordNotFound` for invalid UUIDs
- Standardise main site display name to `(Main Site)` on `Provider::School` and delegate `code`/`urn` on the decorator
- Update `NewlyAddedTagComponent` so register-import schools still show the "Newly added" tag when the index renders `Provider::School` rows — it checks `added_via` on the matching legacy site by UUID
- Add request, service, decorator, component, and system specs; update helpers to create backfilled provider schools with matching UUIDs
- Update `CourseSchools::Identity` specs to reflect transitional 2026 behaviour: available school lists use provider schools, course UUID resolution still uses legacy sites
- Pin support delete specs for legacy site-only scenarios to pre-remodel cycles so they stay stable regardless of CI current year

## Guidance to review

- **`ProviderSchools::Identity`** — confirm `uses_provider_schools?` (>= 2026) is used consistently for both `school_for` and `ordered_school_scope`, and that this matches the backfill assumption that provider school UUIDs match legacy site UUIDs during the remodel year
- **`ProviderSchools::Removal#call`** — check the three branching paths (after remodel / provider school present / site-only) and that `removable?` checks the right associations (`course_schools` vs legacy course sites) in each phase
- **Publish show/delete/index views** — verify the switch from `@site` to `school` / `@schools` reads correctly for normal and main site schools, including when the same GIAS school is linked twice with different site codes
- **`NewlyAddedTagComponent`** — confirm looking up register-import status via the legacy site is the right approach during the 2026 rollover, when index rows are provider schools but `added_via` lives on sites
- **`CourseSchools::Identity`** — note this PR does not change course UUID resolution logic; only specs were updated to match the new index behaviour
- **Support console** — support controller/views still use `@site` via `school_removal.school`; only support *specs* were updated for cycle pinning and casing

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.