### PR TITLE
Update interview process section on Find

### DIFF
--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -6,6 +6,8 @@ module Find
     include GetIntoTeachingRedirect
     include ProviderWebsiteRedirect
 
+    helper_method :show_interview_process?
+
     before_action -> { render_not_found if provider.nil? }
 
     before_action :render_feedback_component, only: :show
@@ -63,6 +65,13 @@ module Find
         subjects: [:financial_incentive],
         site_statuses: [:site],
       ).find_by!(course_code: params[:course_code]&.upcase).decorate
+    end
+
+    def show_interview_process?
+      return false if @enrichment.blank?
+
+      @enrichment.interview_process.present? ||
+        @enrichment.interview_location.in?(%w[online both])
     end
   end
 end

--- a/app/views/find/courses/_components.html.erb
+++ b/app/views/find/courses/_components.html.erb
@@ -18,8 +18,7 @@
   <% end %>
   <%# Interview process %>
   <% if preview?(params) ||
-      course.published_interview_process.present? ||
-      course.published_interview_location.in?(%w[online both]) %>
+      show_interview_process? %>
   <li><%= govuk_link_to t("find.courses.show.interview_process"), "#section-interviews" %></li>
 <% end %>
 <%# Fees and financial support %>

--- a/app/views/find/courses/_components.html.erb
+++ b/app/views/find/courses/_components.html.erb
@@ -17,54 +17,47 @@
     <li><%= govuk_link_to t("find.courses.show.what_you_will_study"), "#section-what-you-will-study" %></li>
   <% end %>
   <%# Interview process %>
-  <% if course.published_interview_process.present? || course.published_interview_location.present? || preview?(params) %>
-    <li><%= govuk_link_to t("find.courses.show.interview_process"), "#section-interviews" %></li>
-  <% end %>
-  <%# Fees and financial support %>
-  <li><%= govuk_link_to (course.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
-  <%# Training with disabilities %>
-  <% if @provider.train_with_disability.present? || preview?(params) %>
-    <li><%= govuk_link_to t("find.courses.show.training_with_disabilities"), "#section-train-with-disabilities" %></li>
-  <% end %>
+  <% if preview?(params) ||
+      course.published_interview_process.present? ||
+      course.published_interview_location.in?(%w[online both]) %>
+  <li><%= govuk_link_to t("find.courses.show.interview_process"), "#section-interviews" %></li>
+<% end %>
+<%# Fees and financial support %>
+<li><%= govuk_link_to (course.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
+<%# Training with disabilities %>
+<% if @provider.train_with_disability.present? || preview?(params) %>
+  <li><%= govuk_link_to t("find.courses.show.training_with_disabilities"), "#section-train-with-disabilities" %></li>
+<% end %>
 </ul>
-
 <%# Why train with us below %>
 <% if @provider.value_proposition.present? || @provider.about_us.present? || preview?(params) %>
   <%= render partial: "find/courses/train_with_us", locals: { provider: @provider } %>
 <% end %>
-
 <%# Where you will train %>
 <% if published_where_you_will_train_present?(course) || preview?(params) %>
   <%= render partial: "find/courses/where_you_will_train", locals: { course: course, enrichment: @enrichment } %>
 <% end %>
-
 <%# What you will do on school placements %>
 <% if course.published_placement_school_activities.present? || preview?(params) %>
   <%= render partial: "find/courses/school_placement", locals: { course: course, enrichment: @enrichment } %>
 <% end %>
-
 <%# What you will study %>
 <% if course.theoretical_training_activities.present? || preview?(params) %>
   <%= render partial: "find/courses/what_you_will_study/what_you_will_study", locals: { course: @course, enrichment: @enrichment } %>
 <% end %>
-
 <%# Interview process %>
 <% if course.published_interview_process.present? || course.published_interview_location.present? || preview?(params) %>
   <%= render partial: "find/courses/interview_process/interview_process", locals: { course: course, enrichment: @enrichment } %>
 <% end %>
-
 <%# Financial support %>
 <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course, @enrichment) %>
-
 <%# Training with disabilities %>
 <% if @provider.train_with_disability.present? || preview?(params) %>
   <h2 class="govuk-heading-m" id="section-train-with-disabilities">
     <%= t("find.courses.show.training_with_disabilities") %>
   </h2>
-
   <p class="govuk-body govuk-!-margin-bottom-8">
     <% if preview?(params) %>
-
       <%= govuk_link_to(
       t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
       training_with_disabilities_publish_provider_recruitment_cycle_course_path(
@@ -73,9 +66,7 @@
         course.course_code,
       ),
     ) %>
-
     <% else %>
-
       <%= govuk_link_to(
       t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
       find_track_click_path(url: find_training_with_disabilities_path(
@@ -83,7 +74,6 @@
         course.course_code,
       )),
     ) %>
-
     <% end %>
   </p>
 <% end %>

--- a/app/views/find/courses/interview_process/_interview_process.html.erb
+++ b/app/views/find/courses/interview_process/_interview_process.html.erb
@@ -1,5 +1,18 @@
+<!-- Show the interview section heading in preview mode, or when there is interview process content or an online interview option is selected (online or both) -->
+<!-- if the provider selects "In person" but leaves "What is the interview process?" blank, the "Interview process" heading is hidden so candidates do not see an empty section -->
+<% show_interview_section =
+     preview?(params) ||
+     (
+       enrichment.present? &&
+       (
+         enrichment.interview_process.present? ||
+         enrichment.interview_location.in?(%w[online both])
+       )
+     ) %>
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-interviews"><%= t(".page_title") %></h2>
+  <% if show_interview_section %>
+    <h2 class="govuk-heading-l" id="section-interviews"><%= t(".page_title") %></h2>
+  <% end %>
   <div data-qa="course__interview_process">
     <% unless enrichment.present? && enrichment.interview_location == "in person" || enrichment.present? && enrichment.interview_location == "in person" %>
       <% if enrichment.present? && enrichment.interview_location == "both" || enrichment.present? && enrichment.interview_location == "both" %>

--- a/app/views/find/courses/interview_process/_interview_process.html.erb
+++ b/app/views/find/courses/interview_process/_interview_process.html.erb
@@ -1,16 +1,7 @@
-<!-- Show the interview section heading in preview mode, or when there is interview process content or an online interview option is selected (online or both) -->
-<!-- if the provider selects "In person" but leaves "What is the interview process?" blank, the "Interview process" heading is hidden so candidates do not see an empty section -->
-<% show_interview_section =
-     preview?(params) ||
-     (
-       enrichment.present? &&
-       (
-         enrichment.interview_process.present? ||
-         enrichment.interview_location.in?(%w[online both])
-       )
-     ) %>
+<%# Show the interview section heading in preview mode, or when there is interview process content or an online interview option is selected (online or both) %>
+<%# if the provider selects "In person" but leaves "What is the interview process?" blank, the "Interview process" heading is hidden so candidates do not see an empty section %>
 <div class="govuk-!-margin-bottom-8">
-  <% if show_interview_section %>
+  <% if preview?(params) || show_interview_process? %>
     <h2 class="govuk-heading-l" id="section-interviews"><%= t(".page_title") %></h2>
   <% end %>
   <div data-qa="course__interview_process">

--- a/app/views/publish/courses/fields/_dynamic_preview.html.erb
+++ b/app/views/publish/courses/fields/_dynamic_preview.html.erb
@@ -14,9 +14,8 @@
     <%= render partial: "publish/courses/fields/fees" %>
   <% end %>
 
+  <%= render partial: "publish/courses/fields/interview_location_preview" %>
   <p class="govuk-body"
       data-input-preview-target="preview"
       data-preview-target="shared"><%= t(".preview_text") %></p>
-
-  <%= render partial: "publish/courses/fields/interview_location_preview" %>
 </div>

--- a/spec/system/find/courses/fields/interview_process_spec.rb
+++ b/spec/system/find/courses/fields/interview_process_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe "Viewing long form course content for the interview process", ser
     when_i_visit_a_course
 
     expect(page).not_to have_selector("h2", text: "Interview process")
+    within(".course-contents") do
+      expect(page).not_to have_link("Interview process")
+    end
   end
 
   def when_i_visit_a_course

--- a/spec/system/find/courses/fields/interview_process_spec.rb
+++ b/spec/system/find/courses/fields/interview_process_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe "Viewing long form course content for the interview process", ser
     then_i_see_the_long_form_content_for_interview_location_online
   end
 
+  scenario "A user cannot see the interview process section when the interview location is IN PERSON and no interview process content is provided" do
+    given_a_published_course_exists(
+      interview_location: "in person",
+      interview_process: nil,
+    )
+
+    when_i_visit_a_course
+
+    expect(page).not_to have_selector("h2", text: "Interview process")
+  end
+
   def when_i_visit_a_course
     visit find_results_path
     click_on_first_course
@@ -59,7 +70,10 @@ RSpec.describe "Viewing long form course content for the interview process", ser
     expect(page).to have_content(enrichment.interview_process)
   end
 
-  def given_a_published_course_exists(interview_location: "both")
+  def given_a_published_course_exists(
+    interview_location: "both",
+    interview_process: "The interview process is a 72 stage process"
+  )
     @course = create(
       :course,
       :with_full_time_sites,
@@ -71,8 +85,8 @@ RSpec.describe "Viewing long form course content for the interview process", ser
         build(
           :course_enrichment,
           :published,
-          interview_process: "The interview process is a 72 stage process",
-          interview_location:,
+          interview_process: interview_process,
+          interview_location: interview_location,
         ),
       ],
       name: "Art and design (SEND)",


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/HNG0rf6K/1246-in-person-interviews-design-and-content-work

If a provider chooses ‘In person’ interviews, and does not complete the longform content, the ‘Interview process’ title appears on Find with no content underneath it.

## Changes proposed in this pull request

- Show the interview section heading in preview mode, or when there is interview process content or an online interview option is selected (online or both)
- If the provider selects "In person" but leaves "What is the interview process?" blank, the "Interview process" heading is hidden so candidates do not see an empty section
- Update spec

## Guidance to review

### Expected behaviour

- On Find, the **Interview process** heading and **Contents** link are hidden when **In person** is selected and no interview process content has been provided.
- On Find, the **Interview process** heading and **Contents** link continue to display when interview process content exists, or when **Online** or **Either in person or online** is selected.
- Preview behaviour remains unchanged, with the **Interview process** heading and missing information prompts still displayed where appropriate.
### Testing Find

1. In Publish, navigate to **Interview process** for a course.
2. Select **In person** as the interview location and leave **What is the interview process?** blank.
3. Publish the course and view it on Find.
   - Confirm the **Interview process** heading is **not displayed**.
   - Confirm that **Interview process** is **not displayed** in the Contents list
4. Add content to **What is the interview process?** and publish the course.
   - Confirm the **Interview process** heading and supporting text **are displayed** on Find.
5. Select **Online** or **Either in person or online** and leave **What is the interview process?** blank.
6. Publish the course and view it on Find.
   - Confirm the **Interview process** heading is displayed alongside the relevant interview information.

### Testing Preview

1. Create a new course in Publish.
2. Navigate to **Interview process**.
3. Select **In person** as the interview location and leave **What is the interview process?** blank.
4. Preview the course.
   - Confirm the **Interview process** heading is displayed.
   - Confirm the missing information prompt (**"Enter details about the interview process"**) is displayed.
   -  Confirm that **Interview process** is **displayed** in the Contents list
5. Add content to **What is the interview process?**.
6. Preview the course again.
   - Confirm the **Interview process** heading and supporting text are displayed.
7. Select **Online** or **Either in person or online** and leave **What is the interview process?** blank.
8. Preview the course.
   - Confirm the **Interview process** heading is displayed alongside the relevant interview information.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
