### PR TITLE
Update content and styling on schools landing page

### DIFF
--- a/app/components/publish/providers/school_placements/outcome_explainer_component.html.erb
+++ b/app/components/publish/providers/school_placements/outcome_explainer_component.html.erb
@@ -1,5 +1,5 @@
 <%= render Shared::AdviceComponent::View.new(
-  title: t(".placement_school_heading")
+  title: t(".placement_school_heading"),
 ) do %>
   <p class="govuk-body govuk-!-font-weight-bold">
     <%= t(".location_searches_text_html") %>
@@ -11,9 +11,9 @@
         t(".courses_link_text"),
         publish_provider_recruitment_cycle_courses_path(
           @provider.provider_code,
-          @recruitment_cycle.year
-        )
-      )
+          @recruitment_cycle.year,
+        ),
+      ),
     ) %>
   </p>
   <p class="govuk-body">
@@ -23,15 +23,15 @@
         "Organisation details",
         details_publish_provider_recruitment_cycle_path(
           provider_code: @provider.provider_code,
-          year: @recruitment_cycle.year
-        )
-      )
+          year: @recruitment_cycle.year,
+        ),
+      ),
     ) %>
   </p>
   <p class="govuk-body">
     <%= govuk_link_to(
       t(".find_out_more"),
-      t("links.how_to.add_school_placements")
+      t("links.how_to.add_school_placements"),
     ) %>
   </p>
 <% end %>

--- a/app/components/publish/providers/school_placements/outcome_explainer_component.html.erb
+++ b/app/components/publish/providers/school_placements/outcome_explainer_component.html.erb
@@ -1,18 +1,37 @@
-<p class="govuk-body">
-  <%= t(".gias_school_text_html", link: govuk_link_to(t(".gias_link_text"), t(".gias_url"))) %>
-</p>
-<p class="govuk-body">
-  <%= t(".placement_school_text_html", link: govuk_link_to(t(".courses_link_text"), publish_provider_recruitment_cycle_courses_path(@provider.provider_code, @recruitment_cycle.year))) %>
-</p>
-<div class="govuk-inset-text">
-  <p class="govuk-body">
+<%= render Shared::AdviceComponent::View.new(
+  title: t(".placement_school_heading")
+) do %>
+  <p class="govuk-body govuk-!-font-weight-bold">
     <%= t(".location_searches_text_html") %>
   </p>
-  <%= govuk_link_to(
-    t(".find_out_more"),
-    t("links.how_to.add_school_placements"),
-  ) %>
-</div>
-<p class="govuk-body">
-  <%= t(".organisation_details_html", link: govuk_link_to("Organisation details", details_publish_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @recruitment_cycle.year))) %>
-  <p>
+  <p class="govuk-body">
+    <%= t(
+      ".placement_school_text_html",
+      link: govuk_link_to(
+        t(".courses_link_text"),
+        publish_provider_recruitment_cycle_courses_path(
+          @provider.provider_code,
+          @recruitment_cycle.year
+        )
+      )
+    ) %>
+  </p>
+  <p class="govuk-body">
+    <%= t(
+      ".organisation_details_html",
+      link: govuk_link_to(
+        "Organisation details",
+        details_publish_provider_recruitment_cycle_path(
+          provider_code: @provider.provider_code,
+          year: @recruitment_cycle.year
+        )
+      )
+    ) %>
+  </p>
+  <p class="govuk-body">
+    <%= govuk_link_to(
+      t(".find_out_more"),
+      t("links.how_to.add_school_placements")
+    ) %>
+  </p>
+<% end %>

--- a/app/views/publish/providers/schools/index.html.erb
+++ b/app/views/publish/providers/schools/index.html.erb
@@ -1,27 +1,18 @@
 <% content_for :page_title, t(".title") %>
 <%= content_for :before_content, render_breadcrumbs(:sites) %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render Publish::SchoolsChangedBannerComponent.new(provider: @provider) %>
-
     <h1 class="govuk-heading-l">
       <%= t(".title") %>
     </h1>
-
-    <p class="govuk-body"><%= t(".update_all_schools_html", register_url: t(".register_url")) %></p>
-    <p class="govuk-body"><%= t(".add_school_to_account") %></p>
-
     <div class="govuk-button-group">
       <%= govuk_button_link_to t(".add_school"), search_publish_provider_recruitment_cycle_schools_path(@provider.provider_code) %>
       <%= govuk_link_to("Add multiple schools", new_publish_provider_recruitment_cycle_schools_multiple_path, class: "govuk-button govuk-button--secondary govuk") %>
     </div>
-
-    <%= render Publish::Providers::SchoolPlacements::OutcomeExplainerComponent.new(
-      recruitment_cycle: @recruitment_cycle,
-      provider: @provider,
-    ) %>
-
+    <p class="govuk-body">
+      <%= t(".gias_school_text_html", link: govuk_link_to(t(".gias_link_text"), t(".gias_url"))) %>
+    </p>
     <% if @schools.any? %>
       <table class="govuk-table app-table--vertical-align-middle app-table--no-collapse">
         <thead class="govuk-table__head">
@@ -41,6 +32,10 @@
           <%= render partial: "school", collection: @schools %>
         </tbody>
       </table>
+      <%= render Publish::Providers::SchoolPlacements::OutcomeExplainerComponent.new(
+      recruitment_cycle: @recruitment_cycle,
+      provider: @provider,
+    ) %>
       <%= govuk_pagination(pagy: @pagy) %>
     <% end %>
   </div>

--- a/app/views/publish/providers/schools/index.html.erb
+++ b/app/views/publish/providers/schools/index.html.erb
@@ -32,11 +32,11 @@
           <%= render partial: "school", collection: @schools %>
         </tbody>
       </table>
+      <%= govuk_pagination(pagy: @pagy) %>
       <%= render Publish::Providers::SchoolPlacements::OutcomeExplainerComponent.new(
       recruitment_cycle: @recruitment_cycle,
       provider: @provider,
     ) %>
-      <%= govuk_pagination(pagy: @pagy) %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en/components/publish/outcome_explainer_component.yml
+++ b/config/locales/en/components/publish/outcome_explainer_component.yml
@@ -3,6 +3,7 @@ en:
     providers:
       school_placements:
         outcome_explainer_component:
+          placement_school_heading: "Attaching schools to courses"
           gias_school_text_html: You can only add schools that are on %{link}.
           gias_link_text: Get Information About Schools (GIAS)
           gias_url: https://get-information-schools.service.gov.uk/Search?SelectedTab=Establishments

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -136,10 +136,9 @@ en:
         postcode: "Postcode"
       schools: # file
         index:
-          add_school_to_account: If needed, you can add new schools to your account.
-          update_all_schools_html: >-
-            We automatically upload all schools you are working with. These are schools that are on <a class="govuk-link" href="%{register_url}">Register trainee teachers</a>.
-          register_url: https://www.register-trainee-teachers.service.gov.uk/
+          gias_school_text_html: You can only add schools that are on %{link}.
+          gias_link_text: Get Information About Schools (GIAS)
+          gias_url: https://get-information-schools.service.gov.uk/Search?SelectedTab=Establishments
       study_site_search:
         new:
           caption: Add study site

--- a/spec/system/publish/providers/schools/add_school_spec.rb
+++ b/spec/system/publish/providers/schools/add_school_spec.rb
@@ -83,17 +83,20 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
   end
 
   def given_i_see_the_schools_guidance_text
-    expect(page).to have_text("We automatically upload all schools you are working with. These are schools that are on Register trainee teachers.", normalize_ws: true)
-    expect(page).to have_link("Register trainee teachers", href: "https://www.register-trainee-teachers.service.gov.uk/")
-    expect(page).to have_text("If needed, you can add new schools to your account.", normalize_ws: true)
     expect(page).to have_text("You can only add schools that are on Get Information About Schools (GIAS).", normalize_ws: true)
     expect(page).to have_link("Get Information About Schools (GIAS)", href: "https://get-information-schools.service.gov.uk/Search?SelectedTab=Establishments")
-    expect(page).to have_text("You can attach placement schools to any of your courses from the ‘Basic details’ tab on each of your courses.", normalize_ws: true)
-    expect(page).to have_link("your courses", href: publish_provider_recruitment_cycle_courses_path(provider.provider_code, Find::CycleTimetable.current_year))
-    expect(page).to have_text("Your courses will not appear in candidates’ location searches if you do not attach placement schools to them.", normalize_ws: true)
-    expect(page).to have_link("Find out more about why you should add school placement locations", href: "https://www.publish-teacher-training-courses.service.gov.uk/how-to-use-this-service/add-schools-and-study-sites")
-    expect(page).to have_text("You can choose whether to show or hide the placements from candidates in Organisation details.", normalize_ws: true)
-    expect(page).to have_link("Organisation details", href: details_publish_provider_recruitment_cycle_path(provider_code: provider.provider_code, year: Find::CycleTimetable.current_year))
+    within(".app-callout.app-callout--orange") do
+      expect(page).to have_css(
+        ".app-callout__title",
+        text: "Attaching schools to courses",
+      )
+      expect(page).to have_text("You can attach placement schools to any of your courses from the ‘Basic details’ tab on each of your courses.", normalize_ws: true)
+      expect(page).to have_link("your courses", href: publish_provider_recruitment_cycle_courses_path(provider.provider_code, Find::CycleTimetable.current_year))
+      expect(page).to have_text("Your courses will not appear in candidates’ location searches if you do not attach placement schools to them.", normalize_ws: true)
+      expect(page).to have_link("Find out more about why you should add school placement locations", href: "https://www.publish-teacher-training-courses.service.gov.uk/how-to-use-this-service/add-schools-and-study-sites")
+      expect(page).to have_text("You can choose whether to show or hide the placements from candidates in Organisation details.", normalize_ws: true)
+      expect(page).to have_link("Organisation details", href: details_publish_provider_recruitment_cycle_path(provider_code: provider.provider_code, year: Find::CycleTimetable.current_year))
+    end
   end
 
   def when_i_click_add_a_school


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/Kl2YTejS/1831-update-content-and-styling-on-schools-landing-page

The content on the schools landing page is incorrect, as it mentions the import of schools from Register which we will no longer do. We need to adapt the content and styling to reflect this.

## Changes proposed in this pull request

Update content and styling on schools landing page (i.e. Schools tab on Publish)
- remove content related to schools import from Register
- move attaching schools to courses information to the bottom of the page, update content ordering and add callout box styling
- now rendering `Shared::AdviceComponent::View` within `OutcomeExplainerComponent` so it takes the callout box styling
- update specs

**ADD SCHOOLS CONTENT**
<img width="726" height="255" alt="Screenshot 2026-07-27 at 13 35 01" src="https://github.com/user-attachments/assets/72aabb05-9e8f-4227-8b34-785216ba0ad4" />

**CALLOUT BOX**
<img width="671" height="358" alt="Screenshot 2026-07-27 at 13 35 08" src="https://github.com/user-attachments/assets/48867b55-e681-45b4-9e88-d735dffbca97" />


## Guidance to review

In Publish, login as a provider and check content and styling on Schools tab.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
