### PR TITLE
Publish course list hide filters

### DIFF
--- a/app/services/publish/course_list.rb
+++ b/app/services/publish/course_list.rb
@@ -31,6 +31,17 @@ module Publish
       start_date: ->(course) { course.start_date.presence&.to_date },
     }.freeze
 
+    # The value each filter group varies on, in panel order. A group whose value
+    # is identical across the whole list offers no useful choice, so it is hidden.
+    # Start date is compared by month because the filter groups by month.
+    FILTER_FACETS = {
+      level: ->(course) { course.level },
+      funding: FIELDS[:funding],
+      qualification: FIELDS[:qualification],
+      study_mode: FIELDS[:study_mode],
+      start_date: ->(course) { course.start_date.presence&.to_date&.beginning_of_month },
+    }.freeze
+
     delegate :any?, to: :groups
 
     def initialize(provider:, params: {})
@@ -46,6 +57,14 @@ module Publish
     def visible_course_information_fields
       @visible_course_information_fields ||=
         FIELDS.keys.select { |key| unfiltered_courses.map(&FIELDS.fetch(key)).uniq.size > 1 }
+    end
+
+    # The filter groups worth showing: those whose value varies across the whole
+    # (unfiltered) list. Measured on the unfiltered set so filtering never adds
+    # or removes a filter.
+    def visible_filter_groups
+      @visible_filter_groups ||=
+        FILTER_FACETS.keys.select { |group| unfiltered_courses.map(&FILTER_FACETS.fetch(group)).uniq.size > 1 }
     end
 
     def groups

--- a/app/services/publish/course_list.rb
+++ b/app/services/publish/course_list.rb
@@ -33,8 +33,10 @@ module Publish
 
     # The value each filter group varies on, in panel order. A group whose value
     # is identical across the whole list offers no useful choice, so it is hidden.
-    # Start date is compared by month because the filter groups by month.
+    # Start date is compared by month because the filter groups by month; status
+    # by the token the filter selects on rather than the rendered label.
     FILTER_FACETS = {
+      status: ->(course) { Publish::Courses::StatusTag.token(course) },
       level: ->(course) { course.level },
       funding: FIELDS[:funding],
       qualification: FIELDS[:qualification],
@@ -60,11 +62,13 @@ module Publish
     end
 
     # The filter groups worth showing: those whose value varies across the whole
-    # (unfiltered) list. Measured on the unfiltered set so filtering never adds
-    # or removes a filter.
+    # (unfiltered) list, plus any group with a filter already applied so an active
+    # filter is never hidden from its panel. Measured on the unfiltered set so
+    # filtering never removes a filter mid-use.
     def visible_filter_groups
-      @visible_filter_groups ||=
-        FILTER_FACETS.keys.select { |group| unfiltered_courses.map(&FILTER_FACETS.fetch(group)).uniq.size > 1 }
+      @visible_filter_groups ||= FILTER_FACETS.keys.select do |group|
+        params.key?(group) || unfiltered_courses.map(&FILTER_FACETS.fetch(group)).uniq.size > 1
+      end
     end
 
     def groups

--- a/app/services/publish/courses/status_tag.rb
+++ b/app/services/publish/courses/status_tag.rb
@@ -19,7 +19,7 @@ module Publish
         when "rolled_over" then :rolled_over
         when "withdrawn" then :withdrawn
         else # published / published_with_unpublished_changes
-          if CycleBranch.current_or_previous?(course.recruitment_cycle.year)
+          if Find::CycleTimetable.current_or_previous_year?(course.recruitment_cycle.year)
             course.application_status_open? ? :open : :closed
           else
             :scheduled

--- a/app/services/publish/courses/status_tag.rb
+++ b/app/services/publish/courses/status_tag.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    # The single status a course displays as, as a token
+    # (:open / :closed / :draft / :rolled_over / :scheduled / :withdrawn).
+    #
+    # This is the value the status filter selects on and the status tag renders,
+    # so it is the right key for deciding whether the Status filter varies across
+    # a provider's courses. Mirrors StatusTagComponent's tag choice and inverts
+    # Query#status_predicate; a drift-guard spec ties the three together.
+    #
+    # "Open" and "Open *" (unpublished changes) share the token :open — the token
+    # is the filterable status, not the rendered label.
+    module StatusTag
+      def self.token(course)
+        case course.read_attribute(:content_status).to_s
+        when "draft" then :draft
+        when "rolled_over" then :rolled_over
+        when "withdrawn" then :withdrawn
+        else # published / published_with_unpublished_changes
+          if CycleBranch.current_or_previous?(course.recruitment_cycle.year)
+            course.application_status_open? ? :open : :closed
+          else
+            :scheduled
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/publish/courses/status_tag.rb
+++ b/app/services/publish/courses/status_tag.rb
@@ -13,18 +13,22 @@ module Publish
     # "Open" and "Open *" (unpublished changes) share the token :open — the token
     # is the filterable status, not the rendered label.
     module StatusTag
+      # Content statuses that are their own token. Anything else is published in
+      # some form, and its token depends on the cycle and application status.
+      SELF_EVIDENT_TOKENS = %w[draft rolled_over withdrawn].freeze
+
       def self.token(course)
-        case course.read_attribute(:content_status).to_s
-        when "draft" then :draft
-        when "rolled_over" then :rolled_over
-        when "withdrawn" then :withdrawn
-        else # published / published_with_unpublished_changes
-          if Find::CycleTimetable.current_or_previous_year?(course.recruitment_cycle.year)
-            course.application_status_open? ? :open : :closed
-          else
-            :scheduled
-          end
-        end
+        content_status = course.read_attribute(:content_status).to_s
+        return content_status.to_sym if SELF_EVIDENT_TOKENS.include?(content_status)
+
+        published_token(course)
+      end
+
+      # published / published_with_unpublished_changes
+      def self.published_token(course)
+        return :scheduled unless Find::CycleTimetable.current_or_previous_year?(course.recruitment_cycle.year)
+
+        course.application_status_open? ? :open : :closed
       end
     end
   end

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -16,7 +16,11 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-4">
   <div class="govuk-grid-column-one-third">
-    <%= render Publish::Courses::FilterPanelComponent.new(filter_form: @filter_form, provider: @provider) %>
+    <%= render Publish::Courses::FilterPanelComponent.new(
+          filter_form: @filter_form,
+          provider: @provider,
+          visible_groups: @course_list.visible_filter_groups,
+        ) %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -15,13 +15,16 @@
 <%= render AddCourseButton.new(provider: @provider) %>
 
 <div class="govuk-grid-row govuk-!-margin-top-4">
-  <div class="govuk-grid-column-one-third">
-    <%= render Publish::Courses::FilterPanelComponent.new(
-          filter_form: @filter_form,
-          provider: @provider,
-          visible_groups: @course_list.visible_filter_groups,
-        ) %>
-  </div>
+  <%# With no filters worth showing, drop the sidebar; the list keeps its width and sits on the left. %>
+  <% if @course_list.visible_filter_groups.any? %>
+    <div class="govuk-grid-column-one-third">
+      <%= render Publish::Courses::FilterPanelComponent.new(
+            filter_form: @filter_form,
+            provider: @provider,
+            visible_groups: @course_list.visible_filter_groups,
+          ) %>
+    </div>
+  <% end %>
 
   <div class="govuk-grid-column-two-thirds">
     <%= render Publish::Courses::ListComponent.new(course_list: @course_list, provider: @provider) %>

--- a/spec/requests/publish/courses_spec.rb
+++ b/spec/requests/publish/courses_spec.rb
@@ -69,6 +69,25 @@ describe "Publish::CoursesController#index" do
 
       expect(filter_headings).to eq(["Education phase"])
     end
+
+    context "when the courses vary on nothing" do
+      before { create(:course, :without_validation, provider:, name: "Only course") }
+
+      it "does not render the filter sidebar" do
+        get_courses
+
+        expect(response.parsed_body.css(".app-c-filter-section")).to be_empty
+        expect(response.parsed_body.text).not_to include("Filter courses")
+      end
+
+      it "shifts the course list to the left at its usual width, without a sidebar column" do
+        get_courses
+
+        expect(response.parsed_body.css(".govuk-grid-column-one-third")).to be_empty
+        expect(response.parsed_body.css(".govuk-grid-column-two-thirds")).to be_present
+        expect(course_names).to include("Only course")
+      end
+    end
   end
 
   describe "filtering" do

--- a/spec/requests/publish/courses_spec.rb
+++ b/spec/requests/publish/courses_spec.rb
@@ -35,16 +35,39 @@ describe "Publish::CoursesController#index" do
       expect(course_names).to include("Primary course", "Secondary course")
     end
 
-    it "shows the filter panel" do
-      get_courses
-
-      expect(response.parsed_body.css(".app-c-filter-section").size).to eq(6)
-    end
-
     it "shows no active filters" do
       get_courses
 
       expect(response.parsed_body.css(".app-active-filters")).to be_empty
+    end
+  end
+
+  describe "which filter groups are shown" do
+    def filter_headings
+      response.parsed_body.css(".app-c-filter-section__summary-heading").map { |heading| heading.text.strip }
+    end
+
+    it "shows every group when the courses vary on all of them" do
+      create(:course, :published, :primary, :fee, provider:, application_status: :open, study_mode: :full_time,
+                                                  qualification: :qts, start_date: Time.zone.local(2026, 9, 1), name: "A")
+      create(:course, :draft_enrichment, :secondary, :salary, provider:, study_mode: :part_time,
+                                                              qualification: :pgce_with_qts, start_date: Time.zone.local(2027, 1, 1), name: "B")
+
+      get_courses
+
+      expect(filter_headings).to eq(
+        ["Status", "Education phase", "Fee or salary", "Qualification", "Full time or part time", "Start date"],
+      )
+    end
+
+    it "hides the groups the courses do not vary on" do
+      # Same status, funding, qualification, study mode and start date; only phase differs.
+      create(:course, :without_validation, :primary, provider:, funding: "fee", qualification: :qts, study_mode: :full_time, start_date: Time.zone.local(2026, 9, 1))
+      create(:course, :without_validation, :secondary, provider:, funding: "fee", qualification: :qts, study_mode: :full_time, start_date: Time.zone.local(2026, 9, 1))
+
+      get_courses
+
+      expect(filter_headings).to eq(["Education phase"])
     end
   end
 

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -145,6 +145,69 @@ RSpec.describe Publish::CourseList do
     end
   end
 
+  describe "#visible_filter_groups" do
+    let(:provider) { create(:provider, :accredited_provider) }
+
+    # Shared defaults keep every non-target facet uniform, so each test isolates
+    # the one facet it varies. A single course means every facet is uniform.
+    def create_course(**attrs)
+      create(:course, :without_validation, provider:, funding: "fee", qualification: :qts, study_mode: :full_time,
+                                           level: :primary, start_date: Time.zone.local(2026, 9, 1), **attrs)
+    end
+
+    context "when the provider has one course" do
+      before { create_course }
+
+      it "shows no filter groups" do
+        expect(course_list.visible_filter_groups).to eq([])
+      end
+    end
+
+    context "when courses differ by education phase" do
+      before do
+        create_course(level: :primary)
+        create_course(level: :secondary)
+      end
+
+      it "shows the level filter" do
+        expect(course_list.visible_filter_groups).to eq([:level])
+      end
+    end
+
+    context "when courses differ by funding, qualification and study mode" do
+      before do
+        create_course(funding: "fee", qualification: :qts, study_mode: :full_time)
+        create_course(funding: "salary", qualification: :pgce_with_qts, study_mode: :part_time)
+      end
+
+      it "shows those filters in panel order" do
+        expect(course_list.visible_filter_groups).to eq(%i[funding qualification study_mode])
+      end
+    end
+
+    context "when courses start in different months" do
+      before do
+        create_course(start_date: Time.zone.local(2026, 9, 1))
+        create_course(start_date: Time.zone.local(2027, 1, 1))
+      end
+
+      it "shows the start date filter" do
+        expect(course_list.visible_filter_groups).to eq([:start_date])
+      end
+    end
+
+    context "when courses start on different days of the same month" do
+      before do
+        create_course(start_date: Time.zone.local(2026, 9, 1))
+        create_course(start_date: Time.zone.local(2026, 9, 20))
+      end
+
+      it "does not show the start date filter, which groups by month" do
+        expect(course_list.visible_filter_groups).not_to include(:start_date)
+      end
+    end
+  end
+
   describe "enumerable facade" do
     let(:provider) { create(:provider, :accredited_provider) }
 

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -206,6 +206,36 @@ RSpec.describe Publish::CourseList do
         expect(course_list.visible_filter_groups).not_to include(:start_date)
       end
     end
+
+    context "when courses display different statuses" do
+      before do
+        create(:course, :without_validation, provider:, name: "Draft course")
+        create(:course, :withdrawn, provider:, name: "Withdrawn course")
+      end
+
+      it "shows the status filter first" do
+        expect(course_list.visible_filter_groups).to include(:status)
+        expect(course_list.visible_filter_groups.first).to eq(:status)
+      end
+    end
+
+    context "when every course displays the same status" do
+      before { create_list(:course, 2, :without_validation, provider:) }
+
+      it "does not show the status filter" do
+        expect(course_list.visible_filter_groups).not_to include(:status)
+      end
+    end
+
+    context "when a uniform facet has an applied filter" do
+      subject(:course_list) { described_class.new(provider: provider.reload, params: { study_mode: %w[full_time] }) }
+
+      before { create_list(:course, 2, :without_validation, provider:, study_mode: :full_time) }
+
+      it "keeps that group visible so the active filter can be seen" do
+        expect(course_list.visible_filter_groups).to include(:study_mode)
+      end
+    end
   end
 
   describe "enumerable facade" do

--- a/spec/services/publish/courses/status_tag_drift_spec.rb
+++ b/spec/services/publish/courses/status_tag_drift_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Drift guard: StatusTag.token must stay consistent with the two places that
+# already agree with each other — the status filter (Query#status_scope) and the
+# rendered status tag (StatusTagComponent). If any of the three changes without
+# the others, this fails.
+RSpec.describe "Publish::Courses::StatusTag drift", type: :component do
+  let(:all_tokens) { %i[open closed draft rolled_over scheduled withdrawn] }
+
+  # Base text of the tag a token renders (ignoring the " *" unpublished suffix).
+  let(:token_tag_text) do
+    { open: "Open", closed: "Closed", draft: "Draft", rolled_over: "Rolled over", scheduled: "Scheduled", withdrawn: "Withdrawn" }
+  end
+
+  def rows(provider)
+    Publish::Courses::Query.call(provider: provider.reload)
+  end
+
+  def tag_text(row)
+    render_inline(
+      Publish::Courses::StatusTagComponent.new(course: row, recruitment_cycle_year: row.recruitment_cycle.year),
+    ).css(".govuk-tag").text.strip.delete_suffix(" *")
+  end
+
+  shared_examples "agrees across the three sources" do
+    it "returns each course from exactly the status filter matching its token, and renders that tag" do
+      all_rows = rows(provider)
+      expect(all_rows).to be_present
+
+      all_rows.each do |row|
+        token = Publish::Courses::StatusTag.token(row)
+
+        # (1) token matches the rendered tag
+        expect(tag_text(row)).to eq(token_tag_text.fetch(token))
+
+        # (2) the status filter for that token returns the course...
+        included = Publish::Courses::Query.call(provider: provider.reload, params: { status: [token.to_s] }).map(&:id)
+        expect(included).to include(row.id)
+
+        # (3) ...and no other token's filter does
+        (all_tokens - [token]).each do |other|
+          excluded = Publish::Courses::Query.call(provider: provider.reload, params: { status: [other.to_s] }).map(&:id)
+          expect(excluded).not_to include(row.id)
+        end
+      end
+    end
+  end
+
+  context "in the current recruitment cycle" do
+    let(:provider) { create(:provider, :accredited_provider) }
+
+    before do
+      create(:course, :published, provider:, application_status: :open, name: "Open")
+      create(:course, :published, provider:, application_status: :closed, name: "Closed")
+      create(:course, :draft_enrichment, provider:, name: "Draft")
+      create(:course, provider:, application_status: :open, name: "Rolled over", enrichments: [build(:course_enrichment, :rolled_over)])
+      create(:course, :withdrawn, provider:, name: "Withdrawn")
+      create(:course, provider:, application_status: :open, name: "Open with changes",
+                      enrichments: [build(:course_enrichment, :published), build(:course_enrichment, :initial_draft)])
+    end
+
+    include_examples "agrees across the three sources"
+  end
+
+  context "in a future recruitment cycle" do
+    let(:provider) { create(:provider, :accredited_provider, :next_recruitment_cycle) }
+
+    before do
+      create(:course, :published, provider:, application_status: :open, name: "Scheduled")
+      create(:course, :draft_enrichment, provider:, name: "Draft")
+    end
+
+    include_examples "agrees across the three sources"
+  end
+end

--- a/spec/services/publish/courses/status_tag_spec.rb
+++ b/spec/services/publish/courses/status_tag_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Publish::Courses::StatusTag do
+  # Rows come from the query, so a course carries the computed content_status
+  # column the token reads.
+  def row_for(course)
+    Publish::Courses::Query.call(provider: course.provider.reload).detect { |row| row.id == course.id }
+  end
+
+  describe ".token" do
+    let(:provider) { create(:provider, :accredited_provider) }
+
+    context "in the current recruitment cycle" do
+      it "is :draft for a course with no enrichment" do
+        course = create(:course, provider:)
+
+        expect(described_class.token(row_for(course))).to eq(:draft)
+      end
+
+      it "is :draft for a course with only a draft enrichment" do
+        course = create(:course, :draft_enrichment, provider:)
+
+        expect(described_class.token(row_for(course))).to eq(:draft)
+      end
+
+      it "is :open for a published course accepting applications" do
+        course = create(:course, :published, provider:, application_status: :open)
+
+        expect(described_class.token(row_for(course))).to eq(:open)
+      end
+
+      it "is :closed for a published course not accepting applications" do
+        course = create(:course, :published, provider:, application_status: :closed)
+
+        expect(described_class.token(row_for(course))).to eq(:closed)
+      end
+
+      it "treats unpublished changes as the same token as published" do
+        course = create(:course, provider:, application_status: :open,
+                                 enrichments: [build(:course_enrichment, :published), build(:course_enrichment, :initial_draft)])
+
+        expect(described_class.token(row_for(course))).to eq(:open)
+      end
+
+      it "is :rolled_over for a rolled over course" do
+        course = create(:course, provider:, enrichments: [build(:course_enrichment, :rolled_over)])
+
+        expect(described_class.token(row_for(course))).to eq(:rolled_over)
+      end
+
+      it "is :withdrawn for a withdrawn course" do
+        course = create(:course, :withdrawn, provider:)
+
+        expect(described_class.token(row_for(course))).to eq(:withdrawn)
+      end
+    end
+
+    context "in a future recruitment cycle" do
+      let(:provider) { create(:provider, :accredited_provider, :next_recruitment_cycle) }
+
+      it "is :scheduled for a published course, whatever its application status" do
+        course = create(:course, :published, provider:, application_status: :closed)
+
+        expect(described_class.token(row_for(course))).to eq(:scheduled)
+      end
+
+      it "is still :draft for a draft course" do
+        course = create(:course, :draft_enrichment, provider:)
+
+        expect(described_class.token(row_for(course))).to eq(:draft)
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/provider_courses_index.rb
+++ b/spec/support/page_objects/publish/provider_courses_index.rb
@@ -38,6 +38,11 @@ module PageObjects
         elements :chips, ".app-active-filters__remove-filter"
         element :clear_all, ".app-c-filter-summary__clear-filters"
       end
+
+      # The filter group headings currently shown, in order.
+      def filter_group_headings
+        filter_groups.map { |group| group.heading.text.strip }
+      end
     end
   end
 end

--- a/spec/system/publish/filtering_courses_spec.rb
+++ b/spec/system/publish/filtering_courses_spec.rb
@@ -90,6 +90,13 @@ RSpec.describe "Filtering the course list" do
     then_only_these_filters_are_shown("Status", "Education phase", "Fee or salary")
   end
 
+  scenario "I see no filters at all when my courses are identical" do
+    given_all_my_courses_are_identical
+    when_i_visit_the_courses_page
+    then_i_see_no_filter_sidebar
+    and_i_still_see_my_courses
+  end
+
   def given_my_provider_has_courses_in_different_states
     create(:course, :published_postgraduate, provider:, accrediting_provider: nil, name: "Open course")
     create(:course, :draft_enrichment, provider:, accrediting_provider: nil, name: "Draft course")
@@ -105,6 +112,12 @@ RSpec.describe "Filtering the course list" do
   def given_my_provider_has_courses_starting_in_different_months
     create(:course, provider:, accrediting_provider: nil, name: "September course", start_date: Time.zone.local(provider.recruitment_cycle_year.to_i, 9, 1))
     create(:course, provider:, accrediting_provider: nil, name: "January course", start_date: Time.zone.local(provider.recruitment_cycle_year.to_i + 1, 1, 1))
+  end
+
+  def given_all_my_courses_are_identical
+    start_date = Time.zone.local(provider.recruitment_cycle_year.to_i, 9, 1)
+    create_list(:course, 3, :without_validation, :primary, :fee, provider:, accrediting_provider: nil,
+                                                                 qualification: :qts, study_mode: :full_time, start_date:)
   end
 
   # Status, education phase and funding vary; qualification, study mode and start
@@ -182,6 +195,15 @@ RSpec.describe "Filtering the course list" do
 
   def then_only_these_filters_are_shown(*headings)
     expect(publish_provider_courses_index_page.filter_group_headings).to eq(headings)
+  end
+
+  def then_i_see_no_filter_sidebar
+    expect(publish_provider_courses_index_page).to have_no_filter_heading
+    expect(publish_provider_courses_index_page).to have_no_filter_groups
+  end
+
+  def and_i_still_see_my_courses
+    expect(course_names.size).to eq(3)
   end
 
   def then_the_group_shows_the_selected_count(heading, text)

--- a/spec/system/publish/filtering_courses_spec.rb
+++ b/spec/system/publish/filtering_courses_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Filtering the course list" do
   end
 
   scenario "I can filter by any month the cycle allows" do
-    given_my_provider_has_primary_and_secondary_courses
+    given_my_provider_has_courses_starting_in_different_months
     when_i_visit_the_courses_page
     then_i_can_choose_a_start_month
   end
@@ -94,6 +94,11 @@ RSpec.describe "Filtering the course list" do
     create(:course, :primary, :fee, provider:, accrediting_provider: nil, name: "Primary fee course")
     create(:course, :secondary, :fee, provider:, accrediting_provider: nil, name: "Secondary fee course")
     create(:course, :primary, :salary, provider:, accrediting_provider: nil, name: "Primary salary course")
+  end
+
+  def given_my_provider_has_courses_starting_in_different_months
+    create(:course, provider:, accrediting_provider: nil, name: "September course", start_date: Time.zone.local(provider.recruitment_cycle_year.to_i, 9, 1))
+    create(:course, provider:, accrediting_provider: nil, name: "January course", start_date: Time.zone.local(provider.recruitment_cycle_year.to_i + 1, 1, 1))
   end
 
   def when_i_visit_the_courses_page(query = {})

--- a/spec/system/publish/filtering_courses_spec.rb
+++ b/spec/system/publish/filtering_courses_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe "Filtering the course list" do
     and_i_see_no_active_filters
   end
 
+  scenario "I only see the filters my courses actually vary on" do
+    given_my_courses_vary_only_by_status_phase_and_funding
+    when_i_visit_the_courses_page
+    then_only_these_filters_are_shown("Status", "Education phase", "Fee or salary")
+  end
+
   def given_my_provider_has_courses_in_different_states
     create(:course, :published_postgraduate, provider:, accrediting_provider: nil, name: "Open course")
     create(:course, :draft_enrichment, provider:, accrediting_provider: nil, name: "Draft course")
@@ -99,6 +105,16 @@ RSpec.describe "Filtering the course list" do
   def given_my_provider_has_courses_starting_in_different_months
     create(:course, provider:, accrediting_provider: nil, name: "September course", start_date: Time.zone.local(provider.recruitment_cycle_year.to_i, 9, 1))
     create(:course, provider:, accrediting_provider: nil, name: "January course", start_date: Time.zone.local(provider.recruitment_cycle_year.to_i + 1, 1, 1))
+  end
+
+  # Status, education phase and funding vary; qualification, study mode and start
+  # date are identical across the two courses.
+  def given_my_courses_vary_only_by_status_phase_and_funding
+    start_date = Time.zone.local(provider.recruitment_cycle_year.to_i, 9, 1)
+    create(:course, :published, :primary, :fee, provider:, accrediting_provider: nil, application_status: :open,
+                                                qualification: :qts, study_mode: :full_time, start_date:, name: "Open primary fee course")
+    create(:course, :draft_enrichment, :secondary, :salary, provider:, accrediting_provider: nil,
+                                                            qualification: :qts, study_mode: :full_time, start_date:, name: "Draft secondary salary course")
   end
 
   def when_i_visit_the_courses_page(query = {})
@@ -163,6 +179,10 @@ RSpec.describe "Filtering the course list" do
     expect(publish_provider_courses_index_page).to have_no_active_filters
   end
   alias_method :and_i_see_no_active_filters, :then_i_see_no_active_filters
+
+  def then_only_these_filters_are_shown(*headings)
+    expect(publish_provider_courses_index_page.filter_group_headings).to eq(headings)
+  end
 
   def then_the_group_shows_the_selected_count(heading, text)
     group = filter_group(heading)

--- a/spec/system/publish/filtering_courses_spec.rb
+++ b/spec/system/publish/filtering_courses_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-# Not tagged :js, so these run on rack_test and prove the filters work with
-# JavaScript disabled. The one :js scenario at the end covers the enhancement.
+# These run on rack_test (no :js), proving the filters work without JavaScript:
+# the "Apply filters" button submits a GET and the server renders the result.
 RSpec.describe "Filtering the course list" do
   let(:provider) { create(:provider, :accredited_provider) }
 


### PR DESCRIPTION
# Hide filter groups that don't vary across a provider's courses

A filter is useless when every course shares the same value — e.g. a provider whose courses are all full time gains nothing from "Full time or part time". This hides a filter group when its value is identical across **all** of the
provider's courses, so the sidebar only ever shows filters that do something.

- Each filter group (Status, Education phase, Fee or salary, Qualification, Full time or part time, Start date) shows only if its value **varies** across the provider's whole course list.
- If **nothing** varies, the whole sidebar is dropped and the course list shifts left (keeping its width, not going full-width).
- A group with an **applied** filter always stays visible, so an active filter is never hidden from its own panel.
- Education phase comes from `course.level` on the read-model rows ("use the new  data model"). No feature flag. **No JavaScript** — the "Apply filters" button isunchanged.

## How

Same "hide uniform values" rule already used for the course-information column, computed once over the **unfiltered** course set (so filtering never adds/removes a filter) and reusing the rows `CourseList` already loads (no extra query).

```mermaid
flowchart TD
    A["provider's unfiltered courses<br/>(rows already loaded by CourseList)"] --> B{"for each of the 6 facets:<br/>more than one distinct value?"}
    B -->|"yes → varies"| C["group shown"]
    B -->|"no → uniform"| D["group hidden"]
    E["group has an applied filter?"] -->|yes| C
    C --> F["visible_filter_groups"]
    D --> F
    F --> G{"any groups visible?"}
    G -->|yes| H["two columns:<br/>sidebar ⅓ + list ⅔"]
    G -->|no| I["no sidebar:<br/>list ⅔, shifted left"]
```

Facet keys per course:

| Group | Facet compared on |
|---|---|
| Status | `StatusTag.token` (open/closed/draft/rolled_over/scheduled/withdrawn) |
| Education phase | `course.level` |
| Fee or salary | `course.funding` |
| Qualification | `course.qualification` |
| Full time or part time | `course.study_mode` |
| Start date | start month (`beginning_of_month`) — the filter groups by month |

### The status token

Status needs the same value the filter selects on and the tag renders — not the
label, since "Open" and "Open \*" (unpublished changes) are the same status. New
`Publish::Courses::StatusTag.token` is that single definition, sitting between
the two existing sources:

```mermaid
flowchart LR
    T["StatusTag.token"] --- Q["Query#status_predicate<br/>(what the filter selects)"]
    T --- C["StatusTagComponent<br/>(what the tag renders)"]
    D["drift-guard spec"] -. "asserts all three agree" .-> T
```

`content_status` → `draft`/`rolled_over`/`withdrawn` map straight through;
`published`(+unpublished changes) → `open`/`closed` in the current/previous cycle
(by application status) or `scheduled` in a future cycle.


## Guide for reviewing and testing

See trello card comments for the scenarios and providers to test.

