### PR TITLE
Use school UUIDs in add course wizard

### DIFF
--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -63,6 +63,14 @@ private
   end
 
   def school_present?
-    provider.sites.any?
+    school_collection.any?
+  end
+
+  def school_collection
+    if provider.recruitment_cycle_year.to_i > Settings.schools_remodel_cycle_year
+      provider.schools
+    else
+      provider.sites
+    end
   end
 end

--- a/app/controllers/publish/course_wizards_controller.rb
+++ b/app/controllers/publish/course_wizards_controller.rb
@@ -16,7 +16,7 @@ module Publish
     end
 
     def new
-      return render_schools_messages unless provider.sites.any?
+      return render_schools_messages unless CourseSchools::Identity.new(provider:).available_schools.exists?
 
       redirect_to publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: params[:provider_code],

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -33,10 +33,8 @@ module Courses
       end
 
       update_study_mode(course)
-      # Legacy site_status write always runs (it is the only home for vacancy
-      # and study-mode data). To move to strict "flag-on ⇒ new-model only"
-      # once vacancies migrate off site_status, guard this call with
-      # `unless FeatureFlag.active?(:course_publishing_uses_new_school_model)`.
+      # TODO School data remodel removal - remove site_status writes # rubocop:disable Style/CommentAnnotation
+      # once add-course creation only writes Course::School.
       update_sites(course)
       update_schools(course)
       update_study_sites(course)
@@ -90,6 +88,10 @@ module Courses
       @site_ids ||= course_params["sites_ids"]
     end
 
+    def school_uuids
+      @school_uuids ||= Array(course_params["school_uuids"]).compact_blank
+    end
+
     def study_mode
       @study_mode ||= if course_params["study_mode"].nil?
                         nil
@@ -116,66 +118,114 @@ module Courses
     end
 
     def update_sites(course)
-      return if site_ids.nil?
+      return unless school_selection_submitted?
 
-      course.sites = sites if site_ids.any?
+      if selected_school_identifiers.empty?
+        course.errors.add(:sites, message: "Select at least one school")
+        return
+      end
 
-      course.errors.add(:sites, message: "Select at least one school") if site_ids.empty?
+      return add_school_uuid_resolution_error(course) if school_uuid_resolution_error?
+
+      selected_sites = selected_school_records.select { |school| school.is_a?(Site) }
+      course.sites = selected_sites if selected_sites.any?
     end
 
     # Dual-writes the selected schools to the new Course::School model,
     # building the records in memory so they persist atomically with the
     # course on save and are visible to CoursePublishableSchoolsPresence-
-    # Validator's :new-context read (which the new-school-model flag routes
-    # to course.schools). Mirrors the site→gias_school→provider_school
-    # mapping used by Publish::Schools::UpdateCourseSchoolsService.
+    # Validator's :new-context read.
     def update_schools(course)
-      return if site_ids.nil?
-      # Nothing selected — update_sites already records the "Select at least
-      # one school" error; skip before touching `sites` (find([]) would raise).
-      return if site_ids.compact_blank.empty?
+      return unless school_selection_submitted?
+      return if selected_school_identifiers.empty?
+      return if school_uuid_resolution_error?
 
-      school_sites.each do |site|
-        gias_school = gias_schools_by_urn[site.urn]
-        next unless gias_school
-
-        provider_school = provider_schools_by_gias_id[gias_school.id]
-
-        unless provider_school
-          # No matching Provider::School yet — provider not fully backfilled
-          # (or its site predates the dual-write). Skip the new-model build;
-          # the schools backfill (or the next provider-side write) reconciles
-          # later. Same rationale as UpdateCourseSchoolsService#attach_school.
-          Rails.logger.warn(
-            "[CourseSchools] skipped course_school build — no provider_school for " \
-            "provider=#{provider.id} gias_school=#{gias_school.id}",
-          )
-          next
+      selected_school_records.each do |school|
+        case school
+        when Site
+          build_course_school_from_site(course:, site: school)
+        when Provider::School
+          build_course_school(course:, provider_school: school)
         end
-
-        course.schools.build(gias_school_id: gias_school.id, provider_school:)
       end
     end
 
-    def school_sites
-      @school_sites ||= sites.select(&:school?)
+    def school_selection_submitted?
+      course_params.key?("school_uuids") || course_params.key?("sites_ids")
     end
 
-    # Only map selectable (non-closed) GIAS schools into the new model. A site
-    # can still point at a school the GIAS import later flipped to closed; we
-    # intentionally leave that school out of course.schools (the legacy
-    # course.sites write above still keeps the site) so the new model never
-    # gains a closed school. `available` excludes only `closed`.
+    def selected_school_identifiers
+      @selected_school_identifiers ||= if course_params.key?("school_uuids")
+                                         school_uuids
+                                       else
+                                         Array(site_ids).compact_blank
+                                       end
+    end
+
+    def selected_school_records
+      return @selected_school_records if defined?(@selected_school_records)
+
+      @selected_school_records = if course_params.key?("school_uuids")
+                                   course_school_identity.school_records_for(school_uuids:)
+                                 else
+                                   sites
+                                 end
+    rescue ArgumentError => e
+      @school_uuid_resolution_error = e
+      @selected_school_records = []
+    end
+
+    def school_uuid_resolution_error?
+      selected_school_records
+      @school_uuid_resolution_error.present?
+    end
+
+    def add_school_uuid_resolution_error(course)
+      Rails.logger.warn(
+        "[CourseSchools] invalid school UUIDs for provider=#{provider.id}: #{@school_uuid_resolution_error.message}",
+      )
+      course.errors.add(:sites, message: "Select at least one school")
+    end
+
+    def build_course_school_from_site(course:, site:)
+      gias_school = gias_schools_by_urn[site.urn]
+      return unless gias_school
+
+      provider_school = provider_schools_by_uuid[site.uuid.to_s]
+
+      unless provider_school
+        Rails.logger.warn(
+          "[CourseSchools] skipped course_school build - no provider_school for " \
+          "provider=#{provider.id} site_uuid=#{site.uuid} gias_school=#{gias_school.id}",
+        )
+        return
+      end
+
+      build_course_school(course:, provider_school:)
+    end
+
+    def build_course_school(course:, provider_school:)
+      course.schools.build(gias_school: provider_school.gias_school, provider_school:)
+    end
+
     def gias_schools_by_urn
       @gias_schools_by_urn ||= GiasSchool.available
-        .where(urn: school_sites.map(&:urn).compact_blank)
+        .where(urn: selected_sites.map(&:urn).compact_blank)
         .index_by(&:urn)
     end
 
-    def provider_schools_by_gias_id
-      @provider_schools_by_gias_id ||= provider.schools
-        .where(gias_school_id: gias_schools_by_urn.values.map(&:id))
-        .index_by(&:gias_school_id)
+    def selected_sites
+      @selected_sites ||= selected_school_records.select { |school| school.is_a?(Site) && school.school? }
+    end
+
+    def provider_schools_by_uuid
+      @provider_schools_by_uuid ||= provider.schools
+        .where(uuid: selected_sites.map { |site| site.uuid.to_s })
+        .index_by { |school| school.uuid.to_s }
+    end
+
+    def course_school_identity
+      @course_school_identity ||= CourseSchools::Identity.new(provider:)
     end
 
     def update_study_sites(course)

--- a/app/services/courses/wizard_params_serializer.rb
+++ b/app/services/courses/wizard_params_serializer.rb
@@ -27,7 +27,7 @@ module Courses
         "qualification" => draft.qualification,
         "funding" => draft.funding,
         "study_mode" => draft.study_modes,
-        "sites_ids" => draft.school_ids,
+        "school_uuids" => draft.school_uuids,
         "study_sites_ids" => draft.study_site_ids,
         "accredited_provider_code" => draft.accredited_provider_code,
         "start_date" => draft.start_date,

--- a/app/views/publish/course_wizards/steps/_schools.html.erb
+++ b/app/views/publish/course_wizards/steps/_schools.html.erb
@@ -25,14 +25,14 @@
   <%= t("course_wizard.steps.schools.hint") %>
 </p>
 
-<%= form.govuk_check_boxes_fieldset :site_ids,
+<%= form.govuk_check_boxes_fieldset :school_uuids,
       legend: { hidden: true, text: heading },
       form_group: { data: { controller: "show-all-schools", show_all_schools_visible_value: current_step.schools_collapse_threshold } } do %>
-  <% current_step.sites.each_with_index do |site, index| %>
-    <%= form.govuk_check_box :site_ids,
-          site.id.to_s,
-          label: { text: [site.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
-          hint: { text: site.decorate.full_address, class: "govuk-!-font-size-16" },
+  <% current_step.schools.each_with_index do |school, index| %>
+    <%= form.govuk_check_box :school_uuids,
+          school.uuid.to_s,
+          label: { text: [school.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: school))].compact_blank.join(" ").html_safe },
+          hint: { text: school.decorate.full_address, class: "govuk-!-font-size-16" },
           include_hidden: false,
           link_errors: index.zero?,
           data: { show_all_schools_target: "school" } %>

--- a/app/wizards/course_wizard/draft.rb
+++ b/app/wizards/course_wizard/draft.rb
@@ -89,12 +89,19 @@ class CourseWizard
       @subjects ||= ordered_subject_records(subject_ids)
     end
 
-    def school_ids
-      Array(state_store.site_ids).compact_blank
+    def school_uuids
+      return Array(state_store.school_uuids).compact_blank unless state_store.school_uuids.nil?
+
+      # TODO School data remodel removal - remove site_ids fallback # rubocop:disable Style/CommentAnnotation
+      # when cached add-course wizard states no longer need it.
+      ordered_site_records(legacy_site_ids).map { |site| site.uuid.to_s }
     end
 
     def schools
-      @schools ||= ordered_site_records(school_ids)
+      @schools ||= course_school_identity.school_records_for(school_uuids:)
+    rescue ArgumentError => e
+      Rails.logger.warn("[CourseWizard::Draft] invalid school UUIDs for provider=#{wizard.provider.id}: #{e.message}")
+      []
     end
 
     def study_site_ids
@@ -173,6 +180,16 @@ class CourseWizard
 
       records_by_id = Site.where(id: ids).index_by { |site| site.id.to_s }
       ids.filter_map { |id| records_by_id[id.to_s] }
+    end
+
+    def legacy_site_ids
+      state = state_store.read
+
+      Array(state[:site_ids] || state["site_ids"]).compact_blank
+    end
+
+    def course_school_identity
+      @course_school_identity ||= CourseSchools::Identity.new(provider: wizard.provider)
     end
   end
 end

--- a/app/wizards/course_wizard/steps/schools.rb
+++ b/app/wizards/course_wizard/steps/schools.rb
@@ -7,9 +7,10 @@ class CourseWizard
       FUNDING_TYPES_WITH_SALARY = %w[salary apprenticeship].freeze
       QUALIFICATIONS_WITH_SALARY = %w[undergraduate_degree_with_qts].freeze
 
-      attribute :site_ids
+      attribute :school_uuids
 
-      validate :site_ids_selected
+      validate :school_uuids_selected
+      validate :school_uuids_resolve
 
       review do |r|
         r.row(
@@ -20,8 +21,8 @@ class CourseWizard
         )
       end
 
-      def sites
-        @sites ||= provider_sites.sort_by(&:location_name)
+      def schools
+        @schools ||= course_school_identity.available_schools
       end
 
       def schools_collapse_threshold
@@ -29,7 +30,7 @@ class CourseWizard
       end
 
       def collapse_schools?
-        sites.size > schools_collapse_threshold
+        schools.size > schools_collapse_threshold
       end
 
       def salaried?
@@ -37,27 +38,38 @@ class CourseWizard
       end
 
       def self.permitted_params
-        [{ site_ids: [] }]
+        [{ school_uuids: [] }]
       end
 
     private
 
-      def site_ids_selected
-        if selected_site_ids.empty? && provider_sites.one?
-          self.site_ids = [provider_sites.first.id.to_s]
+      def school_uuids_selected
+        if selected_school_uuids.empty? && course_school_identity.available_schools_count == 1
+          self.school_uuids = [course_school_identity.available_schools.first.uuid.to_s]
         end
 
-        return if selected_site_ids.any?
+        return if selected_school_uuids.any?
 
-        errors.add(:site_ids, I18n.t("course_wizard.steps.schools.errors.site_ids.blank"))
+        errors.add(:school_uuids, I18n.t("course_wizard.steps.schools.errors.school_uuids.blank"))
       end
 
-      def selected_site_ids
-        Array(site_ids).compact_blank
+      def school_uuids_resolve
+        return if selected_school_uuids.empty?
+
+        course_school_identity.school_records_for(school_uuids: selected_school_uuids)
+      rescue ArgumentError => e
+        Rails.logger.warn(
+          "[CourseWizard::Schools] invalid school UUIDs for provider=#{wizard.provider.id}: #{e.message}",
+        )
+        errors.add(:school_uuids, I18n.t("course_wizard.steps.schools.errors.school_uuids.blank"))
       end
 
-      def provider_sites
-        wizard.provider.sites
+      def selected_school_uuids
+        Array(school_uuids).compact_blank
+      end
+
+      def course_school_identity
+        @course_school_identity ||= CourseSchools::Identity.new(provider: wizard.provider)
       end
 
       def funding_type

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -165,7 +165,7 @@ en:
         description: The more schools you select, the more searches your course will appear in. You should only add schools that are relevant to this course.
         percentage: 60% of searches are by location.
         errors:
-          site_ids:
+          school_uuids:
             blank: Select at least one school
       study_sites:
         caption: Add course

--- a/spec/components/add_course_button_spec.rb
+++ b/spec/components/add_course_button_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe AddCourseButton do
   include Rails.application.routes.url_helpers
 
-  let(:recruitment_cycle) { build(:recruitment_cycle, :next) }
+  let(:recruitment_cycle) { build(:recruitment_cycle, year: Settings.schools_remodel_cycle_year) }
   let(:provider) { build(:provider, recruitment_cycle:) }
 
   before do
@@ -217,6 +217,38 @@ describe AddCourseButton do
           provider.recruitment_cycle.year,
         ),
       )
+    end
+  end
+
+  context "when the provider is after the school remodel cycle" do
+    let(:recruitment_cycle) { build(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1) }
+
+    context "and has a provider school" do
+      let(:provider) { build(:provider, :accredited_provider, schools: [build(:provider_school)], recruitment_cycle:) }
+
+      it "does not render a schools link" do
+        expect(rendered_content).to have_no_link(
+          "add a school",
+          href: publish_provider_recruitment_cycle_schools_path(
+            provider.provider_code,
+            provider.recruitment_cycle.year,
+          ),
+        )
+      end
+    end
+
+    context "and only has a legacy site" do
+      let(:provider) { build(:provider, :accredited_provider, sites: [build(:site)], recruitment_cycle:) }
+
+      it "renders a schools link" do
+        expect(rendered_content).to have_link(
+          "add a school",
+          href: publish_provider_recruitment_cycle_schools_path(
+            provider.provider_code,
+            provider.recruitment_cycle.year,
+          ),
+        )
+      end
     end
   end
 end

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -478,10 +478,9 @@ describe Courses::CreationService do
     let(:primary_subject) { find_or_create(:primary_subject, :primary) }
 
     # A GIAS school + provider_school that mirror the legacy `site` selected in
-    # the wizard, joined to the legacy site by matching URN (same mapping the
-    # edit flow uses in Publish::Schools::UpdateCourseSchoolsService).
+    # the wizard, joined to the legacy site by matching UUID.
     let(:gias_school) { create(:gias_school, urn: site.urn) }
-    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: "-") }
+    let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid) }
 
     let(:valid_course_params) do
       {
@@ -493,7 +492,7 @@ describe Courses::CreationService do
         "qualification" => "qts",
         "start_date" => "September #{recruitment_cycle.year}",
         "study_mode" => %w[full_time],
-        "sites_ids" => [site.id],
+        "school_uuids" => [site.uuid.to_s],
         "study_sites_ids" => [study_site.id],
         "master_subject_id" => primary_subject.id,
         "subjects_ids" => [primary_subject.id],
@@ -530,7 +529,7 @@ describe Courses::CreationService do
 
       it "builds the new Course::School and passes :new validation" do
         expect(created_course.schools.map(&:gias_school_id)).to eq([gias_school.id])
-        expect(created_course.schools.first.site_code).to eq("-")
+        expect(created_course.schools.first.site_code).to eq(site.code)
         expect(created_course.schools.first.provider_school).to eq(provider_school)
         expect(created_course.errors).to be_empty
       end
@@ -540,6 +539,42 @@ describe Courses::CreationService do
 
         expect(Course::School.where(course: created_course).pluck(:gias_school_id, :provider_school_id))
           .to eq([[gias_school.id, provider_school.id]])
+      end
+    end
+
+    context "when the provider is after the school remodel cycle" do
+      let(:future_recruitment_cycle) { create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1) }
+      let(:provider) do
+        create(:provider, sites: [site], study_sites: [study_site], recruitment_cycle: future_recruitment_cycle)
+      end
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:) }
+
+      let(:valid_course_params) do
+        {
+          "age_range_in_years" => "3_to_7",
+          "applications_open_from" => future_recruitment_cycle.application_start_date,
+          "funding" => "fee",
+          "is_send" => "1",
+          "level" => "primary",
+          "qualification" => "qts",
+          "start_date" => "September #{future_recruitment_cycle.year}",
+          "study_mode" => %w[full_time],
+          "school_uuids" => [provider_school.uuid.to_s],
+          "study_sites_ids" => [study_site.id],
+          "master_subject_id" => primary_subject.id,
+          "subjects_ids" => [primary_subject.id],
+        }
+      end
+
+      before do
+        allow(FeatureFlag).to receive(:active?).and_call_original
+        allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(true)
+      end
+
+      it "writes the new Course::School without attaching a legacy site" do
+        expect(created_course.schools.map(&:provider_school)).to eq([provider_school])
+        expect(created_course.sites).to be_empty
+        expect(created_course.errors).to be_empty
       end
     end
 
@@ -559,6 +594,26 @@ describe Courses::CreationService do
 
         expect(created_course.schools).to be_empty
         expect(created_course.sites.map(&:id)).to eq([site.id])
+      end
+    end
+
+    context "when a submitted school UUID cannot be resolved" do
+      let(:unknown_school_uuid) { SecureRandom.uuid }
+
+      let(:valid_course_params) do
+        {
+          "level" => "primary",
+          "qualification" => "qts",
+          "funding" => "fee",
+          "school_uuids" => [unknown_school_uuid],
+        }
+      end
+
+      it "logs the error and adds the existing school selection error" do
+        expect(Rails.logger).to receive(:warn).with(/invalid school UUIDs/)
+
+        expect(created_course.errors[:sites]).to include("Select at least one school")
+        expect(created_course.schools).to be_empty
       end
     end
 
@@ -586,7 +641,7 @@ describe Courses::CreationService do
           "level" => "primary",
           "qualification" => "qts",
           "funding" => "fee",
-          "sites_ids" => [],
+          "school_uuids" => [],
         }
       end
 
@@ -607,7 +662,7 @@ describe Courses::CreationService do
           "level" => "primary",
           "qualification" => "qts",
           "funding" => "fee",
-          "sites_ids" => [],
+          "school_uuids" => [],
         }
       end
 

--- a/spec/services/courses/wizard_params_serializer_spec.rb
+++ b/spec/services/courses/wizard_params_serializer_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Courses::WizardParamsSerializer do
       undergraduate_degree_with_qts?: false,
       funding_type: "salary",
       study_pattern: %w[full_time part_time],
-      site_ids: %w[1 2],
+      school_uuids: %w[11111111-1111-4111-8111-111111111111 22222222-2222-4222-8222-222222222222],
+      site_ids: nil,
       study_sites_ids: %w[3],
       accredited_provider_code: "A0A",
       start_date: "July 2027",
@@ -48,7 +49,10 @@ RSpec.describe Courses::WizardParamsSerializer do
   describe "key translations" do
     it "maps the canonical wizard keys to creation-service keys" do
       expect(params["master_subject_id"]).to eq("100")
-      expect(params["sites_ids"]).to eq(%w[1 2])
+      expect(params["school_uuids"]).to eq(
+        %w[11111111-1111-4111-8111-111111111111 22222222-2222-4222-8222-222222222222],
+      )
+      expect(params).not_to have_key("sites_ids")
       expect(params["study_mode"]).to eq(%w[full_time part_time])
       expect(params["funding"]).to eq("salary")
       expect(params["subordinate_subject_id"]).to eq("200")
@@ -220,10 +224,12 @@ RSpec.describe Courses::WizardParamsSerializer do
 
   describe "site/study-site permutations" do
     context "when ids include blanks" do
-      let(:state_overrides) { { site_ids: ["1", ""], study_sites_ids: ["3", ""] } }
+      let(:state_overrides) do
+        { school_uuids: ["11111111-1111-4111-8111-111111111111", ""], study_sites_ids: ["3", ""] }
+      end
 
       it "compacts blank ids" do
-        expect(params["sites_ids"]).to eq(%w[1])
+        expect(params["school_uuids"]).to eq(%w[11111111-1111-4111-8111-111111111111])
         expect(params["study_sites_ids"]).to eq(%w[3])
       end
     end

--- a/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
@@ -368,7 +368,7 @@ private
       primary_master_subject_id: primary_subject.id.to_s,
       age_range_in_years: "3_to_7",
       qualification: "undergraduate_degree_with_qts",
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
       start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
@@ -393,7 +393,7 @@ private
       primary_master_subject_id: primary_subject.id.to_s,
       age_range_in_years: "3_to_7",
       qualification: "undergraduate_degree_with_qts",
-      site_ids: [@placement_site.id.to_s],
+      school_uuids: [@placement_site.uuid.to_s],
       study_sites_ids: [],
       start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
@@ -420,7 +420,7 @@ private
       qualification: "qts",
       funding_type: "fee",
       study_pattern: %w[full_time],
-      site_ids: [@placement_site.id.to_s],
+      school_uuids: [@placement_site.uuid.to_s],
       study_sites_ids: [],
       start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
@@ -520,7 +520,7 @@ private
   def and_the_selected_school_is_mapped_to_the_new_model
     @selected_site = provider.sites.first
     @gias_school = create(:gias_school, urn: @selected_site.urn)
-    create(:provider_school, provider:, gias_school: @gias_school, site_code: @selected_site.code)
+    create(:provider_school, provider:, gias_school: @gias_school, site_code: @selected_site.code, uuid: @selected_site.uuid)
   end
 
   def then_the_created_course_has_the_new_course_school
@@ -588,7 +588,7 @@ private
       qualification: "qts",
       funding_type: "fee",
       study_pattern: %w[full_time],
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
       accredited_provider_code: partner_provider_code,
       can_sponsor_student_visa: true,
@@ -622,7 +622,7 @@ private
       qualification: "qts",
       funding_type: "salary",
       study_pattern: %w[full_time],
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
       accredited_provider_code: partner_provider_code,
       can_sponsor_skilled_worker_visa: true,
@@ -658,7 +658,7 @@ private
       qualification: "qts",
       funding_type: "fee",
       study_pattern: %w[full_time],
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
       can_sponsor_student_visa: false,
       visa_sponsorship_application_deadline_required: false,
@@ -685,7 +685,7 @@ private
       qualification: "pgde",
       funding_type: "fee",
       study_pattern: %w[full_time],
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
       start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
@@ -715,7 +715,7 @@ private
       primary_master_subject_id: primary_subject.id.to_s,
       age_range_in_years: "3_to_7",
       qualification: "undergraduate_degree_with_qts",
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
       start_date: current_cycle_current_month_label(cycle_year: Find::CycleTimetable.current_year),
       can_sponsor_student_visa: false,
@@ -746,7 +746,7 @@ private
       qualification: "qts",
       funding_type: "fee",
       study_pattern: %w[full_time],
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
       can_sponsor_student_visa: true,
       visa_sponsorship_application_deadline_required: false,
@@ -777,7 +777,7 @@ private
       qualification: "qts",
       funding_type: "fee",
       study_pattern: %w[full_time],
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
       accredited_provider_code: partner_provider_code,
       can_sponsor_student_visa: true,

--- a/spec/system/publish/courses/add_course_wizard/level_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/level_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe "Add course wizard level step", type: :system do
     then_i_have_errors_on_the_level_step
   end
 
+  scenario "provider after the school remodel cycle can start with a provider school" do
+    given_i_am_authenticated_as_a_provider_user_with_a_provider_school
+    when_i_visit_the_wizard_level_page
+    then_i_see_the_level_step
+  end
+
 private
 
   def given_i_am_authenticated_as_a_provider_user_with_a_school
@@ -39,6 +45,16 @@ private
         create(:provider, :accredited_provider, sites: [build(:site)]),
       ],
     )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_a_provider_school
+    recruitment_cycle = find_or_create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
+    provider = create(:provider, :accredited_provider, recruitment_cycle:)
+    create(:provider_school, provider:)
+
+    @user = create(:user, providers: [provider])
 
     given_i_am_authenticated(user: @user)
   end
@@ -95,6 +111,10 @@ private
     expect(page).to have_content("There is a problem")
     expect(page).to have_content("Select a subject level")
     expect(page).to have_content("Select if this course has a special educational needs and disability (SEND) specialism")
+  end
+
+  def then_i_see_the_level_step
+    expect(page).to have_content("Subject level")
   end
 
   def provider

--- a/spec/system/publish/courses/add_course_wizard/schools_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/schools_spec.rb
@@ -240,7 +240,7 @@ private
   end
 
   def school_checkbox_selector
-    "input[name='schools[site_ids][]']"
+    "input[name='schools[school_uuids][]']"
   end
 
   # Counts the visible checkbox rows holding a school checkbox. We check the
@@ -278,11 +278,11 @@ private
   end
 
   def and_the_last_school_is_stored_in_the_wizard_state
-    expect(stored_site_ids).to contain_exactly(last_school.id.to_s)
+    expect(stored_school_uuids).to contain_exactly(last_school.uuid.to_s)
   end
 
   def given_the_last_school_is_already_selected_in_the_wizard_state
-    wizard_state_store.write(site_ids: [last_school.id.to_s])
+    wizard_state_store.write(school_uuids: [last_school.uuid.to_s])
   end
 
   # A collapsed school keeps its checked state in the DOM even though its row is
@@ -336,9 +336,9 @@ private
 
   # Read straight off the repository: the state store only exposes step attributes
   # through a wizard, which we do not have here.
-  def stored_site_ids
+  def stored_school_uuids
     state = wizard_state_repository.read
 
-    Array(state[:site_ids] || state["site_ids"]).compact_blank
+    Array(state[:school_uuids] || state["school_uuids"]).compact_blank
   end
 end

--- a/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
@@ -235,7 +235,7 @@ private
       primary_master_subject_id: primary_subject.id.to_s,
       age_range_in_years: "3_to_7",
       qualification: "undergraduate_degree_with_qts",
-      site_ids: [placement_site.id.to_s],
+      school_uuids: [placement_site.uuid.to_s],
       study_sites_ids: [study_site.id.to_s],
     )
   end

--- a/spec/wizards/add_course_wizard/draft_spec.rb
+++ b/spec/wizards/add_course_wizard/draft_spec.rb
@@ -190,12 +190,21 @@ RSpec.describe CourseWizard::Draft, type: :wizard do
       expect(draft.subjects.map(&:id)).to eq([first.id, second.id])
     end
 
-    it "returns school ids and ordered school records" do
+    it "returns school UUIDs and ordered school records" do
+      site_one = provider.sites.first || create(:site, provider:)
+      site_two = create(:site, provider:)
+      state_store.write(school_uuids: [site_two.uuid.to_s, site_one.uuid.to_s])
+
+      expect(draft.school_uuids).to eq([site_two.uuid.to_s, site_one.uuid.to_s])
+      expect(draft.schools.map(&:id)).to eq([site_two.id, site_one.id])
+    end
+
+    it "converts legacy site ids to school UUIDs for in-progress wizard state" do
       site_one = provider.sites.first || create(:site, provider:)
       site_two = create(:site, provider:)
       state_store.write(site_ids: [site_two.id.to_s, site_one.id.to_s])
 
-      expect(draft.school_ids).to eq([site_two.id.to_s, site_one.id.to_s])
+      expect(draft.school_uuids).to eq([site_two.uuid.to_s, site_one.uuid.to_s])
       expect(draft.schools.map(&:id)).to eq([site_two.id, site_one.id])
     end
 

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 RSpec.describe CourseWizard::Repositories::Course do
   let(:cache) { ActiveSupport::Cache::MemoryStore.new }
   let(:visa_deadline_payload) { { year: "2026", month: "9", day: "1" } }
+  let(:school_uuids) do
+    %w[11111111-1111-4111-8111-111111111111 22222222-2222-4222-8222-222222222222]
+  end
   let(:repository) do
     described_class.new(
       provider_code: "PROV",
@@ -26,7 +29,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "qualification" => "qts" })
       repository.write({ "funding_type" => "fee" })
       repository.write({ "study_pattern" => %w[full_time part_time] })
-      repository.write({ "site_ids" => %w[1 2] })
+      repository.write({ "school_uuids" => school_uuids })
       repository.write({ "study_sites_ids" => %w[3 4] })
       repository.write({ "start_date" => "January 2026" })
       repository.write({ "accredited_provider_code" => "123" })
@@ -50,7 +53,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:qualification]).to eq("qts")
       expect(data[:funding_type]).to eq("fee")
       expect(data[:study_pattern]).to eq(%w[full_time part_time])
-      expect(data[:site_ids]).to eq(%w[1 2])
+      expect(data[:school_uuids]).to eq(school_uuids)
       expect(data[:study_sites_ids]).to eq(%w[3 4])
       expect(data[:start_date]).to eq("January 2026")
       expect(data[:accredited_provider_code]).to eq("123")

--- a/spec/wizards/add_course_wizard/steps/schools_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/schools_spec.rb
@@ -7,51 +7,93 @@ RSpec.describe CourseWizard::Steps::Schools do
 
   let(:current_step) { :schools }
   let(:provider_code) { provider.provider_code }
-  let(:recruitment_cycle_year) { provider.recruitment_cycle_year }
-  let(:site_ids) { nil }
+  let(:recruitment_cycle_year) { Settings.schools_remodel_cycle_year }
+  let(:school_uuids) { nil }
 
-  let(:provider) { create(:provider, :accredited_provider, recruitment_cycle: find_or_create(:recruitment_cycle)) }
+  let(:provider) { create(:provider, :accredited_provider, recruitment_cycle:) }
   let!(:site_a) { create(:site, provider:, location_name: "B School") }
   let!(:site_b) { create(:site, provider:, location_name: "A School") }
 
   describe "#valid?" do
     subject(:wizard_step) { wizard.current_step }
 
-    it "is valid when at least one site is selected" do
-      wizard_step.site_ids = [site_a.id.to_s]
+    it "is valid when at least one school UUID is selected" do
+      wizard_step.school_uuids = [site_a.uuid.to_s]
 
       expect(wizard_step).to be_valid
     end
 
-    it "is not valid when no sites are selected and provider has multiple sites" do
-      wizard_step.site_ids = nil
+    it "is not valid when no schools are selected and provider has multiple schools" do
+      wizard_step.school_uuids = nil
 
       expect(wizard_step).not_to be_valid
-      expect(wizard_step.errors.messages_for(:site_ids)).to contain_exactly("Select at least one school")
+      expect(wizard_step.errors.messages_for(:school_uuids)).to contain_exactly("Select at least one school")
+    end
+
+    it "is not valid when a school UUID cannot be resolved" do
+      wizard_step.school_uuids = [SecureRandom.uuid]
+
+      expect(Rails.logger).to receive(:warn).with(/invalid school UUIDs/)
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:school_uuids)).to contain_exactly("Select at least one school")
     end
 
     context "when provider has only one site" do
       let!(:site_b) { nil }
 
       it "auto-selects the only site and is valid when no site is submitted" do
-        wizard_step.site_ids = nil
+        wizard_step.school_uuids = nil
 
         expect(wizard_step).to be_valid
-        expect(wizard_step.site_ids).to eq([site_a.id.to_s])
+        expect(wizard_step.school_uuids).to eq([site_a.uuid.to_s])
+      end
+    end
+
+    context "when the provider is after the school remodel cycle" do
+      let(:recruitment_cycle_year) { Settings.schools_remodel_cycle_year + 1 }
+      let!(:site_a) { nil }
+      let!(:site_b) { nil }
+      let(:gias_school) { create(:gias_school, name: "Provider School") }
+      let!(:provider_school) { create(:provider_school, provider:, gias_school:) }
+
+      it "is valid when a provider school UUID is selected" do
+        wizard_step.school_uuids = [provider_school.uuid.to_s]
+
+        expect(wizard_step).to be_valid
       end
     end
   end
 
-  describe "#sites" do
+  describe "#schools" do
     subject(:wizard_step) { wizard.current_step }
 
     it "returns provider sites sorted by location name" do
-      expect(wizard_step.sites).to eq(
+      expect(wizard_step.schools).to eq(
         [
           site_b,
           site_a,
         ],
       )
+    end
+
+    context "when the provider is after the school remodel cycle" do
+      let(:recruitment_cycle_year) { Settings.schools_remodel_cycle_year + 1 }
+      let!(:site_a) { nil }
+      let!(:site_b) { nil }
+      let(:gias_school_a) { create(:gias_school, name: "B School") }
+      let(:gias_school_b) { create(:gias_school, name: "A School") }
+      let!(:provider_school_a) { create(:provider_school, provider:, gias_school: gias_school_a) }
+      let!(:provider_school_b) { create(:provider_school, provider:, gias_school: gias_school_b) }
+
+      it "returns provider schools sorted by GIAS school name" do
+        expect(wizard_step.schools).to eq(
+          [
+            provider_school_b,
+            provider_school_a,
+          ],
+        )
+      end
     end
   end
 
@@ -73,7 +115,7 @@ RSpec.describe CourseWizard::Steps::Schools do
 
   describe ".permitted_params" do
     it "returns the correct permitted params" do
-      expect(described_class.permitted_params).to eq([{ site_ids: [] }])
+      expect(described_class.permitted_params).to eq([{ school_uuids: [] }])
     end
   end
 

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
           qualification: "pgce_with_qts",
           funding_type: "fee",
           study_pattern: %w[full_time],
-          site_ids: [provider.sites.first.id.to_s],
+          school_uuids: [provider.sites.first.uuid.to_s],
           study_sites_ids: [study_site.id.to_s],
           can_sponsor_student_visa: false,
           start_date: "July 2027",


### PR DESCRIPTION
# THIS PR WAS MADE BY AI AND HAS NOT BEEN REVIEWED YET, you can use it as a guide or improve it to work and look presentable


## Context

This PR is talking care of writing schools in the add course wizard.

The wizard now submits `school_uuids`, using `CourseSchools::Identity` to resolve the correct school model for the provider’s recruitment cycle:

- current/remodel cycle resolves UUIDs to legacy `Site`
- after the remodel cycle resolves UUIDs to `Provider::School`

This PR depends on P1 being merged because it uses `CourseSchools::Identity`. It does not depend on P2.

Before the backfill has run, current-cycle course creation still writes the legacy `SiteStatus` and logs/skips the new `Course::School` write if the matching `Provider::School` does not exist yet.

## Changes proposed in this pull request

- Change the add-course schools step from `site_ids` to `school_uuids`.
- Render school checkboxes with `Site.uuid` or `Provider::School.uuid`, depending on the cycle.
- Serialize wizard state to `school_uuids` for course creation.
- Keep a temporary fallback for cached wizard state that still has legacy `site_ids`.
- Update `Courses::CreationService` to accept `school_uuids` while keeping legacy `sites_ids` support for existing callers.
- Create `Course::School` by resolving `Provider::School` via UUID, avoiding ambiguous provider/GIAS lookups.
- Update add-course entry checks to use provider schools after the remodel cycle.
- Update unit, service, component, and system specs for the new wizard contract.

No screenshots included because there is no visual UI change; the form values changed from IDs to UUIDs.

## Guidance to review

Review by topic:

Wizard school selection:
- `app/wizards/course_wizard/steps/schools.rb`
- `app/views/publish/course_wizards/steps/_schools.html.erb`
- `config/locales/en/publish/course_wizard.yml`
- `spec/wizards/add_course_wizard/steps/schools_spec.rb`
- `spec/system/publish/courses/add_course_wizard/schools_spec.rb`

Wizard state and serialization:
- `app/wizards/course_wizard/draft.rb`
- `app/services/courses/wizard_params_serializer.rb`
- `spec/wizards/add_course_wizard/draft_spec.rb`
- `spec/services/courses/wizard_params_serializer_spec.rb`
- `spec/wizards/add_course_wizard/repositories/course_spec.rb`
- `spec/wizards/add_course_wizard/wizard/next_step_spec.rb`

Course creation writes:
- `app/services/courses/creation_service.rb`
- `spec/services/courses/creation_service_spec.rb`
- `spec/system/publish/courses/add_course_wizard/check_answers_spec.rb`
- `spec/system/publish/courses/add_course_wizard/start_date_spec.rb`

Wizard entry checks:
- `app/components/add_course_button.rb`
- `app/controllers/publish/course_wizards_controller.rb`
- `spec/components/add_course_button_spec.rb`
- `spec/system/publish/courses/add_course_wizard/level_spec.rb`

Things worth checking closely:
- current/remodel cycle still works before the provider school backfill
- after-remodel cycle uses `Provider::School.uuid`
- invalid UUIDs fail rather than silently dropping a selected school
- no existing-course/basic-details edit flow files are included in this PR

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
