### PR TITLE
Prevent closed GIAS schools from being added to provide or course

### DIFF
--- a/app/components/closed_school_tag_component.html.erb
+++ b/app/components/closed_school_tag_component.html.erb
@@ -1,0 +1,3 @@
+<strong class="govuk-tag govuk-tag--red closed-tag">
+  <%= t(".closed") %>
+</strong>

--- a/app/components/closed_school_tag_component.rb
+++ b/app/components/closed_school_tag_component.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 # Flags a school whose GIAS record has closed. Shared by Publish and Support.
-# Presentational only: the caller decides closedness, batching the lookup on
-# list pages (a set of closed URNs) and using Site/Provider::School
-# #gias_school_closed? on the single-record show pages.
+# Presentational only: the caller decides closedness. Provider::School pages use
+# #gias_school_closed?, which is free wherever gias_school is preloaded; the
+# Site-backed course schools picker has no such association, so it batches the
+# lookup into a set of closed URNs.
 class ClosedSchoolTagComponent < ViewComponent::Base
   def initialize(closed:)
     @closed = closed

--- a/app/components/closed_school_tag_component.rb
+++ b/app/components/closed_school_tag_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Flags a school whose GIAS record has closed. Shared by Publish and Support.
+# Presentational only: the caller decides closedness, batching the lookup on
+# list pages (a set of closed URNs) and using Site/Provider::School
+# #gias_school_closed? on the single-record show pages.
+class ClosedSchoolTagComponent < ViewComponent::Base
+  def initialize(closed:)
+    @closed = closed
+
+    super()
+  end
+
+  def render?
+    @closed
+  end
+end

--- a/app/controllers/publish/providers/schools/checks_controller.rb
+++ b/app/controllers/publish/providers/schools/checks_controller.rb
@@ -54,7 +54,7 @@ module Publish
         end
 
         def gias_school
-          @gias_school ||= GiasSchool.find(school_id)
+          @gias_school ||= GiasSchool.available.find(school_id)
         end
 
         def school_id

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -10,6 +10,7 @@ module Publish
 
       def index
         @pagy, @schools = pagy(ProviderSchools::Identity.ordered_school_scope(provider:), limit: PER_PAGE)
+        @closed_urns = closed_urns_for(@schools)
       end
 
       def show; end
@@ -64,6 +65,15 @@ module Publish
 
       def reset_urn_form
         URNForm.new(provider).clear_stash
+      end
+
+      # Resolve which of the listed schools point at a closed GIAS record in a
+      # single query, keyed by URN (shared by Site and Provider::School rows).
+      def closed_urns_for(schools)
+        urns = schools.map(&:urn).compact_blank
+        return Set.new if urns.empty?
+
+        GiasSchool.closed.where(urn: urns).pluck(:urn).to_set
       end
     end
   end

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -10,7 +10,6 @@ module Publish
 
       def index
         @pagy, @schools = pagy(ProviderSchools::Identity.ordered_school_scope(provider:), limit: PER_PAGE)
-        @closed_urns = closed_urns_for(@schools)
       end
 
       def show; end
@@ -65,15 +64,6 @@ module Publish
 
       def reset_urn_form
         URNForm.new(provider).clear_stash
-      end
-
-      # Resolve which of the listed schools point at a closed GIAS record in a
-      # single query, keyed by URN (shared by Site and Provider::School rows).
-      def closed_urns_for(schools)
-        urns = schools.map(&:urn).compact_blank
-        return Set.new if urns.empty?
-
-        GiasSchool.closed.where(urn: urns).pluck(:urn).to_set
       end
     end
   end

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -69,7 +69,7 @@ module Support
         # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
 
         def gias_school
-          @gias_school ||= GiasSchool.find(params[:school_id])
+          @gias_school ||= GiasSchool.available.find(params[:school_id])
         end
 
         def provider

--- a/app/forms/publish/course_school_form.rb
+++ b/app/forms/publish/course_school_form.rb
@@ -13,8 +13,23 @@ module Publish
     end
 
     # Every school the provider could attach, in the order they are listed.
+    # Schools whose GIAS record has closed are excluded, matching the add-course
+    # wizard's picker - except one already attached to this course, which stays
+    # (flagged as closed) so it is not silently detached by the next save.
     def sites
-      @sites ||= course.provider.sites.sort_by(&:location_name)
+      @sites ||= course
+        .provider
+        .sites
+        .with_available_gias_school
+        .or(course.provider.sites.where(id: course.site_ids))
+        .sort_by(&:location_name)
+    end
+
+    # Only an already-attached school survives the filter above, so this is
+    # normally empty. Resolved in one query, keyed by urn, to avoid an N+1
+    # across the list.
+    def closed_school?(site)
+      site.urn.present? && closed_urns.include?(site.urn)
     end
 
     def schools_collapse_threshold
@@ -26,6 +41,14 @@ module Publish
     end
 
   private
+
+    def closed_urns
+      @closed_urns ||= begin
+        urns = sites.map(&:urn).compact_blank
+
+        urns.empty? ? Set.new : GiasSchool.closed.where(urn: urns).pluck(:urn).to_set
+      end
+    end
 
     def no_schools_selected
       return if params[:site_ids].present?

--- a/app/models/course/school.rb
+++ b/app/models/course/school.rb
@@ -11,6 +11,10 @@ class Course::School < ApplicationRecord
   belongs_to :gias_school
   belongs_to :provider_school, class_name: "Provider::School", inverse_of: :course_schools
 
+  # Course schools whose GIAS record is still available (i.e. not closed).
+  # Used to keep closed schools out of the rollover copy path.
+  scope :with_available_gias_school, -> { joins(:gias_school).merge(GiasSchool.available) }
+
   delegate :provider, :recruitment_cycle, to: :course, allow_nil: true
 
   validates :provider_school_id, uniqueness: { scope: :course_id }

--- a/app/models/gias_school.rb
+++ b/app/models/gias_school.rb
@@ -26,6 +26,8 @@ class GiasSchool < ApplicationRecord
     ])
   }
 
+  scope :unavailable, -> { where.not(id: available) }
+
   enum :status_code, {
     open: "1",
     closed: "2",

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -14,6 +14,10 @@ class Provider::School < ApplicationRecord
 
   has_many :course_schools, class_name: "Course::School", inverse_of: :provider_school, dependent: :destroy
 
+  # Provider schools whose GIAS record is still available (i.e. not closed).
+  # Used to keep closed schools out of the add-course picker and the rollover.
+  scope :with_available_gias_school, -> { joins(:gias_school).merge(GiasSchool.available) }
+
   delegate :recruitment_cycle, :provider_code, to: :provider, allow_nil: true
   delegate :urn, :address1, :address2, :address3, :town, :postcode, to: :gias_school
 

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -20,6 +20,7 @@ class Provider::School < ApplicationRecord
 
   delegate :recruitment_cycle, :provider_code, to: :provider, allow_nil: true
   delegate :urn, :address1, :address2, :address3, :town, :postcode, to: :gias_school
+  delegate :closed?, to: :gias_school, prefix: :gias_school
 
   validates :site_code, presence: true
   validates :gias_school_id, uniqueness: { scope: %i[provider_id site_code] }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -60,11 +60,16 @@ class Site < ApplicationRecord
 
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil) }
 
-  # Filter out sites we can identify as closed: those whose URN matches an
-  # unavailable GIAS school. Sites with no URN, or a URN matching no GIAS
-  # school, are kept.
+  # Sites backed by an available GIAS school. Effectively a join on urn (Site
+  # has no foreign key to gias_school) without selecting the GIAS columns, so a
+  # urn matching no GIAS row is excluded rather than passed through - from 2026
+  # every school site's urn matches a GIAS record, and an earlier cycle's
+  # unmatched urn is uncleansed data, not a school we can vouch for.
+  #
+  # Main sites are the one exemption: they are legitimately urn-less
+  # (see the urn presence validation above), so they are always kept.
   scope :with_available_gias_school, lambda {
-    where.not(urn: GiasSchool.unavailable.select(:urn)).or(where(urn: nil))
+    where(urn: nil).or(where(urn: GiasSchool.available.select(:urn)))
   }
 
   attr_accessor :skip_geocoding

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -60,6 +60,13 @@ class Site < ApplicationRecord
 
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil) }
 
+  # Filter out sites we can identify as closed: those whose URN matches an
+  # unavailable GIAS school. Sites with no URN, or a URN matching no GIAS
+  # school, are kept.
+  scope :with_available_gias_school, lambda {
+    where.not(urn: GiasSchool.unavailable.select(:urn)).or(where(urn: nil))
+  }
+
   attr_accessor :skip_geocoding
 
   after_commit :geocode_site, unless: :skip_geocoding

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -83,12 +83,6 @@ class Site < ApplicationRecord
     Course.kept.includes(:sites).where(sites: { id: }).none?
   end
 
-  # A Site has no foreign key to gias_school, so match on urn (which is unique
-  # in the gias_school table). Blank-urn sites are never treated as closed.
-  def gias_school_closed?
-    urn.present? && GiasSchool.closed.exists?(urn:)
-  end
-
   def geocode_site
     GeocodeJob.perform_later("Site", id) if needs_geolocation?
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -78,6 +78,12 @@ class Site < ApplicationRecord
     Course.kept.includes(:sites).where(sites: { id: }).none?
   end
 
+  # A Site has no foreign key to gias_school, so match on urn (which is unique
+  # in the gias_school table). Blank-urn sites are never treated as closed.
+  def gias_school_closed?
+    urn.present? && GiasSchool.closed.exists?(urn:)
+  end
+
   def geocode_site
     GeocodeJob.perform_later("Site", id) if needs_geolocation?
   end

--- a/app/services/rollover/schools/course_copier.rb
+++ b/app/services/rollover/schools/course_copier.rb
@@ -7,7 +7,7 @@ module Rollover
         lookup = new_provider_schools(new_provider)
         existing = new_course.schools.index_by(&:provider_school_id)
 
-        course.schools.includes(:provider_school).find_each do |course_school|
+        course.schools.with_available_gias_school.includes(:provider_school).find_each do |course_school|
           old_provider_school = course_school.provider_school
           new_provider_school = lookup[[old_provider_school.gias_school_id, old_provider_school.site_code]]
 

--- a/app/services/rollover/schools/legacy_course_copier.rb
+++ b/app/services/rollover/schools/legacy_course_copier.rb
@@ -10,7 +10,7 @@ module Rollover
       def call(course:, new_provider:, new_course:)
         lookup = new_provider_sites(new_provider)
 
-        course.sites.each do |site|
+        course.sites.with_available_gias_school.each do |site|
           new_site = lookup[site.code]
           site_copier.call(new_site:, new_course:) if new_site.present?
         end

--- a/app/services/rollover/schools/legacy_provider_copier.rb
+++ b/app/services/rollover/schools/legacy_provider_copier.rb
@@ -10,7 +10,7 @@ module Rollover
       def execute(provider:, new_provider:)
         result = { copied: 0, skipped: [] }
 
-        provider.sites.each do |site|
+        provider.sites.with_available_gias_school.each do |site|
           site_result = site_copier.execute(site:, new_provider:)
 
           if site_result.success?

--- a/app/services/rollover/schools/provider_copier.rb
+++ b/app/services/rollover/schools/provider_copier.rb
@@ -5,8 +5,9 @@ module Rollover
     class ProviderCopier
       def execute(provider:, new_provider:)
         existing = new_provider.schools.index_by { |school| [school.gias_school_id, school.site_code] }
+        schools = provider.schools.with_available_gias_school
 
-        provider.schools.each do |provider_school|
+        schools.each do |provider_school|
           key = [provider_school.gias_school_id, provider_school.site_code]
           next if existing.key?(key)
 
@@ -16,7 +17,7 @@ module Rollover
           )
         end
 
-        { copied: provider.schools.size, skipped: [] }
+        { copied: schools.size, skipped: [] }
       end
     end
   end

--- a/app/views/publish/courses/schools/edit.html.erb
+++ b/app/views/publish/courses/schools/edit.html.erb
@@ -55,7 +55,11 @@
           <% @course_school_form.sites.each_with_index do |site, index| %>
             <%= f.govuk_check_box :site_ids,
                 site.id,
-                label: { text: [site.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
+                label: { text: [
+                  site.location_name,
+                  render(Publish::Schools::NewlyAddedTagComponent.new(school: site)),
+                  render(ClosedSchoolTagComponent.new(closed: @course_school_form.closed_school?(site))),
+                ].compact_blank.join(" ").html_safe },
                 hint: { text: site.decorate.full_address, class: "govuk-!-font-size-16" },
                 link_errors: index.zero?,
                 data: {

--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -3,6 +3,7 @@
     <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid) %>
 
     <%= render Publish::Schools::NewlyAddedTagComponent.new(school:) %>
+    <%= render ClosedSchoolTagComponent.new(closed: @closed_urns.include?(school.urn)) %>
   </th>
 
   <td class="govuk-table__cell code">

--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -3,7 +3,7 @@
     <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid) %>
 
     <%= render Publish::Schools::NewlyAddedTagComponent.new(school:) %>
-    <%= render ClosedSchoolTagComponent.new(closed: @closed_urns.include?(school.urn)) %>
+    <%= render ClosedSchoolTagComponent.new(closed: school.gias_school_closed?) %>
   </th>
 
   <td class="govuk-table__cell code">

--- a/app/views/publish/providers/schools/show.html.erb
+++ b/app/views/publish/providers/schools/show.html.erb
@@ -7,7 +7,10 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= school.location_name %></h1>
+        <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
+          <%= @site.location_name %>
+          <%= render ClosedSchoolTagComponent.new(closed: school.closed?) %>
+        </h1>
       </legend>
       <%= render GovukComponent::SummaryListComponent.new do |component|
             component.with_row do |row|

--- a/app/views/publish/providers/schools/show.html.erb
+++ b/app/views/publish/providers/schools/show.html.erb
@@ -8,8 +8,8 @@
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
-          <%= @site.location_name %>
-          <%= render ClosedSchoolTagComponent.new(closed: school.closed?) %>
+          <%= school.location_name %>
+          <%= render ClosedSchoolTagComponent.new(closed: school.gias_school_closed?) %>
         </h1>
       </legend>
       <%= render GovukComponent::SummaryListComponent.new do |component|

--- a/app/views/support/providers/schools/show.html.erb
+++ b/app/views/support/providers/schools/show.html.erb
@@ -6,7 +6,10 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= @provider.decorate.name_and_code %> </span>
-        <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= @site.location_name %></h1>
+        <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3">
+          <%= @site.location_name %>
+          <%= render ClosedSchoolTagComponent.new(closed: @site.gias_school_closed?) %>
+        </h1>
       </legend>
       <%= render GovukComponent::SummaryListComponent.new do |component|
             component.with_row do |row|

--- a/app/wizards/course_wizard/steps/schools.rb
+++ b/app/wizards/course_wizard/steps/schools.rb
@@ -57,7 +57,7 @@ class CourseWizard
       end
 
       def provider_sites
-        wizard.provider.sites
+        wizard.provider.sites.with_available_gias_school
       end
 
       def funding_type

--- a/config/locales/en/components/closed_school_tag_component.yml
+++ b/config/locales/en/components/closed_school_tag_component.yml
@@ -1,0 +1,3 @@
+en:
+  closed_school_tag_component:
+    closed: Closed

--- a/spec/components/closed_school_tag_component_spec.rb
+++ b/spec/components/closed_school_tag_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClosedSchoolTagComponent, type: :component do
+  it "renders a Closed tag when the school is closed" do
+    render_inline(described_class.new(closed: true))
+
+    expect(page).to have_css(".govuk-tag", text: "Closed")
+  end
+
+  it "does not render when the school is not closed" do
+    render_inline(described_class.new(closed: false))
+
+    expect(page).to have_no_css(".govuk-tag")
+  end
+end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -22,6 +22,15 @@ FactoryBot.define do
       age { nil }
     end
 
+    # Only needed by specs exercising Site.with_available_gias_school - the two
+    # school pickers and the legacy rollover copiers. An existing row for the
+    # urn is never replaced, so a spec wanting a closed school creates it first.
+    trait :with_gias_school do
+      after(:build) do |site|
+        create(:gias_school, :open, urn: site.urn) unless GiasSchool.exists?(urn: site.urn)
+      end
+    end
+
     trait :study_site do
       site_type { "study_site" }
     end

--- a/spec/forms/publish/course_school_form_spec.rb
+++ b/spec/forms/publish/course_school_form_spec.rb
@@ -16,23 +16,72 @@ module Publish
 
     describe "#sites" do
       it "returns the provider's schools sorted by location name" do
-        provider = create(:provider, sites: [build(:site, location_name: "B School"), build(:site, location_name: "A School")])
+        provider = create(:provider, sites: [build(:site, :with_gias_school, location_name: "B School"), build(:site, :with_gias_school, location_name: "A School")])
         form = described_class.new(create(:course, provider:), params: {})
 
         expect(form.sites.map(&:location_name)).to eq(["A School", "B School"])
+      end
+
+      it "excludes a school whose GIAS record has closed" do
+        closed_gias_school = create(:gias_school, :closed, urn: "654321")
+        provider = create(
+          :provider,
+          sites: [
+            build(:site, :with_gias_school, location_name: "Available School", urn: "123456"),
+            build(:site, location_name: "Closed School", urn: closed_gias_school.urn),
+          ],
+        )
+        form = described_class.new(create(:course, provider:), params: {})
+
+        expect(form.sites.map(&:location_name)).to eq(["Available School"])
+      end
+
+      it "keeps a closed school that is already attached to the course" do
+        closed_gias_school = create(:gias_school, :closed, urn: "654321")
+        attached_site = build(:site, location_name: "Closed School", urn: closed_gias_school.urn)
+        provider = create(
+          :provider,
+          sites: [build(:site, :with_gias_school, location_name: "Available School", urn: "123456"), attached_site],
+        )
+        course = create(:course, provider:, site_statuses: [build(:site_status, site: attached_site)])
+        form = described_class.new(course, params: {})
+
+        expect(form.sites.map(&:location_name)).to contain_exactly("Available School", "Closed School")
+      end
+    end
+
+    describe "#closed_school?" do
+      let(:closed_gias_school) { create(:gias_school, :closed, urn: "654321") }
+      let(:closed_site) { build(:site, location_name: "Closed School", urn: closed_gias_school.urn) }
+      let(:available_site) { build(:site, :with_gias_school, location_name: "Available School", urn: "123456") }
+      let(:provider) { create(:provider, sites: [available_site, closed_site]) }
+      let(:course) { create(:course, provider:, site_statuses: [build(:site_status, site: closed_site)]) }
+
+      subject(:form) { described_class.new(course, params: {}) }
+
+      it "is true for a site whose GIAS record has closed" do
+        expect(form.closed_school?(closed_site)).to be(true)
+      end
+
+      it "is false for a site whose GIAS record is available" do
+        expect(form.closed_school?(available_site)).to be(false)
+      end
+
+      it "is false for a site with no urn" do
+        expect(form.closed_school?(build(:site, :main_site))).to be(false)
       end
     end
 
     describe "#collapse_schools?" do
       it "is false when the provider has 20 schools or fewer" do
-        provider = create(:provider, sites: build_list(:site, 20))
+        provider = create(:provider, sites: build_list(:site, 20, :with_gias_school))
         form = described_class.new(create(:course, provider:), params: {})
 
         expect(form.collapse_schools?).to be(false)
       end
 
       it "is true when the provider has more than 20 schools" do
-        provider = create(:provider, sites: build_list(:site, 21))
+        provider = create(:provider, sites: build_list(:site, 21, :with_gias_school))
         form = described_class.new(create(:course, provider:), params: {})
 
         expect(form.collapse_schools?).to be(true)

--- a/spec/models/course/school_spec.rb
+++ b/spec/models/course/school_spec.rb
@@ -11,6 +11,15 @@ describe Course::School do
     it { is_expected.to belong_to(:provider_school).class_name("Provider::School").required }
   end
 
+  describe ".with_available_gias_school" do
+    it "excludes course schools whose GIAS record is closed" do
+      available = create(:course_school, gias_school: create(:gias_school, :open))
+      create(:course_school, gias_school: create(:gias_school, :closed))
+
+      expect(described_class.with_available_gias_school).to contain_exactly(available)
+    end
+  end
+
   describe "validations" do
     it "creates a valid record" do
       expect(course_school).to be_valid

--- a/spec/models/gias_school_spec.rb
+++ b/spec/models/gias_school_spec.rb
@@ -25,6 +25,20 @@ describe GiasSchool do
         expect(result).not_to contain_exactly(closed.id)
       end
     end
+
+    describe ".unavailable" do
+      it "returns only closed schools, the complement of .available" do
+        open = create(:gias_school, :open)
+        proposed_close = create(:gias_school, status_code: :proposed_to_close)
+        proposed_open = create(:gias_school, status_code: :proposed_to_open)
+        closed = create(:gias_school, :closed)
+
+        result = described_class.unavailable.ids
+
+        expect(result).to contain_exactly(closed.id)
+        expect(result).not_to include(open.id, proposed_close.id, proposed_open.id)
+      end
+    end
   end
 
   context "callbacks" do

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -20,6 +20,16 @@ describe Provider::School do
     end
   end
 
+  describe "#gias_school_closed?" do
+    it "is true when the GIAS school is closed" do
+      expect(build(:provider_school, gias_school: build(:gias_school, :closed))).to be_gias_school_closed
+    end
+
+    it "is false when the GIAS school is open" do
+      expect(build(:provider_school, gias_school: build(:gias_school, :open))).not_to be_gias_school_closed
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:site_code) }
 

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -11,6 +11,15 @@ describe Provider::School do
     it { is_expected.to have_many(:course_schools).class_name("Course::School").dependent(:destroy) }
   end
 
+  describe ".with_available_gias_school" do
+    it "excludes provider schools whose GIAS record is closed" do
+      available = create(:provider_school, gias_school: create(:gias_school, :open))
+      create(:provider_school, gias_school: create(:gias_school, :closed))
+
+      expect(described_class.with_available_gias_school).to contain_exactly(available)
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:site_code) }
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -23,13 +23,13 @@ describe Site do
       expect(described_class.with_available_gias_school).not_to include(closed_site)
     end
 
-    it "keeps a site whose URN matches no GIAS school" do
+    it "excludes a site whose URN matches no GIAS school" do
       unmatched_site = create(:site, provider:, urn: "999999")
 
-      expect(described_class.with_available_gias_school).to include(unmatched_site)
+      expect(described_class.with_available_gias_school).not_to include(unmatched_site)
     end
 
-    it "keeps a site with no URN" do
+    it "keeps a main site, which is legitimately urn-less" do
       main_site = create(:site, :main_site, provider:)
 
       expect(described_class.with_available_gias_school).to include(main_site)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -13,6 +13,29 @@ describe Site do
     it { is_expected.to be_audited.associated_with(:provider) }
   end
 
+  describe ".with_available_gias_school" do
+    it "excludes a site whose GIAS school has closed" do
+      create(:gias_school, :closed, urn: "654321")
+      closed_site = create(:site, provider:, urn: "654321")
+      available_site = create(:site, provider:, urn: create(:gias_school, :open).urn)
+
+      expect(described_class.with_available_gias_school).to include(available_site)
+      expect(described_class.with_available_gias_school).not_to include(closed_site)
+    end
+
+    it "keeps a site whose URN matches no GIAS school" do
+      unmatched_site = create(:site, provider:, urn: "999999")
+
+      expect(described_class.with_available_gias_school).to include(unmatched_site)
+    end
+
+    it "keeps a site with no URN" do
+      main_site = create(:site, :main_site, provider:)
+
+      expect(described_class.with_available_gias_school).to include(main_site)
+    end
+  end
+
   describe "school" do
     it { is_expected.to validate_presence_of(:location_name) }
     it { is_expected.to validate_presence_of(:address1) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -36,6 +36,28 @@ describe Site do
     end
   end
 
+  describe "#gias_school_closed?" do
+    it "is true when a closed GIAS school matches the urn" do
+      create(:gias_school, :closed, urn: "654321")
+
+      expect(build(:site, urn: "654321")).to be_gias_school_closed
+    end
+
+    it "is false when the matching GIAS school is open" do
+      create(:gias_school, :open, urn: "123456")
+
+      expect(build(:site, urn: "123456")).not_to be_gias_school_closed
+    end
+
+    it "is false when the urn matches no GIAS school" do
+      expect(build(:site, urn: "999999")).not_to be_gias_school_closed
+    end
+
+    it "is false when the site has no urn" do
+      expect(build(:site, urn: nil)).not_to be_gias_school_closed
+    end
+  end
+
   describe "school" do
     it { is_expected.to validate_presence_of(:location_name) }
     it { is_expected.to validate_presence_of(:address1) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -36,28 +36,6 @@ describe Site do
     end
   end
 
-  describe "#gias_school_closed?" do
-    it "is true when a closed GIAS school matches the urn" do
-      create(:gias_school, :closed, urn: "654321")
-
-      expect(build(:site, urn: "654321")).to be_gias_school_closed
-    end
-
-    it "is false when the matching GIAS school is open" do
-      create(:gias_school, :open, urn: "123456")
-
-      expect(build(:site, urn: "123456")).not_to be_gias_school_closed
-    end
-
-    it "is false when the urn matches no GIAS school" do
-      expect(build(:site, urn: "999999")).not_to be_gias_school_closed
-    end
-
-    it "is false when the site has no urn" do
-      expect(build(:site, urn: nil)).not_to be_gias_school_closed
-    end
-  end
-
   describe "school" do
     it { is_expected.to validate_presence_of(:location_name) }
     it { is_expected.to validate_presence_of(:address1) }

--- a/spec/requests/publish/providers/schools/checks_spec.rb
+++ b/spec/requests/publish/providers/schools/checks_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Publish provider school checks", type: :request do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user, :with_provider) }
+  let(:provider) { user.providers.first }
+
+  before { login_user(user) }
+
+  it "adds an available GIAS school" do
+    available_school = create(:gias_school, :open)
+
+    expect {
+      put publish_provider_recruitment_cycle_schools_check_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        school_id: available_school.id,
+      )
+    }.to change { provider.schools.count }.by(1)
+  end
+
+  it "does not add an unavailable GIAS school" do
+    closed_school = create(:gias_school, :closed)
+
+    expect {
+      put publish_provider_recruitment_cycle_schools_check_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        school_id: closed_school.id,
+      )
+    }.not_to(change { provider.schools.count })
+
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe "Support::CopyCourses" do
     end
 
     context "with schools" do
+      # The copier only carries over sites backed by an available GIAS school,
+      # and the course factory's sites use a urn sequence that matches none.
+      before do
+        source_provider.courses.flat_map(&:sites).each { |site| create(:gias_school, :open, urn: site.urn) }
+      end
+
       it "copies the courses with schools" do
         login_user(user)
         post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { "course[autocompleted_provider_code]" => source_provider.provider_code, schools: "1" }

--- a/spec/requests/support/providers/schools/checks_spec.rb
+++ b/spec/requests/support/providers/schools/checks_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe "Support provider school checks" do
     login_user(admin)
   end
 
+  it "does not add an unavailable GIAS school" do
+    closed_school = create(:gias_school, :closed)
+
+    expect {
+      put support_recruitment_cycle_provider_schools_check_path(
+        recruitment_cycle.year,
+        provider,
+        school_id: closed_school.id,
+      )
+    }.not_to(change { provider.schools.count })
+
+    expect(response).to have_http_status(:not_found)
+  end
+
   it "rolls back the legacy Site when Provider::School creation fails" do
     allow(ProviderSchools::Creator).to receive(:call).and_raise(StandardError, "provider school failed")
 

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe Courses::CopyToProviderService do
   end
 
   context "the original course has schools" do
-    let(:site) { create(:site, :school, provider:) }
+    let(:site) { create(:site, :school, :with_gias_school, provider:) }
     let!(:new_site) { create(:site, :school, provider: new_provider, code: site.code) }
     let!(:site_status) do
       create(:site_status,

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe Providers::CopyToRecruitmentCycleService do
   describe "#execute" do
-    let(:site) { build(:site, :school) }
+    let(:site) { build(:site, :school, :with_gias_school) }
     let(:study_site) { build(:site, :study_site) }
     let(:published_course_enrichment) { build(:course_enrichment, :published) }
     let(:course_enrichments) { [published_course_enrichment] }

--- a/spec/services/rollover/schools/course_copier_spec.rb
+++ b/spec/services/rollover/schools/course_copier_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe Rollover::Schools::CourseCopier do
   it "does not create legacy site statuses" do
     expect { copy_schools }.not_to change(new_course.site_statuses, :count)
   end
+
+  context "when a course school's GIAS record has closed" do
+    let(:closed_gias_school) { create(:gias_school, :closed) }
+    let!(:closed_course_school) do
+      closed_provider_school = create(:provider_school, provider:, gias_school: closed_gias_school, site_code: "Z")
+      create(:course_school, course:, provider_school: closed_provider_school, gias_school: closed_gias_school, site_code: "Z")
+    end
+    # Deliberately no matching Provider::School on new_provider: the closed school
+    # is not rolled over, so CourseCopier must skip it rather than raise.
+
+    it "does not copy it and does not raise" do
+      expect { copy_schools }.not_to raise_error
+
+      expect(new_course.schools.pluck(:gias_school_id)).not_to include(closed_gias_school.id)
+    end
+  end
 end

--- a/spec/services/rollover/schools/dual_course_copier_spec.rb
+++ b/spec/services/rollover/schools/dual_course_copier_spec.rb
@@ -60,4 +60,22 @@ RSpec.describe Rollover::Schools::DualCourseCopier do
       gias_school_id: course_school.gias_school_id,
     )
   end
+
+  it "copies neither the SiteStatus nor the Course::School when the GIAS record has closed" do
+    closed_gias_school = create(:gias_school, :closed)
+
+    closed_site = create(:site, provider:, code: "Z", urn: closed_gias_school.urn)
+    create(:site_status, course:, site: closed_site, status: :running)
+    # A matching new site exists, so exclusion must come from the availability
+    # filter rather than merely a missing destination site.
+    create(:site, provider: new_provider, code: "Z", urn: closed_gias_school.urn)
+
+    closed_provider_school = create(:provider_school, provider:, gias_school: closed_gias_school, site_code: "Y")
+    create(:course_school, course:, provider_school: closed_provider_school, gias_school: closed_gias_school, site_code: "Y")
+
+    copy_schools
+
+    expect(new_course.site_statuses.map { |site_status| site_status.site.code }).not_to include("Z")
+    expect(new_course.schools.pluck(:gias_school_id)).not_to include(closed_gias_school.id)
+  end
 end

--- a/spec/services/rollover/schools/dual_course_copier_spec.rb
+++ b/spec/services/rollover/schools/dual_course_copier_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Rollover::Schools::DualCourseCopier do
 
   let(:provider) { create(:provider) }
   let(:new_provider) { create(:provider, recruitment_cycle: create(:recruitment_cycle, :next)) }
-  let!(:legacy_site) { create(:site, provider:, code: "S") }
+  let!(:legacy_site) { create(:site, :with_gias_school, provider:, code: "S") }
   let!(:provider_school) { create(:provider_school, provider:, site_code: "B") }
   let(:course) { create(:course, provider:) }
   let!(:site_status) { create(:site_status, course:, site: legacy_site, status: :running) }

--- a/spec/services/rollover/schools/dual_provider_copier_spec.rb
+++ b/spec/services/rollover/schools/dual_provider_copier_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Rollover::Schools::DualProviderCopier do
 
   let(:provider) { create(:provider) }
   let(:new_provider) { create(:provider, recruitment_cycle: create(:recruitment_cycle, :next)) }
-  let!(:legacy_site) { create(:site, provider:, code: "S") }
+  let!(:legacy_site) { create(:site, :with_gias_school, provider:, code: "S") }
   let!(:provider_school) { create(:provider_school, provider:, site_code: "B") }
 
   it "copies both legacy Site and new Provider::School records" do

--- a/spec/services/rollover/schools/dual_provider_copier_spec.rb
+++ b/spec/services/rollover/schools/dual_provider_copier_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe Rollover::Schools::DualProviderCopier do
   it "returns the legacy result used by rollover reporting" do
     expect(copy_schools).to eq(copied: 1, skipped: [])
   end
+
+  it "copies neither the legacy Site nor the Provider::School when the GIAS record has closed" do
+    closed_gias_school = create(:gias_school, :closed)
+    create(:site, provider:, code: "Z", urn: closed_gias_school.urn)
+    create(:provider_school, provider:, gias_school: closed_gias_school, site_code: "Z")
+
+    copy_schools
+
+    expect(new_provider.sites.pluck(:code)).to contain_exactly(legacy_site.code)
+    expect(new_provider.schools.pluck(:site_code)).to contain_exactly(provider_school.site_code)
+  end
 end

--- a/spec/services/rollover/schools/provider_copier_spec.rb
+++ b/spec/services/rollover/schools/provider_copier_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe Rollover::Schools::ProviderCopier do
 
     expect(new_provider.schools.count).to eq(2)
   end
+
+  it "does not copy a provider school whose GIAS record has closed" do
+    create(:provider_school, provider:, gias_school: create(:gias_school, :closed), site_code: "C")
+
+    copy_schools
+
+    expect(new_provider.schools.pluck(:site_code)).not_to include("C")
+  end
 end

--- a/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/check_answers_spec.rb
@@ -345,13 +345,13 @@ private
 
   def given_the_provider_has_no_study_sites
     provider.study_sites.destroy_all
-    @placement_site = provider.sites.first || create(:site, provider:)
+    @placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     expect(provider.reload.study_sites).to be_empty
   end
 
   def given_i_have_completed_tda_wizard_state
     primary_subject = find_or_create(:primary_subject, :primary)
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     repository = CourseWizard::Repositories::Course.new(
@@ -567,7 +567,7 @@ private
   def given_i_have_completed_secondary_fee_wizard_state
     physics = find_or_create(:secondary_subject, :physics)
     business = find_or_create(:secondary_subject, :business_studies)
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     repository = CourseWizard::Repositories::Course.new(
@@ -601,7 +601,7 @@ private
   def given_i_have_completed_secondary_salary_wizard_state
     physics = find_or_create(:secondary_subject, :physics)
     business = find_or_create(:secondary_subject, :business_studies)
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     repository = CourseWizard::Repositories::Course.new(
@@ -637,7 +637,7 @@ private
     @design_technology = SecondarySubject.design_technology
     @language_specialism = find_or_create(:secondary_subject, :french)
     @design_technology_specialism = find_or_create(:design_technology_subject, :engineering)
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     repository = CourseWizard::Repositories::Course.new(
@@ -668,7 +668,7 @@ private
 
   def given_i_have_completed_further_education_wizard_state
     further_education_subject = find_or_create(:further_education_subject)
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     repository = CourseWizard::Repositories::Course.new(
@@ -699,7 +699,7 @@ private
 
   def given_i_have_completed_tda_wizard_state_with_send_yes
     primary_subject = find_or_create(:primary_subject, :primary)
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     repository = CourseWizard::Repositories::Course.new(
@@ -727,7 +727,7 @@ private
     given_i_am_authenticated_as_school_provider_with_single_partner(cycle_year: Find::CycleTimetable.current_year)
     physics = find_or_create(:secondary_subject, :physics)
     business = find_or_create(:secondary_subject, :business_studies)
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     repository = CourseWizard::Repositories::Course.new(
@@ -757,7 +757,7 @@ private
   def given_i_have_completed_secondary_fee_wizard_state_with_no_visa_deadline
     physics = find_or_create(:secondary_subject, :physics)
     business = find_or_create(:secondary_subject, :business_studies)
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_site = provider.sites.first || create(:site, :with_gias_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     repository = CourseWizard::Repositories::Course.new(

--- a/spec/system/publish/courses/add_course_wizard/schools_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/schools_spec.rb
@@ -179,7 +179,7 @@ private
         create(
           :provider,
           :accredited_provider,
-          sites: [build(:site), build(:site), build(:site, :study_site)],
+          sites: [build(:site, :with_gias_school), build(:site, :with_gias_school), build(:site, :study_site)],
         ),
       ],
     )
@@ -191,7 +191,7 @@ private
     @user = create(
       :user,
       providers: [
-        create(:provider, :accredited_provider, sites: [build(:site), build(:site, :study_site)]),
+        create(:provider, :accredited_provider, sites: [build(:site, :with_gias_school), build(:site, :study_site)]),
       ],
     )
 
@@ -212,7 +212,7 @@ private
         create(
           :provider,
           :accredited_provider,
-          sites: (1..25).map { |n| build(:site, location_name: sprintf("School %02d", n)) } + [build(:site, :study_site)],
+          sites: (1..25).map { |n| build(:site, :with_gias_school, location_name: sprintf("School %02d", n)) } + [build(:site, :study_site)],
         ),
       ],
     )
@@ -230,6 +230,7 @@ private
           sites: [
             build(
               :site,
+              :with_gias_school,
               location_name: "Belvidere School",
               address1: "Belvidere Lane",
               address2: "",
@@ -238,7 +239,7 @@ private
               address4: "Shropshire",
               postcode: "SY2 5RJ",
             ),
-            build(:site),
+            build(:site, :with_gias_school),
           ],
         ),
       ],
@@ -256,7 +257,7 @@ private
           :provider,
           :accredited_provider,
           sites: [
-            build(:site, location_name: "Available School", urn: "123456"),
+            build(:site, :with_gias_school, location_name: "Available School", urn: "123456"),
             build(:site, location_name: "Closed School", urn: closed_gias_school.urn),
           ],
         ),

--- a/spec/system/publish/courses/add_course_wizard/schools_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/schools_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe "Add course wizard schools step", type: :system do
     and_the_address_is_shown_without_the_school_name
   end
 
+  scenario "a school whose GIAS record has closed is not offered" do
+    given_i_am_authenticated_as_a_provider_user_with_an_open_and_a_closed_school
+    and_i_have_wizard_state_for_schools(funding_type: "fee")
+    when_i_visit_the_wizard_schools_page
+    then_i_see_the_available_school
+    and_i_do_not_see_the_closed_school
+  end
+
   context "when the provider has more than 20 schools", :js do
     before do
       given_i_am_authenticated_as_a_provider_user_with_25_schools
@@ -237,6 +245,33 @@ private
     )
 
     given_i_am_authenticated(user: @user)
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_an_open_and_a_closed_school
+    closed_gias_school = create(:gias_school, :closed, urn: "654321")
+    @user = create(
+      :user,
+      providers: [
+        create(
+          :provider,
+          :accredited_provider,
+          sites: [
+            build(:site, location_name: "Available School", urn: "123456"),
+            build(:site, location_name: "Closed School", urn: closed_gias_school.urn),
+          ],
+        ),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def then_i_see_the_available_school
+    expect(page).to have_css(".govuk-checkboxes__label", text: "Available School")
+  end
+
+  def and_i_do_not_see_the_closed_school
+    expect(page).to have_no_css(".govuk-checkboxes__label", text: "Closed School")
   end
 
   def school_checkbox_selector

--- a/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
@@ -116,8 +116,8 @@ private
           :provider,
           :accredited_provider,
           sites: [
-            build(:site),
-            build(:site),
+            build(:site, :with_gias_school),
+            build(:site, :with_gias_school),
             build(:site, :study_site),
             build(:site, :study_site),
           ],
@@ -135,7 +135,7 @@ private
         create(
           :provider,
           provider_type: :lead_school,
-          sites: [build(:site), build(:site)],
+          sites: [build(:site, :with_gias_school), build(:site, :with_gias_school)],
         ),
       ],
     )

--- a/spec/system/publish/courses/editing_course_schools_closed_schools_spec.rb
+++ b/spec/system/publish/courses/editing_course_schools_closed_schools_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Editing course schools with a closed school", travel: mid_cycle(2026) do
+  scenario "a school whose GIAS record has closed is not offered" do
+    given_i_am_signed_in_with_an_open_and_a_closed_school
+    and_there_is_a_course_with_no_schools_attached
+    when_i_visit_the_publish_course_school_edit_page
+    then_i_see_the_available_school
+    and_i_do_not_see_the_closed_school
+  end
+
+  scenario "a closed school already attached to the course is still listed, flagged as closed" do
+    given_i_am_signed_in_with_an_open_and_a_closed_school
+    and_the_course_already_has_the_closed_school_attached
+    when_i_visit_the_publish_course_school_edit_page
+    then_i_see_the_available_school
+    and_the_closed_school_is_listed_and_tagged_closed
+    and_i_can_keep_it_attached_by_submitting_unchanged
+  end
+
+  def given_i_am_signed_in_with_an_open_and_a_closed_school
+    closed_gias_school = create(:gias_school, :closed, urn: "654321")
+    @closed_site = build(:site, location_name: "Closed School", urn: closed_gias_school.urn)
+    @provider = create(
+      :provider,
+      sites: [build(:site, :with_gias_school, location_name: "Available School", urn: "123456"), @closed_site],
+    )
+
+    given_i_am_authenticated(user: create(:user, providers: [@provider]))
+  end
+
+  def and_there_is_a_course_with_no_schools_attached
+    @course = create(:course, provider: @provider, site_statuses: [])
+  end
+
+  def and_the_course_already_has_the_closed_school_attached
+    @course = create(
+      :course,
+      provider: @provider,
+      site_statuses: [build(:site_status, :new_status, :unpublished, site: @closed_site)],
+    )
+  end
+
+  def when_i_visit_the_publish_course_school_edit_page
+    visit schools_publish_provider_recruitment_cycle_course_path(
+      @provider.provider_code,
+      @provider.recruitment_cycle_year,
+      @course.course_code,
+    )
+  end
+
+  def then_i_see_the_available_school
+    expect(page).to have_css(".govuk-checkboxes__label", text: "Available School")
+  end
+
+  def and_i_do_not_see_the_closed_school
+    expect(page).to have_no_css(".govuk-checkboxes__label", text: "Closed School")
+  end
+
+  def and_the_closed_school_is_listed_and_tagged_closed
+    within(page.find(".govuk-checkboxes__label", text: "Closed School")) do
+      expect(page).to have_css(".govuk-tag", text: "Closed")
+    end
+
+    expect(page).to have_field("Closed School Closed", type: "checkbox", checked: true)
+  end
+
+  def and_i_can_keep_it_attached_by_submitting_unchanged
+    click_on "Update placement schools"
+
+    expect(@course.reload.sites.map(&:location_name)).to include("Closed School")
+  end
+end

--- a/spec/system/publish/courses/schools/school_list_display_spec.rb
+++ b/spec/system/publish/courses/schools/school_list_display_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe "Publish - Placement schools list display", type: :system do
   def given_the_provider_has_a_named_school
     @school = create(
       :site,
+      :with_gias_school,
       provider: @provider,
       location_name: "Belvidere School",
       address1: "Belvidere Lane",

--- a/spec/system/publish/courses/schools/select_all_schools_spec.rb
+++ b/spec/system/publish/courses/schools/select_all_schools_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
     @provider = build(
       :provider,
       sites: [
-        build(:site, location_name: "Site 1"),
-        build(:site, location_name: "Site 2"),
-        build(:site, location_name: "Site 3"),
+        build(:site, :with_gias_school, location_name: "Site 1"),
+        build(:site, :with_gias_school, location_name: "Site 2"),
+        build(:site, :with_gias_school, location_name: "Site 3"),
       ],
     )
     @user = create(
@@ -92,12 +92,12 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
   end
 
   def given_there_are_many_schools
-    @schools = create_list(:site, 30, provider: @provider)
+    @schools = create_list(:site, 30, :with_gias_school, provider: @provider)
   end
 
   def given_the_provider_has_25_schools
     # the provider already has 3 sites from authentication setup
-    create_list(:site, 22, provider: @provider)
+    create_list(:site, 22, :with_gias_school, provider: @provider)
     @provider.reload
   end
 

--- a/spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb
+++ b/spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Publish - Courses: 'Newly added' tag for register import sites w
   let!(:site_one) do
     create(
       :site,
+      :with_gias_school,
       provider:,
       added_via: :register_import,
       location_name: "Register Import School",
@@ -20,6 +21,7 @@ RSpec.describe "Publish - Courses: 'Newly added' tag for register import sites w
   let!(:site_two) do
     create(
       :site,
+      :with_gias_school,
       provider:,
       added_via: :publish_interface,
       location_name: "UI Added School",

--- a/spec/system/publish/providers/schools/closed_school_indicator_spec.rb
+++ b/spec/system/publish/providers/schools/closed_school_indicator_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Provider schools index closed indicator" do
+  scenario "a school whose GIAS record has closed is flagged" do
+    given_i_am_signed_in_with_an_open_and_a_closed_school
+    when_i_visit_the_schools_index
+    then_the_closed_school_is_tagged_closed
+    and_the_open_school_is_not_tagged_closed
+  end
+
+  def given_i_am_signed_in_with_an_open_and_a_closed_school
+    closed_gias_school = create(:gias_school, :closed, urn: "654321")
+    open_gias_school = create(:gias_school, :open, urn: "123456")
+    @provider = create(
+      :provider,
+      sites: [
+        build(:site, location_name: "Millbrook School", urn: closed_gias_school.urn),
+        build(:site, location_name: "Riverside School", urn: open_gias_school.urn),
+      ],
+    )
+
+    given_i_am_authenticated(user: create(:user, providers: [@provider]))
+  end
+
+  def when_i_visit_the_schools_index
+    visit publish_provider_recruitment_cycle_schools_path(@provider.provider_code, @provider.recruitment_cycle_year)
+  end
+
+  def then_the_closed_school_is_tagged_closed
+    within(page.find(".school-row", text: "Millbrook School")) do
+      expect(page).to have_content("Closed")
+    end
+  end
+
+  def and_the_open_school_is_not_tagged_closed
+    within(page.find(".school-row", text: "Riverside School")) do
+      expect(page).to have_no_content("Closed")
+    end
+  end
+end

--- a/spec/system/publish/providers/schools/closed_school_indicator_spec.rb
+++ b/spec/system/publish/providers/schools/closed_school_indicator_spec.rb
@@ -11,15 +11,9 @@ RSpec.describe "Provider schools index closed indicator" do
   end
 
   def given_i_am_signed_in_with_an_open_and_a_closed_school
-    closed_gias_school = create(:gias_school, :closed, urn: "654321")
-    open_gias_school = create(:gias_school, :open, urn: "123456")
-    @provider = create(
-      :provider,
-      sites: [
-        build(:site, location_name: "Millbrook School", urn: closed_gias_school.urn),
-        build(:site, location_name: "Riverside School", urn: open_gias_school.urn),
-      ],
-    )
+    @provider = create(:provider)
+    create(:provider_school, provider: @provider, gias_school: create(:gias_school, :closed, name: "Millbrook School"))
+    create(:provider_school, provider: @provider, gias_school: create(:gias_school, :open, name: "Riverside School"))
 
     given_i_am_authenticated(user: create(:user, providers: [@provider]))
   end

--- a/spec/system/publish/providers/schools/closed_school_show_indicator_spec.rb
+++ b/spec/system/publish/providers/schools/closed_school_show_indicator_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Provider school show page closed indicator" do
+  scenario "flags a school whose GIAS record has closed" do
+    given_i_am_signed_in_viewing_a_school_backed_by(create(:gias_school, :closed, urn: "654321"))
+    when_i_visit_the_school_show_page
+    then_i_see_it_flagged_as_closed
+  end
+
+  scenario "does not flag an available school" do
+    given_i_am_signed_in_viewing_a_school_backed_by(create(:gias_school, :open, urn: "123456"))
+    when_i_visit_the_school_show_page
+    then_i_do_not_see_it_flagged_as_closed
+  end
+
+  def given_i_am_signed_in_viewing_a_school_backed_by(gias_school)
+    @provider = create(:provider)
+    @site = create(:site, provider: @provider, urn: gias_school.urn)
+
+    given_i_am_authenticated(user: create(:user, providers: [@provider]))
+  end
+
+  def when_i_visit_the_school_show_page
+    visit publish_provider_recruitment_cycle_school_path(@provider.provider_code, @provider.recruitment_cycle_year, @site.uuid)
+  end
+
+  def then_i_see_it_flagged_as_closed
+    expect(page).to have_content("Closed")
+  end
+
+  def then_i_do_not_see_it_flagged_as_closed
+    expect(page).to have_no_content("Closed")
+  end
+end

--- a/spec/system/publish/providers/schools/closed_school_show_indicator_spec.rb
+++ b/spec/system/publish/providers/schools/closed_school_show_indicator_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe "Provider school show page closed indicator" do
 
   def given_i_am_signed_in_viewing_a_school_backed_by(gias_school)
     @provider = create(:provider)
-    @site = create(:site, provider: @provider, urn: gias_school.urn)
+    @school = create(:provider_school, provider: @provider, gias_school:)
 
     given_i_am_authenticated(user: create(:user, providers: [@provider]))
   end
 
   def when_i_visit_the_school_show_page
-    visit publish_provider_recruitment_cycle_school_path(@provider.provider_code, @provider.recruitment_cycle_year, @site.uuid)
+    visit publish_provider_recruitment_cycle_school_path(@provider.provider_code, @provider.recruitment_cycle_year, @school.uuid)
   end
 
   def then_i_see_it_flagged_as_closed

--- a/spec/system/support/providers/schools/closed_school_show_indicator_spec.rb
+++ b/spec/system/support/providers/schools/closed_school_show_indicator_spec.rb
@@ -4,16 +4,15 @@ require "rails_helper"
 
 RSpec.describe "Support provider school show page closed indicator" do
   scenario "flags a school whose GIAS record has closed" do
-    closed_gias_school = create(:gias_school, :closed, urn: "654321")
     @provider = create(:provider)
-    @site = create(:site, provider: @provider, urn: closed_gias_school.urn)
+    school = create(:provider_school, provider: @provider, gias_school: create(:gias_school, :closed))
 
     given_i_am_authenticated(user: create(:user, :admin))
 
     visit support_recruitment_cycle_provider_school_path(
       recruitment_cycle_year: @provider.recruitment_cycle_year,
       provider_id: @provider.id,
-      uuid: @site.uuid,
+      uuid: school.uuid,
     )
 
     expect(page).to have_content("Closed")

--- a/spec/system/support/providers/schools/closed_school_show_indicator_spec.rb
+++ b/spec/system/support/providers/schools/closed_school_show_indicator_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Support provider school show page closed indicator" do
+  scenario "flags a school whose GIAS record has closed" do
+    closed_gias_school = create(:gias_school, :closed, urn: "654321")
+    @provider = create(:provider)
+    @site = create(:site, provider: @provider, urn: closed_gias_school.urn)
+
+    given_i_am_authenticated(user: create(:user, :admin))
+
+    visit support_recruitment_cycle_provider_school_path(
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+      provider_id: @provider.id,
+      uuid: @site.uuid,
+    )
+
+    expect(page).to have_content("Closed")
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/schools_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/schools_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe CourseWizard::Steps::Schools do
   let(:site_ids) { nil }
 
   let(:provider) { create(:provider, :accredited_provider, recruitment_cycle: find_or_create(:recruitment_cycle)) }
-  let!(:site_a) { create(:site, provider:, location_name: "B School") }
-  let!(:site_b) { create(:site, provider:, location_name: "A School") }
+  let!(:site_a) { create(:site, :with_gias_school, provider:, location_name: "B School") }
+  let!(:site_b) { create(:site, :with_gias_school, provider:, location_name: "A School") }
 
   describe "#valid?" do
     subject(:wizard_step) { wizard.current_step }
@@ -63,7 +63,7 @@ RSpec.describe CourseWizard::Steps::Schools do
     end
 
     context "when the provider has more than 20 schools" do
-      before { create_list(:site, 19, provider:) }
+      before { create_list(:site, 19, :with_gias_school, provider:) }
 
       it "is true" do
         expect(wizard_step.collapse_schools?).to be(true)


### PR DESCRIPTION
## Context

#### Creating provider schools / sites
- When adding schools to a provider (via Site or ProviderSchool), we only want GIAS open schools to be available for adding.
- Provider::School currently handles this but Site does not prevent closed GIAS schools from being created on the provider.
- We need to stop closed GIAS school sites from being created to keep the dual write consistent

#### Adding provider schools to courses
- When adding schools to courses, the user is presented with the list of provider schools. We don't filter out closed GIAS schools from this list so providers can add closed gias schools when creating/updating a course.
- If a course already has a closed school attached, and the user goes to edit the attached schools, we still load the closed school, checked, in the list of schools. This is so the school isn't automatically removed.


#### Rollover of schools
When we run rollover, we copy Site/SiteStatus and Provider::School/Course::School that correspond to closed GIAS schools.

## Changes proposed in this pull request

- Prevent closed GIAS schools from being added to a provider.
- If a closed GIAS school already exists on the provider, prevent the user from choosing them when adding / updating a course shools.
- Update the Course and Provider rollover schools copiers to ignore closed GIAS schools when copying fro mone recruitment cycle to another.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
