### PR TITLE
Remove 'unpublished changes' from the service

### DIFF
--- a/app/components/publish/courses/status_tag_component.rb
+++ b/app/components/publish/courses/status_tag_component.rb
@@ -3,9 +3,9 @@
 module Publish
   module Courses
     # Renders a course's status tag from the read-model columns produced by
-    # Publish::Courses::Query (content_status + has_unpublished_changes), the
-    # course's application_status, and the recruitment-cycle branch — so the list
-    # needs no enrichment or site rows.
+    # Publish::Courses::Query (content_status), the course's application_status,
+    # and the recruitment-cycle branch — so the list needs no enrichment or
+    # site rows.
     #
     # The text/colour mapping mirrors ApplicationDecorator#status_tags*; a
     # cross-check spec asserts this component renders identically to
@@ -16,18 +16,15 @@ module Publish
         withdrawn: { text: "Withdrawn", colour: "red" },
         empty: { text: "Draft", colour: "grey" },
         draft: { text: "Draft", colour: "grey" },
-        published_with_unpublished_changes: { text: "Open *", colour: "teal" },
         rolled_over: { text: "Rolled over", colour: "yellow" },
       }.freeze
 
       CLOSED_APPLICATION_STATUS_TAGS = OPEN_APPLICATION_STATUS_TAGS.merge(
         published: { text: "Closed", colour: "purple" },
-        published_with_unpublished_changes: { text: "Closed *", colour: "purple" },
       ).freeze
 
       SCHEDULED_STATUS_TAGS = OPEN_APPLICATION_STATUS_TAGS.merge(
         published: { text: "Scheduled", colour: "blue" },
-        published_with_unpublished_changes: { text: "Scheduled *", colour: "blue" },
       ).freeze
 
       def initialize(course:, recruitment_cycle_year:, classes: [], html_attributes: {})
@@ -37,9 +34,7 @@ module Publish
       end
 
       def call
-        rendered = helpers.govuk_tag(text: status[:text], colour: status[:colour])
-        rendered += unpublished_hint if has_unpublished_changes?
-        rendered
+        helpers.govuk_tag(text: status[:text], colour: status[:colour])
       end
 
     private
@@ -64,17 +59,6 @@ module Publish
 
       def content_status
         course.read_attribute(:content_status)
-      end
-
-      def has_unpublished_changes?
-        ActiveModel::Type::Boolean.new.cast(course.read_attribute(:has_unpublished_changes))
-      end
-
-      def unpublished_hint
-        helpers.tag.span(
-          "* Unpublished changes",
-          class: "govuk-body-s govuk-!-display-block govuk-!-margin-bottom-0 govuk-!-margin-top-1",
-        )
       end
     end
   end

--- a/app/controllers/concerns/publish/confirm_live_changes.rb
+++ b/app/controllers/concerns/publish/confirm_live_changes.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Publish
+  module ConfirmLiveChanges
+    extend ActiveSupport::Concern
+
+    CONFIRM_PUBLISH_PARAM = "true"
+
+  private
+
+    def require_live_changes_confirmation?
+      course_for_live_changes_confirmation&.is_published? &&
+        params[:confirm_publish] != CONFIRM_PUBLISH_PARAM
+    end
+
+    # Returns true (and renders the interstitial) when a published course edit
+    # still needs confirmation. Returns false when the caller should save.
+    #
+    # Paths default to the current request path (edit + update share a URL for
+    # most course sections). Fields default to form.class::FIELDS when present.
+    def confirm_live_changes_if_required!(section_name:, form:, form_param_key:, fields: nil, method: nil, update_path: nil, back_path: nil, cancel_path: nil, extra_hidden_fields: {})
+      return false unless require_live_changes_confirmation?
+
+      render_live_changes_confirmation(
+        section_name:,
+        form:,
+        form_param_key:,
+        fields: fields || fields_for_live_changes_form(form),
+        method: method || request_method_for_live_changes,
+        update_path: update_path || request.path,
+        back_path: back_path || request.path,
+        cancel_path: cancel_path || default_cancel_path_for_live_changes,
+        extra_hidden_fields: default_extra_hidden_fields_for_live_changes(form_param_key).merge(extra_hidden_fields).compact,
+      )
+      true
+    end
+
+    def render_live_changes_confirmation(section_name:, form:, form_param_key:, fields:, update_path:, back_path:, cancel_path:, method: :patch, extra_hidden_fields: {})
+      @confirm_live_changes = Publish::Courses::ConfirmLiveChangesView.new(
+        course: course_for_live_changes_confirmation,
+        section_name:,
+        form:,
+        form_param_key:,
+        fields:,
+        update_path:,
+        back_path:,
+        cancel_path:,
+        method:,
+        extra_hidden_fields:,
+      )
+
+      render "publish/courses/confirm_live_changes/show"
+    end
+
+    def course_for_live_changes_confirmation
+      if respond_to?(:course, true)
+        course
+      elsif instance_variable_defined?(:@course)
+        @course
+      end
+    end
+
+    def fields_for_live_changes_form(form)
+      form.class::FIELDS if form.class.const_defined?(:FIELDS)
+    end
+
+    def request_method_for_live_changes
+      request.request_method.downcase.to_sym
+    end
+
+    def default_cancel_path_for_live_changes
+      course = course_for_live_changes_confirmation
+      publish_provider_recruitment_cycle_course_path(
+        course.provider_code,
+        course.recruitment_cycle_year,
+        course.course_code,
+      )
+    end
+
+    def default_extra_hidden_fields_for_live_changes(form_param_key)
+      {
+        "#{form_param_key}[goto_preview]" => params.dig(form_param_key, :goto_preview).presence || params[:goto_preview],
+      }
+    end
+  end
+end

--- a/app/controllers/concerns/success_message.rb
+++ b/app/controllers/concerns/success_message.rb
@@ -6,11 +6,32 @@ module SuccessMessage
   def course_updated_message(value)
     raise TypeError unless value.is_a?(String)
 
-    flash[:success] = I18n.t("success.saved", value:)
+    title = I18n.t("success.saved", value:)
+
+    if published_course_for_live_message?
+      flash[:success_with_body] = {
+        "title" => title,
+        "body" => I18n.t("success.changes_now_live"),
+      }
+    else
+      flash[:success] = title
+    end
   end
 
   def schools_added_message(schools)
     items_added = schools.size > 1 ? "#{schools.size} schools" : "1 school"
     flash[:success] = I18n.t("success.added", items_added:)
+  end
+
+private
+
+  def published_course_for_live_message?
+    current_course = if respond_to?(:course, true)
+                       course
+                     elsif instance_variable_defined?(:@course)
+                       @course
+                     end
+
+    current_course.respond_to?(:is_published?) && current_course.is_published?
   end
 end

--- a/app/controllers/publish/application_controller.rb
+++ b/app/controllers/publish/application_controller.rb
@@ -4,6 +4,7 @@ module Publish
   class ApplicationController < ::ApplicationController
     include Authentication
     include SuccessMessage
+    include ConfirmLiveChanges
 
     before_action :check_interrupt_redirects
     before_action :clear_previous_cycle_year_in_session, unless: -> { RecruitmentCycle.upcoming_cycles_open_to_publish? }

--- a/app/controllers/publish/courses/accredited_provider_controller.rb
+++ b/app/controllers/publish/courses/accredited_provider_controller.rb
@@ -34,7 +34,20 @@ module Publish
           return render :edit if @errors.present?
         end
 
-        if @course.update(update_params)
+        if code.blank?
+          @errors = { accredited_provider_code: ["Select an accredited provider"] }
+          render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name: "Accredited provider",
+          form: Struct.new(:accredited_provider_code).new(code),
+          form_param_key: :course,
+          fields: %i[accredited_provider_code],
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code, @course.recruitment_cycle_year, @course.course_code
+          ),
+        )
+          # rendered interstitial
+        elsif @course.update(update_params)
           course_updated_message("Accredited provider")
           redirect_to_update_successful
         else

--- a/app/controllers/publish/courses/age_range_controller.rb
+++ b/app/controllers/publish/courses/age_range_controller.rb
@@ -13,22 +13,23 @@ module Publish
       end
 
       def update
-        if form_object.valid?
+        if form_object.invalid?
+          render :edit, locals: { form_object: }
+        elsif confirm_live_changes_if_required!(
+          section_name: "Age range",
+          form: form_object,
+          form_param_key: :course,
+          cancel_path: details_path_for_live_changes,
+        )
+          # rendered interstitial
+        else
           course_updated_message("Age range")
 
           update_age_range_param
 
           if @course.update(course_params)
-            redirect_to(
-              details_publish_provider_recruitment_cycle_course_path(
-                @course.provider_code,
-                @course.recruitment_cycle_year,
-                @course.course_code,
-              ),
-            )
+            redirect_to details_path_for_live_changes
           end
-        else
-          render :edit, locals: { form_object: }
         end
       end
 
@@ -85,6 +86,14 @@ module Publish
       def build_course
         super
         authorize @course
+      end
+
+      def details_path_for_live_changes
+        details_publish_provider_recruitment_cycle_course_path(
+          @course.provider_code,
+          @course.recruitment_cycle_year,
+          @course.course_code,
+        )
       end
     end
   end

--- a/app/controllers/publish/courses/degrees/grade_controller.rb
+++ b/app/controllers/publish/courses/degrees/grade_controller.rb
@@ -14,6 +14,7 @@ module Publish
 
         def update
           authorize(provider)
+          course
 
           @grade_form = DegreeGradeForm.new(grade: grade_params)
 

--- a/app/controllers/publish/courses/degrees/grade_controller.rb
+++ b/app/controllers/publish/courses/degrees/grade_controller.rb
@@ -17,24 +17,18 @@ module Publish
 
           @grade_form = DegreeGradeForm.new(grade: grade_params)
 
-          if course.is_primary? && @grade_form.valid? && !goto_preview?
-            @grade_form.save(course)
-            course_updated_message("Minimum degree classification")
-
-            redirect_to publish_provider_recruitment_cycle_course_path
-
-          elsif course.is_primary? && @grade_form.valid? && goto_preview?
-            @grade_form.save(course)
-            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
-          elsif @grade_form.valid? && !goto_preview?
-            @grade_form.save(course)
-            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
-          elsif @grade_form.valid? && goto_preview?
-            @grade_form.save(course)
-            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
-          else
+          if @grade_form.invalid?
             @errors = @grade_form.errors.messages
             render :edit
+          elsif confirm_live_changes_if_required!(
+            section_name: "Minimum degree classification",
+            form: @grade_form,
+            form_param_key: param_form_key,
+            fields: %i[grade],
+          )
+            # rendered interstitial
+          else
+            save_and_redirect
           end
         end
 
@@ -53,6 +47,21 @@ module Publish
         end
 
         def param_form_key = :publish_degree_grade_form
+
+        def save_and_redirect
+          @grade_form.save(course)
+
+          if course.is_primary? && !goto_preview?
+            course_updated_message("Minimum degree classification")
+            redirect_to publish_provider_recruitment_cycle_course_path
+          elsif course.is_primary? && goto_preview?
+            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+          elsif goto_preview?
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
+          else
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
+          end
+        end
       end
     end
   end

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -18,26 +18,21 @@ module Publish
           authorize(provider)
 
           @start_form = DegreeStartForm.new(degree_grade_required: grade_required_params)
-          if course.is_primary? && @start_form.valid? && !goto_preview? && @start_form.degree_grade_required.blank?
-            @start_form.save(course)
-            course_updated_message("Minimum degree classification")
-            redirect_to publish_provider_recruitment_cycle_course_path
-          elsif course.is_primary? && @start_form.valid? && goto_preview? && @start_form.degree_grade_required.blank?
-            @start_form.save(course)
-            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
-          elsif @start_form.valid? && !goto_preview? && @start_form.degree_grade_required.blank?
-            @start_form.save(course)
-            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
-          elsif @start_form.valid? && goto_preview? && @start_form.degree_grade_required.blank?
-            @start_form.save(course)
-            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
-          elsif @start_form.degree_grade_required.present? && !goto_preview?
-            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path
-          elsif @start_form.degree_grade_required.present? && goto_preview?
-            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path(goto_preview: true)
-          else
+
+          if @start_form.invalid?
             @errors = @start_form.errors.messages
             render :edit
+          elsif @start_form.degree_grade_required.present?
+            redirect_to_grade_step
+          elsif confirm_live_changes_if_required!(
+            section_name: "Minimum degree classification",
+            form: @start_form,
+            form_param_key: param_form_key,
+            fields: %i[degree_grade_required],
+          )
+            # rendered interstitial
+          else
+            save_and_redirect
           end
         end
 
@@ -55,6 +50,29 @@ module Publish
           params.require(param_form_key)
                 .except(:goto_preview)
                 .permit(:degree_grade_required)[:degree_grade_required]
+        end
+
+        def redirect_to_grade_step
+          if goto_preview?
+            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path(goto_preview: true)
+          else
+            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path
+          end
+        end
+
+        def save_and_redirect
+          @start_form.save(course)
+
+          if course.is_primary? && !goto_preview?
+            course_updated_message("Minimum degree classification")
+            redirect_to publish_provider_recruitment_cycle_course_path
+          elsif course.is_primary? && goto_preview?
+            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+          elsif goto_preview?
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
+          else
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
+          end
         end
       end
     end

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -16,6 +16,7 @@ module Publish
 
         def update
           authorize(provider)
+          course
 
           @start_form = DegreeStartForm.new(degree_grade_required: grade_required_params)
 

--- a/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
@@ -23,18 +23,25 @@ module Publish
 
           @subject_requirements_form = SubjectRequirementForm.new(subject_requirements_params)
 
-          if @subject_requirements_form.valid? && !goto_preview?
-            @subject_requirements_form.save(@course)
-            course_updated_message("Degree requirements")
-            redirect_to publish_provider_recruitment_cycle_course_path
-          elsif @subject_requirements_form.valid? && goto_preview?
-            @subject_requirements_form.save(@course)
-            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
-          else
+          if @subject_requirements_form.invalid?
             set_backlink
             fetch_course_list_to_copy_from
             @errors = @subject_requirements_form.errors.messages
             render :edit
+          elsif confirm_live_changes_if_required!(
+            section_name: "Degree requirements",
+            form: @subject_requirements_form,
+            form_param_key: param_form_key,
+            fields: %i[additional_degree_subject_requirements degree_subject_requirements],
+          )
+            # rendered interstitial
+          elsif goto_preview?
+            @subject_requirements_form.save(@course)
+            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+          else
+            @subject_requirements_form.save(@course)
+            course_updated_message("Degree requirements")
+            redirect_to publish_provider_recruitment_cycle_course_path
           end
         end
 

--- a/app/controllers/publish/courses/design_technology_controller.rb
+++ b/app/controllers/publish/courses/design_technology_controller.rb
@@ -34,7 +34,21 @@ module Publish
       def update
         authorize(provider)
 
-        if course_subjects_form.save!
+        if confirm_live_changes_if_required!(
+          section_name: "Design and technology",
+          form: design_technology_confirmation_form,
+          form_param_key: :course,
+          fields: %i[subjects_ids design_technology_ids],
+          back_path: design_technology_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code, @course.recruitment_cycle_year, @course.course_code,
+            course: { subjects_ids: params.dig(:course, :subjects_ids) }
+          ),
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code, @course.recruitment_cycle_year, @course.course_code
+          ),
+        )
+          # rendered interstitial
+        elsif course_subjects_form.save!
           course_updated_message("Design and technology")
 
           course.update(name: course.generate_name)
@@ -77,6 +91,13 @@ module Publish
 
       def course_subjects_form
         @course_subjects_form ||= CourseSubjectsForm.new(@course, params: sorted_subject_ids)
+      end
+
+      def design_technology_confirmation_form
+        Struct.new(:subjects_ids, :design_technology_ids).new(
+          Array(params.dig(:course, :subjects_ids)),
+          Array(params.dig(:course, :design_technology_ids)),
+        )
       end
 
       def error_keys

--- a/app/controllers/publish/courses/engineers_teach_physics_controller.rb
+++ b/app/controllers/publish/courses/engineers_teach_physics_controller.rb
@@ -23,55 +23,39 @@ module Publish
 
       def update
         @engineers_teach_physics_form = EngineersTeachPhysicsForm.new(course, params: form_params)
+
         if form_params[:skip_languages_goto_confirmation].present?
-
-          if @engineers_teach_physics_form.save!
-            course_updated_message(section_key)
-
-            course.update(name: course.generate_name)
+          update_with_confirmation { save_and_redirect_to_details }
+        elsif form_params[:subjects_ids]&.include?(modern_languages_id)
+          if confirm_live_changes_if_required!(**engineers_live_changes_confirmation_args)
+            # rendered interstitial
+          else
+            course.update(campaign_name: form_params[:campaign_name])
             redirect_to(
-              details_publish_provider_recruitment_cycle_course_path(
-                provider.provider_code,
-                recruitment_cycle.year,
-                course.course_code,
+              modern_languages_publish_provider_recruitment_cycle_course_path(
+                @course.provider_code,
+                @course.recruitment_cycle_year,
+                @course.course_code,
+                course: { subjects_ids: form_params[:subjects_ids] },
               ),
             )
-          else
-            render :edit
           end
-
-        elsif form_params[:subjects_ids]&.include?(modern_languages_id)
-          course.update(campaign_name: form_params[:campaign_name])
-          redirect_to(
-            modern_languages_publish_provider_recruitment_cycle_course_path(
-              @course.provider_code,
-              @course.recruitment_cycle_year,
-              @course.course_code,
-              course: { subjects_ids: form_params[:subjects_ids] },
-            ),
-          )
         elsif form_params[:subjects_ids]&.include?(design_technology_id)
-          course.update(campaign_name: form_params[:campaign_name])
-          redirect_to(
-            design_technology_publish_provider_recruitment_cycle_course_path(
-              @course.provider_code,
-              @course.recruitment_cycle_year,
-              @course.course_code,
-              course: { subjects_ids: form_params[:subjects_ids] },
-            ),
-          )
-        elsif @engineers_teach_physics_form.save!
-          course_updated_message(section_key)
-          course.update(name: course.generate_name)
-
-          redirect_to details_publish_provider_recruitment_cycle_course_path(
-            provider.provider_code,
-            recruitment_cycle.year,
-            course.course_code,
-          )
+          if confirm_live_changes_if_required!(**engineers_live_changes_confirmation_args)
+            # rendered interstitial
+          else
+            course.update(campaign_name: form_params[:campaign_name])
+            redirect_to(
+              design_technology_publish_provider_recruitment_cycle_course_path(
+                @course.provider_code,
+                @course.recruitment_cycle_year,
+                @course.course_code,
+                course: { subjects_ids: form_params[:subjects_ids] },
+              ),
+            )
+          end
         else
-          @errors = @engineers_teach_physics_form.errors.messages
-          render :edit
+          update_with_confirmation { save_and_redirect_to_details }
         end
       end
 
@@ -100,6 +84,43 @@ module Publish
       end
 
     private
+
+      def update_with_confirmation
+        if @engineers_teach_physics_form.invalid?
+          @errors = @engineers_teach_physics_form.errors.messages
+          render :edit
+        elsif confirm_live_changes_if_required!(**engineers_live_changes_confirmation_args)
+          # rendered interstitial
+        elsif @engineers_teach_physics_form.save!
+          yield
+        else
+          @errors = @engineers_teach_physics_form.errors.messages
+          render :edit
+        end
+      end
+
+      def save_and_redirect_to_details
+        course_updated_message(section_key)
+        course.update(name: course.generate_name)
+        redirect_to(
+          details_publish_provider_recruitment_cycle_course_path(
+            provider.provider_code,
+            recruitment_cycle.year,
+            course.course_code,
+          ),
+        )
+      end
+
+      def engineers_live_changes_confirmation_args
+        {
+          section_name: section_key,
+          form: @engineers_teach_physics_form,
+          form_param_key: :publish_engineers_teach_physics_form,
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            provider.provider_code, recruitment_cycle.year, course.course_code
+          ),
+        }
+      end
 
       def modern_languages_present?
         params[:course][:subjects_ids]&.include?(modern_languages_id)

--- a/app/controllers/publish/courses/fields/fees_and_financial_support_controller.rb
+++ b/app/controllers/publish/courses/fields/fees_and_financial_support_controller.rb
@@ -22,15 +22,21 @@ module Publish
             course_enrichment,
             params: fees_and_financial_support_params,
           )
+          section_name = "Fees and financial support"
 
-          if @fees_and_financial_support_form.save!
-            course_updated_message "Fees and financial support"
-
-            redirect_after_edit
-          else
+          if @fees_and_financial_support_form.invalid?
             @v1_enrichment = course.enrichments.find_by(version: 1)
             fetch_course_list_to_copy_from
             render :edit
+          elsif confirm_live_changes_if_required!(
+            section_name:,
+            form: @fees_and_financial_support_form,
+            form_param_key: :publish_fields_fees_and_financial_support_form,
+          )
+            # rendered interstitial
+          elsif @fees_and_financial_support_form.save!
+            course_updated_message section_name
+            redirect_after_edit
           end
         end
 

--- a/app/controllers/publish/courses/fields/interview_process_controller.rb
+++ b/app/controllers/publish/courses/fields/interview_process_controller.rb
@@ -19,14 +19,20 @@ module Publish
 
         def update
           @interview_process_form = Publish::Fields::InterviewProcessForm.new(course_enrichment, params: interview_process_params)
+          section_name = I18n.t("publish.courses.fields.interview_process.edit.interview_process_success")
 
-          if @interview_process_form.save!
-            course_updated_message I18n.t("publish.courses.fields.interview_process.edit.interview_process_success")
-
-            redirect_after_edit
-          else
+          if @interview_process_form.invalid?
             fetch_course_list_to_copy_from
             render :edit
+          elsif confirm_live_changes_if_required!(
+            section_name:,
+            form: @interview_process_form,
+            form_param_key: :publish_fields_interview_process_form,
+          )
+            # rendered interstitial
+          elsif @interview_process_form.save!
+            course_updated_message section_name
+            redirect_after_edit
           end
         end
 

--- a/app/controllers/publish/courses/fields/school_placement_controller.rb
+++ b/app/controllers/publish/courses/fields/school_placement_controller.rb
@@ -25,13 +25,20 @@ module Publish
             course_enrichment,
             params: school_placement_params,
           )
+          section_name = CourseEnrichment.human_attribute_name("what-trainee-do-in-school-success")
 
-          if @school_placement_form.save!
-            course_updated_message CourseEnrichment.human_attribute_name("what-trainee-do-in-school-success")
-            redirect_after_edit
-          else
+          if @school_placement_form.invalid?
             fetch_course_list_to_copy_from
             render :edit
+          elsif confirm_live_changes_if_required!(
+            section_name:,
+            form: @school_placement_form,
+            form_param_key: :publish_courses_fields_school_placement_form,
+          )
+            # rendered interstitial
+          elsif @school_placement_form.save!
+            course_updated_message section_name
+            redirect_after_edit
           end
         end
 

--- a/app/controllers/publish/courses/fields/what_you_will_study_controller.rb
+++ b/app/controllers/publish/courses/fields/what_you_will_study_controller.rb
@@ -1,10 +1,12 @@
-# app/controllers/publish/courses/fields/what_you_will_study_controller.rb
+# frozen_string_literal: true
+
 module Publish
   module Courses
     module Fields
       class WhatYouWillStudyController < BaseController
         include CopyCourseContent
         before_action :authorise_user
+
         def edit
           @what_you_will_study_form = Publish::Fields::WhatYouWillStudyForm.new(
             course_enrichment,
@@ -20,13 +22,20 @@ module Publish
             course_enrichment,
             params: what_you_will_study_params,
           )
-          if @what_you_will_study_form.save!
-            course_updated_message CourseEnrichment.human_attribute_name("what_you_will_study")
+          section_name = CourseEnrichment.human_attribute_name("what_you_will_study")
 
-            redirect_after_edit
-          else
+          if @what_you_will_study_form.invalid?
             fetch_course_list_to_copy_from
             render :edit
+          elsif confirm_live_changes_if_required!(
+            section_name:,
+            form: @what_you_will_study_form,
+            form_param_key: :publish_fields_what_you_will_study_form,
+          )
+            # rendered interstitial
+          elsif @what_you_will_study_form.save!
+            course_updated_message section_name
+            redirect_after_edit
           end
         end
 

--- a/app/controllers/publish/courses/fields/where_you_will_train_controller.rb
+++ b/app/controllers/publish/courses/fields/where_you_will_train_controller.rb
@@ -17,14 +17,20 @@ module Publish
             course_enrichment,
             params: where_you_will_train_params,
           )
+          section_name = "Where you will train"
 
-          if @where_you_will_train_form.save!
-            course_updated_message "Where you will train"
-
-            redirect_after_edit
-          else
+          if @where_you_will_train_form.invalid?
             fetch_course_list_to_copy_from
             render :edit
+          elsif confirm_live_changes_if_required!(
+            section_name:,
+            form: @where_you_will_train_form,
+            form_param_key: :publish_fields_where_you_will_train_form,
+          )
+            # rendered interstitial
+          elsif @where_you_will_train_form.save!
+            course_updated_message section_name
+            redirect_after_edit
           end
         end
 

--- a/app/controllers/publish/courses/funding_type_controller.rb
+++ b/app/controllers/publish/courses/funding_type_controller.rb
@@ -26,10 +26,20 @@ module Publish
 
         @course_funding_form = CourseFundingForm.new(@course, params: funding_type_params)
 
-        if @course_funding_form.valid?
-          handle_valid_form
-        else
+        if @course_funding_form.invalid?
           handle_invalid_form
+        elsif !previous_tda_course? && confirm_live_changes_if_required!(
+          section_name: "Funding type",
+          form: @course_funding_form,
+          form_param_key: :publish_course_funding_form,
+          fields: %i[funding previous_tda_course],
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            course.provider_code, course.recruitment_cycle_year, course.course_code
+          ),
+        )
+          # rendered interstitial
+        else
+          handle_valid_form
         end
       end
 
@@ -55,7 +65,7 @@ module Publish
       end
 
       def previous_tda_course?
-        params[:publish_course_funding_form][:previous_tda_course] == "true"
+        params.dig(:publish_course_funding_form, :previous_tda_course) == "true"
       end
 
       def process_previous_tda_course

--- a/app/controllers/publish/courses/gcse_requirements_controller.rb
+++ b/app/controllers/publish/courses/gcse_requirements_controller.rb
@@ -8,6 +8,15 @@ module Publish
 
       decorates_assigned :source_course
 
+      GCSE_FORM_FIELDS = %i[
+        accept_pending_gcse
+        accept_gcse_equivalency
+        accept_english_gcse_equivalency
+        accept_maths_gcse_equivalency
+        accept_science_gcse_equivalency
+        additional_gcse_equivalencies
+      ].freeze
+
       def edit
         @gcse_requirements_form = GcseRequirementsForm.build_from_course(course)
         copy_boolean_check(::Courses::Copy::GCSE_FIELDS)
@@ -18,17 +27,24 @@ module Publish
         gcse_requirements_form_params[:level] = course.level
         @gcse_requirements_form = GcseRequirementsForm.new(**gcse_requirements_form_params)
 
-        if @gcse_requirements_form.valid? && goto_preview?
-          @gcse_requirements_form.save(course)
-          redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
-        elsif @gcse_requirements_form.valid? && !goto_preview?
-          course_updated_message("GCSE requirements")
-          @gcse_requirements_form.save(course)
-          redirect_to publish_provider_recruitment_cycle_course_path
-        else
+        if @gcse_requirements_form.invalid?
           fetch_course_list_to_copy_from
           @errors = @gcse_requirements_form.errors.messages
           render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name: "GCSE requirements",
+          form: @gcse_requirements_form,
+          form_param_key: param_form_key,
+          fields: GCSE_FORM_FIELDS,
+        )
+          # rendered interstitial
+        elsif goto_preview?
+          @gcse_requirements_form.save(course)
+          redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+        else
+          course_updated_message("GCSE requirements")
+          @gcse_requirements_form.save(course)
+          redirect_to publish_provider_recruitment_cycle_course_path
         end
       end
 

--- a/app/controllers/publish/courses/length_controller.rb
+++ b/app/controllers/publish/courses/length_controller.rb
@@ -13,13 +13,19 @@ module Publish
 
       def update
         @course_length_form = CourseLengthForm.new(course_enrichment, params: length_params)
+        section_name = I18n.t("publish.providers.course_length.edit.course_length")
 
-        if @course_length_form.save!
-          course_updated_message I18n.t("publish.providers.course_length.edit.course_length")
-
-          redirect_to redirect_path
-        else
+        if @course_length_form.invalid?
           render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name:,
+          form: @course_length_form,
+          form_param_key: :publish_course_length_form,
+        )
+          # rendered interstitial
+        elsif @course_length_form.save!
+          course_updated_message section_name
+          redirect_to redirect_path
         end
       end
 

--- a/app/controllers/publish/courses/modern_languages_controller.rb
+++ b/app/controllers/publish/courses/modern_languages_controller.rb
@@ -44,7 +44,21 @@ module Publish
           return
         end
 
-        if course_subjects_form.save!
+        if confirm_live_changes_if_required!(
+          section_name: "Subjects",
+          form: modern_languages_confirmation_form,
+          form_param_key: :course,
+          fields: %i[subjects_ids language_ids],
+          back_path: modern_languages_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code, @course.recruitment_cycle_year, @course.course_code,
+            course: { subjects_ids: params.dig(:course, :subjects_ids) }
+          ),
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code, @course.recruitment_cycle_year, @course.course_code
+          ),
+        )
+          # rendered interstitial
+        elsif course_subjects_form.save!
           course_updated_message("Subjects")
           redirect_to(
             details_publish_provider_recruitment_cycle_course_path(
@@ -84,6 +98,13 @@ module Publish
 
       def course_subjects_form
         @course_subjects_form ||= CourseSubjectsForm.new(@course, params: sorted_subject_ids)
+      end
+
+      def modern_languages_confirmation_form
+        Struct.new(:subjects_ids, :language_ids).new(
+          Array(params.dig(:course, :subjects_ids)),
+          Array(params.dig(:course, :language_ids)),
+        )
       end
 
       def error_keys

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -37,7 +37,17 @@ module Publish
         @current_qualification = @course.qualification
         @updated_qualification = params.dig(:course, :qualification)
 
-        if @course.update(course_params)
+        if confirm_live_changes_if_required!(
+          section_name: "Qualification",
+          form: Struct.new(:qualification).new(@updated_qualification),
+          form_param_key: :course,
+          fields: %i[qualification],
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code, @course.recruitment_cycle_year, @course.course_code
+          ),
+        )
+          # rendered interstitial
+        elsif @course.update(course_params)
           handle_qualification_update
         else
           handle_update_failure

--- a/app/controllers/publish/courses/ratifying_provider_controller.rb
+++ b/app/controllers/publish/courses/ratifying_provider_controller.rb
@@ -30,7 +30,20 @@ module Publish
       end
 
       def update
-        if @course.update(update_params)
+        if update_params[:accredited_provider_code].blank?
+          set_error_messages
+          render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name: "Accredited provider",
+          form: Struct.new(:accredited_provider_code).new(update_params[:accredited_provider_code]),
+          form_param_key: :course,
+          fields: %i[accredited_provider_code],
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code, @course.recruitment_cycle_year, @course.course_code
+          ),
+        )
+          # rendered interstitial
+        elsif @course.update(update_params)
           course_updated_message("Accredited provider")
 
           redirect_to(

--- a/app/controllers/publish/courses/salary_controller.rb
+++ b/app/controllers/publish/courses/salary_controller.rb
@@ -10,17 +10,24 @@ module Publish
 
       def update
         @course_salary_form = CourseSalaryForm.new(course_enrichment, params: formatted_params)
+        section_name = I18n.t("publish.providers.course_salary.edit.course_salary")
 
-        if @course_salary_form.save!
-          course_updated_message I18n.t("publish.providers.course_salary.edit.course_salary")
+        if @course_salary_form.invalid?
+          render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name:,
+          form: @course_salary_form,
+          form_param_key: funding_type,
+        )
+          # rendered interstitial
+        elsif @course_salary_form.save!
+          course_updated_message section_name
 
           redirect_to publish_provider_recruitment_cycle_course_path(
             provider.provider_code,
             recruitment_cycle.year,
             course.course_code,
           )
-        else
-          render :edit
         end
       end
 

--- a/app/controllers/publish/courses/salary_fees_controller.rb
+++ b/app/controllers/publish/courses/salary_fees_controller.rb
@@ -17,9 +17,19 @@ module Publish
 
       def update
         @course_salary_fees_form = ::Publish::CourseSalaryFeesForm.new(course_enrichment, params: form_params)
+        section_name = t(".course_salary_fee")
 
-        if @course_salary_fees_form.save!
-          course_updated_message t(".course_salary_fee")
+        if @course_salary_fees_form.invalid?
+          fetch_course_list_to_copy_from
+          render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name:,
+          form: @course_salary_fees_form,
+          form_param_key:,
+        )
+          # rendered interstitial
+        elsif @course_salary_fees_form.save!
+          course_updated_message section_name
 
           if goto_preview?
             redirect_to preview_publish_provider_recruitment_cycle_course_path(
@@ -34,9 +44,6 @@ module Publish
               course.course_code,
             )
           end
-        else
-          fetch_course_list_to_copy_from
-          render :edit
         end
       end
 

--- a/app/controllers/publish/courses/salary_fees_controller.rb
+++ b/app/controllers/publish/courses/salary_fees_controller.rb
@@ -25,7 +25,7 @@ module Publish
         elsif confirm_live_changes_if_required!(
           section_name:,
           form: @course_salary_fees_form,
-          form_param_key:,
+          form_param_key: param_form_key,
         )
           # rendered interstitial
         elsif @course_salary_fees_form.save!

--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -22,10 +22,20 @@ module Publish
       def update
         @course_study_mode_form = CourseStudyModeForm.new(@course, params: study_mode_params)
 
-        if @course_study_mode_form.save!
-          handle_redirect
-        else
+        if @course_study_mode_form.invalid?
           render :edit
+        elsif !previous_tda_course? && confirm_live_changes_if_required!(
+          section_name: I18n.t("publish.providers.study_mode.form.study_pattern"),
+          form: study_mode_confirmation_form,
+          form_param_key: :publish_course_study_mode_form,
+          fields: %i[study_mode previous_tda_course],
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            provider.provider_code, recruitment_cycle.year, course.course_code
+          ),
+        )
+          # rendered interstitial
+        elsif @course_study_mode_form.save!
+          handle_redirect
         end
       end
 
@@ -35,6 +45,13 @@ module Publish
         return { study_mode: nil } if params[:publish_course_study_mode_form].blank?
 
         params.expect(publish_course_study_mode_form: [:previous_tda_course, { study_mode: [] }])
+      end
+
+      def study_mode_confirmation_form
+        Struct.new(:study_mode, :previous_tda_course).new(
+          Array(params.dig(:publish_course_study_mode_form, :study_mode)).compact_blank,
+          params.dig(:publish_course_study_mode_form, :previous_tda_course),
+        )
       end
 
       def handle_redirect

--- a/app/controllers/publish/courses/subjects_controller.rb
+++ b/app/controllers/publish/courses/subjects_controller.rb
@@ -12,7 +12,17 @@ module Publish
 
       def update
         if validate_subject_ids
-          if params[:course][:master_subject_id] == SecondarySubject.physics.id.to_s
+          if confirm_live_changes_if_required!(
+            section_name: section_key,
+            form: subjects_confirmation_form,
+            form_param_key: :course,
+            fields: %i[master_subject_id subordinate_subject_id],
+            cancel_path: details_publish_provider_recruitment_cycle_course_path(
+              @course.provider_code, @course.recruitment_cycle_year, @course.course_code
+            ),
+          )
+            # rendered interstitial
+          elsif params[:course][:master_subject_id] == SecondarySubject.physics.id.to_s
             course.update(master_subject_id: params[:course][:master_subject_id])
             redirect_to(
               engineers_teach_physics_publish_provider_recruitment_cycle_course_path(
@@ -84,6 +94,13 @@ module Publish
 
       def course_subjects_form
         @course_subjects_form ||= CourseSubjectsForm.new(@course, params: [selected_master, selected_subordinate])
+      end
+
+      def subjects_confirmation_form
+        Struct.new(:master_subject_id, :subordinate_subject_id).new(
+          selected_master,
+          selected_subordinate,
+        )
       end
 
       def modern_languages_subject_id

--- a/app/controllers/publish/courses/visa_sponsorship_application_deadline_date_controller.rb
+++ b/app/controllers/publish/courses/visa_sponsorship_application_deadline_date_controller.rb
@@ -35,13 +35,27 @@ module Publish
           course:,
         )
 
-        if @deadline_form.valid?
+        if @deadline_form.invalid?
+          set_back_link
+          render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name: "Visa sponsorship deadline",
+          form: @deadline_form,
+          form_param_key: :course,
+          fields: [],
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(*course_nav_params),
+          extra_hidden_fields: {
+            "course[visa_sponsorship_application_deadline_at(1i)]" => @deadline_form.year,
+            "course[visa_sponsorship_application_deadline_at(2i)]" => @deadline_form.month,
+            "course[visa_sponsorship_application_deadline_at(3i)]" => @deadline_form.day,
+            "course[starting_step]" => @deadline_form.starting_step,
+          },
+        )
+          # rendered interstitial
+        else
           @deadline_form.update!
           flash[:success] = t(".success.#{@deadline_form.starting_step}")
           redirect_to(details_publish_provider_recruitment_cycle_course_path(*course_nav_params))
-        else
-          set_back_link
-          render :edit
         end
       end
 

--- a/app/controllers/publish/courses/visa_sponsorship_application_deadline_required_controller.rb
+++ b/app/controllers/publish/courses/visa_sponsorship_application_deadline_required_controller.rb
@@ -27,12 +27,23 @@ module Publish
         @deadline_required_form = VisaSponsorshipApplicationDeadlineRequiredForm.new(
           date_required_params.merge(course:, starting_step:),
         )
-        if @deadline_required_form.valid?
-          @deadline_required_form.update!
-          redirect_to_after_update
-        else
+        if @deadline_required_form.invalid?
           set_back_link
           render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name: "Visa sponsorship deadline",
+          form: @deadline_required_form,
+          form_param_key: :course,
+          fields: %i[visa_sponsorship_application_deadline_required],
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(*course_nav_params),
+          extra_hidden_fields: {
+            "course[starting_step]" => @deadline_required_form.starting_step,
+          },
+        )
+          # rendered interstitial
+        else
+          @deadline_required_form.update!
+          redirect_to_after_update
         end
       end
 

--- a/app/controllers/publish/courses/visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/visa_sponsorship_controller.rb
@@ -14,7 +14,19 @@ module Publish
       end
 
       def update
-        if visa_sponsorship_form.save!
+        if visa_sponsorship_form.invalid?
+          render :edit
+        elsif confirm_live_changes_if_required!(
+          section_name: "Visa sponsorship",
+          form: visa_sponsorship_form,
+          form_param_key: :publish_course_funding_form,
+          fields: CourseFundingForm::FIELDS,
+          cancel_path: details_publish_provider_recruitment_cycle_course_path(
+            provider.provider_code, recruitment_cycle.year, course.course_code
+          ),
+        )
+          # rendered interstitial
+        elsif visa_sponsorship_form.save!
           redirect_to_after_update
         else
           render :edit

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -3,9 +3,7 @@
 class ApplicationDecorator < Draper::Decorator
   # TODO: Move this to a view component
   def status_tag
-    tag = h.govuk_tag(text: status_text.html_safe, colour: status_colour)
-    tag += unpublished_status_hint if object.has_unpublished_changes?
-    tag.html_safe
+    h.govuk_tag(text: status_text.html_safe, colour: status_colour)
   end
 
   def status_text
@@ -28,10 +26,6 @@ class ApplicationDecorator < Draper::Decorator
     end
   end
 
-  def unpublished_status_hint
-    h.tag.span("*&nbsp;Unpublished&nbsp;changes".html_safe, class: "govuk-body-s govuk-!-display-block govuk-!-margin-bottom-0 govuk-!-margin-top-1")
-  end
-
 private
 
   def status_tags_for_vacancies
@@ -40,17 +34,16 @@ private
       withdrawn: { text: "Withdrawn", colour: "red" },
       empty: { text: "Draft", colour: "grey" },
       draft: { text: "Draft", colour: "grey" },
-      published_with_unpublished_changes: { text: "Open&nbsp;*", colour: "teal" },
       rolled_over: { text: "Rolled over", colour: "yellow" },
     }
   end
 
   def status_tags_for_no_vacancies
-    status_tags_for_vacancies.merge(published: { text: "Closed", colour: "purple" }, published_with_unpublished_changes: { text: "Closed&nbsp;*", colour: "purple" })
+    status_tags_for_vacancies.merge(published: { text: "Closed", colour: "purple" })
   end
 
   def status_tags_for_rolled_over_courses
-    status_tags_for_vacancies.merge(published: { text: "Scheduled", colour: "blue" }, published_with_unpublished_changes: { text: "Scheduled&nbsp;*", colour: "blue" })
+    status_tags_for_vacancies.merge(published: { text: "Scheduled", colour: "blue" })
   end
 
   def current_recruitment_cycle_year?

--- a/app/forms/publish/course_study_site_form.rb
+++ b/app/forms/publish/course_study_site_form.rb
@@ -6,7 +6,29 @@ module Publish
 
     attr_accessor(*FIELDS)
 
+    def save!
+      return false unless valid?
+      # Avoid course.save! when the selection is unchanged — that can still
+      # refresh "Last updated" via unrelated course update callbacks.
+      return true unless study_sites_changed?
+
+      save_action
+    end
+
   private
+
+    def after_successful_save_action
+      course.refresh_last_published_at!
+      super
+    end
+
+    def study_sites_changed?
+      normalised_ids(course.study_site_ids) != normalised_ids(study_site_ids)
+    end
+
+    def normalised_ids(ids)
+      Array(ids).compact_blank.map(&:to_i).sort
+    end
 
     def compute_fields
       { study_site_ids: course.study_site_ids }.merge(new_attributes)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -104,6 +104,16 @@ class Course < ApplicationRecord
   before_save :set_applications_open_from
 
   before_save :update_program_type!, if: :will_save_change_to_funding?
+  after_update :refresh_last_published_at!, if: :bump_last_published_at_on_live_edit?
+
+  # System/metadata attributes that should not, on their own, refresh the
+  # "Last updated" timestamp shown for published courses.
+  LIVE_EDIT_IGNORED_ATTRIBUTES = %w[
+    updated_at
+    changed_at
+    created_at
+    first_published_at
+  ].freeze
 
   belongs_to :provider
 
@@ -629,6 +639,22 @@ class Course < ApplicationRecord
     return enrichments.select(&:last_published_timestamp_utc).max_by(&:last_published_timestamp_utc)&.last_published_timestamp_utc if enrichments.loaded?
 
     enrichments.maximum(:last_published_timestamp_utc)
+  end
+
+  def bump_last_published_at_on_live_edit?
+    published? && (previous_changes.keys - LIVE_EDIT_IGNORED_ATTRIBUTES).any?
+  end
+
+  # Schools/study sites update join tables rather than course attributes, so
+  # callers that change those associations should invoke this directly.
+  def refresh_last_published_at!
+    enrichment = current_published_enrichment
+    return if enrichment.blank?
+
+    enrichment.update_columns(
+      last_published_timestamp_utc: Time.zone.now,
+      updated_at: Time.zone.now,
+    )
   end
 
   def withdrawn_at

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -178,27 +178,26 @@ class Course < ApplicationRecord
       # will return a new instance of a CourseEnrichment object which is different
       # to the ones in the cached `enrichments` association. This makes checking
       # for validations later down non-trivial.
+      #
+      # Prefer an existing draft/rolled_over enrichment (never-published or
+      # rolled-over courses). For already-published courses, edit the published
+      # enrichment in place so changes go live immediately without creating
+      # unpublished changes.
       latest_draft_enrichment = select(&:draft?).last&.tap { |d| d.version = 2 }
+      return latest_draft_enrichment if latest_draft_enrichment
 
-      latest_draft_enrichment || new(new_draft_attributes)
+      latest_published_enrichment = select(&:published?).last
+      return latest_published_enrichment if latest_published_enrichment
+
+      new(new_draft_attributes)
     end
 
     def new_draft_attributes
-      latest_published_enrichment = most_recent.published.first
-
-      new_enrichment_attributes = if latest_published_enrichment.present?
-                                    latest_published_enrichment
-                                      .dup
-                                      .attributes
-                                      .with_indifferent_access
-                                      .except(:json_data)
-                                  else
-                                    {}
-                                  end
-
-      new_enrichment_attributes.merge(
-        { status: :draft, last_published_timestamp_utc: nil, version: 2 },
-      )
+      {
+        status: :draft,
+        last_published_timestamp_utc: nil,
+        version: 2,
+      }
     end
   end
 
@@ -729,13 +728,11 @@ class Course < ApplicationRecord
   end
 
   def is_published?
-    %i[published published_with_unpublished_changes].include? content_status
+    content_status == :published
   end
 
   def has_unpublished_changes?
-    return false if all_enrichments_are_published?
-
-    (published? && draft_enrichment.present?) || (last_published_at.present? && enrichment_not_withdrawn?)
+    false
   end
 
   def draft_enrichment

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -46,6 +46,7 @@ class CourseEnrichment < ApplicationRecord
   delegate :value_proposition=, to: :provider, prefix: true
 
   before_validation :apply_publish_changes, on: :publish
+  before_update :bump_last_published_timestamp_on_live_edit, if: :bump_last_published_timestamp_on_live_edit?
 
   belongs_to :course
   has_one :provider, through: :course
@@ -169,5 +170,16 @@ class CourseEnrichment < ApplicationRecord
 
   def standard_course_length?
     course_length.in?(%w[OneYear TwoYears ThreeYears FourYears])
+  end
+
+private
+
+  def bump_last_published_timestamp_on_live_edit?
+    # Content lives in json_data; ignore association/metadata updates (e.g. course_id).
+    published? && will_save_change_to_json_data?
+  end
+
+  def bump_last_published_timestamp_on_live_edit
+    self.last_published_timestamp_utc = Time.zone.now
   end
 end

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -6,10 +6,6 @@ module API
       class SerializableCourse < JSONAPI::Serializable::Resource
         extend JSONAPI::Serializable::Resource::ConditionalFields
 
-        COURSE_STATE_MAPPING = {
-          published_with_unpublished_changes: :published,
-        }.freeze
-
         class << self
           # Attributes that should be nullified when the enrichment is version 2
           NULLIFY_ENRICHMENT_ATTRIBUTES = %i[about_course fee_details how_school_placements_work].freeze
@@ -152,7 +148,7 @@ module API
         end
 
         attribute :state do
-          COURSE_STATE_MAPPING[@object.content_status] || @object.content_status
+          @object.content_status
         end
 
         attribute :summary do

--- a/app/services/courses/content_status_service.rb
+++ b/app/services/courses/content_status_service.rb
@@ -6,7 +6,11 @@ module Courses
       return :rolled_over if enrichment&.rolled_over?
       return :published if enrichment&.published?
       return :withdrawn if enrichment&.withdrawn?
-      return :published_with_unpublished_changes if enrichment&.has_been_published_before? || (enrichment&.course&.enrichments&.most_recent.present? && enrichment&.course&.enrichments&.many?)
+      # Subsequent drafts (published before, then edited) used to map to
+      # published_with_unpublished_changes. Treat them as published so status
+      # tags stay correct until the data migration deletes those drafts.
+      # New edits no longer create this state.
+      return :published if enrichment&.has_been_published_before? || (enrichment&.course&.enrichments&.most_recent.present? && enrichment&.course&.enrichments&.many?)
 
       :draft
     end

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -551,14 +551,12 @@ module Courses
       published_course_sql
     end
 
-    # SQL mirror of Course#is_published? (content_status in published /
-    # published_with_unpublished_changes). A course counts as published when it
+    # SQL mirror of Course#is_published?. A course counts as published when it
     # has a published enrichment AND its latest enrichment has not since been
     # rolled over or withdrawn. The published row + "latest not rolled_over /
-    # withdrawn" pair is what keeps a draft-on-top-of-published course findable
-    # (unpublished changes, like fee courses) while excluding draft-only,
-    # rolled-over and withdrawn courses. The created_at/id ordering matches
-    # CourseEnrichment.most_recent.
+    # withdrawn" pair keeps courses findable when a legacy subsequent draft is
+    # still present, while excluding draft-only, rolled-over and withdrawn
+    # courses. The created_at/id ordering matches CourseEnrichment.most_recent.
     def published_course_sql
       <<~SQL
         EXISTS (

--- a/app/services/publish/courses/query.rb
+++ b/app/services/publish/courses/query.rb
@@ -35,10 +35,6 @@ module Publish
         END
       SQL
 
-      # The content statuses that render as Open, Closed or Scheduled depending
-      # on the application status and the cycle.
-      PUBLISHED_CONTENT_STATUSES = %w[published].freeze
-
       # Filter option -> Course enum keys. Both mirror Courses::Query (the Find
       # search query), except that selecting several options here unions them
       # rather than falling through to "no filter".
@@ -168,7 +164,7 @@ module Publish
       end
 
       def published_predicate(application_status = nil)
-        predicate = content_status.in(PUBLISHED_CONTENT_STATUSES)
+        predicate = content_status.eq("published")
         return predicate if application_status.nil?
 
         predicate.and(courses[:application_status].eq(::Course.application_statuses.fetch(application_status)))

--- a/app/services/publish/courses/query.rb
+++ b/app/services/publish/courses/query.rb
@@ -9,20 +9,20 @@ module Publish
     #
     # The query returns each course pre-ordered for grouping (self-accredited
     # first, then accredited provider name, then course name/code) and decorated
-    # with three computed columns so the list needs no enrichment or site rows:
+    # with two computed columns so the list needs no enrichment or site rows:
     #
-    # - +group_name+               the accredited provider heading (NULL = self-accredited)
-    # - +content_status+           draft / published / withdrawn / rolled_over /
-    #                              published_with_unpublished_changes
-    # - +has_unpublished_changes+  boolean
+    # - +group_name+      the accredited provider heading (NULL = self-accredited)
+    # - +content_status+  draft / published / withdrawn / rolled_over
     #
-    # content_status and has_unpublished_changes are a SQL port of
-    # +Courses::ContentStatusService+ and +Course#has_unpublished_changes?+; the
-    # Ruby remains the source of truth and a cross-check spec asserts agreement.
+    # content_status is a SQL port of +Courses::ContentStatusService+; the Ruby
+    # remains the source of truth and a cross-check spec asserts agreement.
     class Query
       # Ports Courses::ContentStatusService#execute. Held as a constant because
       # Postgres cannot reference a SELECT alias from WHERE, so the status filter
       # has to repeat the expression rather than reuse the +content_status+ column.
+      # Subsequent drafts (published before, then edited) used to map to
+      # published_with_unpublished_changes; treat them as published until the
+      # data migration deletes those drafts.
       CONTENT_STATUS_SQL = <<~SQL.squish
         CASE
           WHEN enrichment_stats.latest_status = 2 THEN 'rolled_over'
@@ -30,14 +30,14 @@ module Publish
           WHEN enrichment_stats.latest_status = 3 THEN 'withdrawn'
           WHEN enrichment_stats.latest_status IS NULL THEN 'draft'
           WHEN enrichment_stats.latest_published_at IS NOT NULL OR enrichment_stats.total > 1
-            THEN 'published_with_unpublished_changes'
+            THEN 'published'
           ELSE 'draft'
         END
       SQL
 
       # The content statuses that render as Open, Closed or Scheduled depending
       # on the application status and the cycle.
-      PUBLISHED_CONTENT_STATUSES = %w[published published_with_unpublished_changes].freeze
+      PUBLISHED_CONTENT_STATUSES = %w[published].freeze
 
       # Filter option -> Course enum keys. Both mirror Courses::Query (the Find
       # search query), except that selecting several options here unions them
@@ -231,11 +231,6 @@ module Publish
           LEFT JOIN LATERAL (
             SELECT
               COUNT(*) AS total,
-              COUNT(*) FILTER (WHERE status = 1) AS published_count,
-              COUNT(*) FILTER (WHERE status = 0) AS draft_count,
-              COUNT(*) FILTER (WHERE status = 3) AS withdrawn_count,
-              COUNT(*) FILTER (WHERE status IN (0, 2)) AS draft_or_rolled_count,
-              MAX(last_published_timestamp_utc) AS max_published_at,
               (ARRAY_AGG(status ORDER BY created_at DESC, id DESC))[1] AS latest_status,
               (ARRAY_AGG(last_published_timestamp_utc ORDER BY created_at DESC, id DESC))[1] AS latest_published_at
             FROM course_enrichment
@@ -258,21 +253,7 @@ module Publish
           END AS group_name
         SQL
 
-        # Ports Course#has_unpublished_changes? (false when all enrichments are published).
-        has_unpublished_changes = <<~SQL.squish
-          (
-            NOT (
-              (enrichment_stats.total = 1 AND enrichment_stats.published_count >= 1)
-              OR (enrichment_stats.draft_count = 0 AND enrichment_stats.withdrawn_count = 0)
-            )
-            AND (
-              (enrichment_stats.published_count >= 1 AND enrichment_stats.draft_or_rolled_count >= 1)
-              OR (enrichment_stats.max_published_at IS NOT NULL AND COALESCE(enrichment_stats.latest_status, -1) <> 3)
-            )
-          ) AS has_unpublished_changes
-        SQL
-
-        @scope.select("course.*", group_name, "#{CONTENT_STATUS_SQL} AS content_status", has_unpublished_changes)
+        @scope.select("course.*", group_name, "#{CONTENT_STATUS_SQL} AS content_status")
       end
 
       # Self-accredited group first, then case-insensitive by accredited provider

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -27,6 +27,7 @@ module Publish
           course.save!
         end
 
+        refresh_last_published_at_if_sites_changed
         send_notifications
       end
 
@@ -45,6 +46,12 @@ module Publish
         sites_to_remove_ids.each { |id| detach_school(sites_by_id[id]) }
 
         course.sites.reload
+      end
+
+      def refresh_last_published_at_if_sites_changed
+        return if sites_to_attach_ids.empty? && sites_to_remove_ids.empty?
+
+        course.refresh_last_published_at!
       end
 
       def submitted_site_ids

--- a/app/view_objects/publish/courses/confirm_live_changes_view.rb
+++ b/app/view_objects/publish/courses/confirm_live_changes_view.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    class ConfirmLiveChangesView
+      attr_reader :course,
+                  :section_name,
+                  :form,
+                  :form_param_key,
+                  :fields,
+                  :update_path,
+                  :back_path,
+                  :cancel_path,
+                  :method,
+                  :extra_hidden_fields
+
+      def initialize(course:, section_name:, form:, form_param_key:, fields:, update_path:, back_path:, cancel_path:, method:, extra_hidden_fields:)
+        @course = course
+        @section_name = section_name
+        @form = form
+        @form_param_key = form_param_key
+        @fields = Array(fields)
+        @update_path = update_path
+        @back_path = back_path
+        @cancel_path = cancel_path
+        @method = method
+        @extra_hidden_fields = extra_hidden_fields
+      end
+
+      def page_title
+        I18n.t("publish.courses.confirm_live_changes.page_title", section: section_name)
+      end
+
+      def heading
+        I18n.t("publish.courses.confirm_live_changes.heading", section: section_name)
+      end
+
+      def body
+        I18n.t("publish.courses.confirm_live_changes.body")
+      end
+
+      def continue_label
+        I18n.t("publish.courses.confirm_live_changes.continue")
+      end
+
+      delegate :name_and_code, to: :course, prefix: true
+
+      def each_hidden_field(&block)
+        fields.each do |field|
+          value = form.public_send(field)
+
+          if value.is_a?(Array)
+            value.each do |item|
+              yield "#{form_param_key}[#{field}][]", item
+            end
+          else
+            yield "#{form_param_key}[#{field}]", value
+          end
+        end
+
+        extra_hidden_fields.each(&block)
+      end
+    end
+  end
+end

--- a/app/views/publish/courses/_course_button_panel.html.erb
+++ b/app/views/publish/courses/_course_button_panel.html.erb
@@ -1,5 +1,5 @@
 <div data-qa="course__button_panel">
-  <% if (course.has_unpublished_changes?) || (course.is_published? && (course.is_running? || course.without_employing_school?)) %>
+  <% if course.is_published? && (course.is_running? || course.without_employing_school?) %>
     <%= render partial: "publish/courses/course_button_panel/published" %>
   <% elsif course.is_withdrawn? %>
     <%= render partial: "publish/courses/course_button_panel/withdrawn" %>

--- a/app/views/publish/courses/confirm_live_changes/show.html.erb
+++ b/app/views/publish/courses/confirm_live_changes/show.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, @confirm_live_changes.page_title %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(@confirm_live_changes.back_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: @confirm_live_changes.update_path, method: @confirm_live_changes.method, local: true do |f| %>
+      <% @confirm_live_changes.each_hidden_field do |name, value| %>
+        <%= hidden_field_tag name, value %>
+      <% end %>
+
+      <%= hidden_field_tag :confirm_publish, Publish::ConfirmLiveChanges::CONFIRM_PUBLISH_PARAM %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @confirm_live_changes.course_name_and_code %></span>
+        <%= @confirm_live_changes.heading %>
+      </h1>
+
+      <p class="govuk-body">
+        <%= @confirm_live_changes.body %>
+      </p>
+
+      <%= f.govuk_submit @confirm_live_changes.continue_label %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t("cancel"), @confirm_live_changes.cancel_path %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -1,23 +1,15 @@
 <span class="govuk-hint govuk-!-font-size-16" data-qa="course__last_publish_date">
-  <%= t(".last_published_on", date: l(course.last_published_at.to_time, format: :last_event)) %>
+  <%= t(".last_updated_on", date: l(course.last_published_at.to_time, format: :last_event)) %>
 </span>
 
 <div class="govuk-button-group">
   <%= govuk_link_to course.application_status_closed? ? "Open course" : "Close course", application_status_publish_provider_recruitment_cycle_course_path, class: "govuk-button govuk-!-margin-right-2" %>
 
-  <% if course.has_unpublished_changes? %>
-    <%= govuk_button_to(t(".publish_course"), publish_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                        class: "govuk-!-margin-right-2",
-                        data: { qa: "course__publish" }) %>
-  <% end %>
-
-  <% unless course.has_unpublished_changes? %>
-    <% if course.scheduled? %>
-     <%= govuk_link_to t(".preview_course"), preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
-    <% else %>
-      <%= govuk_link_to find_course_url(course.provider_code, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
-      <%= t(".view_live_course") %> <span class="govuk-visually-hidden"><%= t(".hidden_text") %></span>
-      <% end %>
+  <% if course.scheduled? %>
+   <%= govuk_link_to t(".preview_course"), preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
+  <% else %>
+    <%= govuk_link_to find_course_url(course.provider_code, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
+    <%= t(".view_live_course") %> <span class="govuk-visually-hidden"><%= t(".hidden_text") %></span>
     <% end %>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1304,6 +1304,7 @@ en:
     saved: "%{value} updated"
     added: "%{items_added} added"
     changes_ttl: "Changes will appear on Find teacher training courses within 15 minutes."
+    changes_now_live: "These changes are now live."
     visa_partner_warning: "Changing your answer will not change visa information for courses you or your training partners have already created."
     visa_warning: "Changing your answer will not change visa information for courses you have already created."
     visa_changes: "Visa sponsorship updated"

--- a/config/locales/en/publish/courses/confirm_live_changes.yml
+++ b/config/locales/en/publish/courses/confirm_live_changes.yml
@@ -1,0 +1,8 @@
+en:
+  publish:
+    courses:
+      confirm_live_changes:
+        page_title: Are you sure you want to publish your changes to '%{section}'?
+        heading: Are you sure you want to publish your changes to '%{section}'?
+        body: Your changes will go live immediately.
+        continue: Continue and publish changes

--- a/config/locales/en/publish/courses/course_button_panel/published.yml
+++ b/config/locales/en/publish/courses/course_button_panel/published.yml
@@ -4,8 +4,7 @@ en:
       course_button_panel:
         published:
           withdraw_course: Withdraw course
-          last_published_on: Last published on %{date}
-          publish_course: Publish course
+          last_updated_on: Last updated on %{date}
           preview_course: Preview course
           view_live_course: View live course
           hidden_text: teacher training courses

--- a/db/data/20260729110000_delete_subsequent_draft_enrichments.rb
+++ b/db/data/20260729110000_delete_subsequent_draft_enrichments.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DeleteSubsequentDraftEnrichments < ActiveRecord::Migration[8.1]
+  # Removes draft enrichments that sit on top of previously published courses
+  # (the old "unpublished changes" state). Find continues to show the last
+  # published enrichment. Does not change application_status.
+  # Initial drafts (never published) are left untouched.
+  def up
+    CourseEnrichment
+      .where(status: CourseEnrichment.statuses[:draft])
+      .where.not(last_published_timestamp_utc: nil)
+      .in_batches(of: 1_000, &:delete_all)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/components/publish/courses/status_tag_component_spec.rb
+++ b/spec/components/publish/courses/status_tag_component_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Publish::Courses::StatusTagComponent, type: :component do
       expect_match(build_course(provider:, application_status: :open, traits: %i[published]))
     end
 
-    it "matches the decorator for a published course with unpublished changes" do
+    it "matches the decorator for a published course with a legacy subsequent draft" do
       course = build_course(provider:, application_status: :open, enrichments: -> { [build(:course_enrichment, :published), build(:course_enrichment, :initial_draft)] })
       expect_match(course)
     end

--- a/spec/components/publish/courses/table_component_spec.rb
+++ b/spec/components/publish/courses/table_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Publish::Courses::TableComponent, type: :component do
   subject(:render_component) { render_inline(described_class.new(courses:, provider:)) }
 
   let(:provider) { create(:provider) }
-  # Rows carry the read-model columns (content_status, has_unpublished_changes), so
-  # source them through the query exactly as the page does.
+  # Rows carry the read-model column (content_status), so source them through
+  # the query exactly as the page does.
   let(:courses) { Publish::Courses::Query.call(provider: provider.reload).map(&:decorate) }
 
   it "renders the Course, Course information and Status column headers" do

--- a/spec/controllers/concerns/publish/confirm_live_changes_spec.rb
+++ b/spec/controllers/concerns/publish/confirm_live_changes_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Publish::ConfirmLiveChanges do
+  subject(:helper) { test_class.new }
+
+  let(:test_class) do
+    Class.new do
+      include Publish::ConfirmLiveChanges
+      include Rails.application.routes.url_helpers
+
+      attr_accessor :course, :params, :request
+
+      def initialize
+        @params = {}
+        @request = Struct.new(:path, :request_method).new("/update", "PATCH")
+        @rendered = false
+      end
+
+      def render(*)
+        @rendered = true
+        :rendered_confirmation
+      end
+
+      def rendered?
+        @rendered
+      end
+
+      def default_url_options
+        { host: "test.host" }
+      end
+    end
+  end
+
+  describe "#require_live_changes_confirmation?" do
+    context "when the course is published and confirm_publish is not set" do
+      before do
+        helper.course = create(:course, :published)
+        helper.params = {}
+      end
+
+      it { expect(helper.send(:require_live_changes_confirmation?)).to be true }
+    end
+
+    context "when the course is published and confirm_publish is true" do
+      before do
+        helper.course = create(:course, :published)
+        helper.params = { confirm_publish: "true" }
+      end
+
+      it { expect(helper.send(:require_live_changes_confirmation?)).to be false }
+    end
+
+    context "when the course is a draft" do
+      before do
+        helper.course = create(:course, :draft_enrichment)
+        helper.params = {}
+      end
+
+      it { expect(helper.send(:require_live_changes_confirmation?)).to be false }
+    end
+  end
+
+  describe "#confirm_live_changes_if_required!" do
+    let(:form_class) do
+      Class.new do
+        const_set(:FIELDS, %i[course_length])
+
+        attr_accessor :course_length
+
+        def initialize(course_length:)
+          @course_length = course_length
+        end
+      end
+    end
+    let(:form) { form_class.new(course_length: "TwoYears") }
+
+    context "when confirmation is required" do
+      before do
+        helper.course = create(:course, :published)
+        helper.params = {}
+      end
+
+      it "renders the interstitial and returns true" do
+        result = helper.send(
+          :confirm_live_changes_if_required!,
+          section_name: "Course length",
+          form:,
+          form_param_key: :publish_course_length_form,
+        )
+
+        expect(result).to be true
+        expect(helper.rendered?).to be true
+        expect(helper.instance_variable_get(:@confirm_live_changes)).to have_attributes(
+          section_name: "Course length",
+          form_param_key: :publish_course_length_form,
+          fields: %i[course_length],
+          update_path: "/update",
+          back_path: "/update",
+          method: :patch,
+        )
+      end
+    end
+
+    context "when confirmation is not required" do
+      before do
+        helper.course = create(:course, :draft_enrichment)
+        helper.params = {}
+      end
+
+      it "returns false and does not render" do
+        result = helper.send(
+          :confirm_live_changes_if_required!,
+          section_name: "Course length",
+          form:,
+          form_param_key: :publish_course_length_form,
+        )
+
+        expect(result).to be false
+        expect(helper.rendered?).to be false
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/success_message_spec.rb
+++ b/spec/controllers/concerns/success_message_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SuccessMessage do
+  subject(:helper) { test_class.new }
+
+  let(:test_class) do
+    Class.new do
+      include SuccessMessage
+
+      attr_accessor :course, :flash
+
+      def initialize
+        @flash = {}
+      end
+    end
+  end
+
+  describe "#course_updated_message" do
+    context "when the course is published" do
+      before { helper.course = create(:course, :published) }
+
+      it "sets a success_with_body flash with the live changes message" do
+        helper.course_updated_message("Interview process")
+
+        expect(helper.flash[:success_with_body]).to eq(
+          "title" => "Interview process updated",
+          "body" => "These changes are now live.",
+        )
+        expect(helper.flash[:success]).to be_nil
+      end
+    end
+
+    context "when the course is not published" do
+      before { helper.course = create(:course, :draft_enrichment) }
+
+      it "sets a simple success flash without the live changes message" do
+        helper.course_updated_message("Interview process")
+
+        expect(helper.flash[:success]).to eq("Interview process updated")
+        expect(helper.flash[:success_with_body]).to be_nil
+      end
+    end
+
+    context "when there is no course" do
+      before { helper.course = nil }
+
+      it "sets a simple success flash" do
+        helper.course_updated_message("Study site")
+
+        expect(helper.flash[:success]).to eq("Study site updated")
+        expect(helper.flash[:success_with_body]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/publish/courses/length_controller_spec.rb
+++ b/spec/controllers/publish/courses/length_controller_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
         patch :update, params: params
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include(I18n.t("publish.courses.confirm_live_changes.body"))
-        expect(response.body).to include(I18n.t("publish.courses.confirm_live_changes.continue"))
+        expect(response.body).to include("Your changes will go live immediately.")
+        expect(response.body).to include("Continue and publish changes")
         expect(course.reload.enrichments.find_or_initialize_draft.course_length).not_to eq("TwoYears")
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
         )
         expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq("TwoYears")
         expect(flash[:success_with_body]).to include(
-          "body" => I18n.t("success.changes_now_live"),
+          "body" => "These changes are now live.",
         )
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
             course.course_code,
           ),
         )
-        expect(response.body).not_to include(I18n.t("publish.courses.confirm_live_changes.body"))
+        expect(response.body).not_to include("Your changes will go live immediately.")
         expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq("TwoYears")
       end
     end

--- a/spec/controllers/publish/courses/length_controller_spec.rb
+++ b/spec/controllers/publish/courses/length_controller_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Publish::Courses::LengthController, type: :controller do
+  render_views
+  let(:user) { create(:user, :with_provider) }
+  let(:provider) { user.providers.first }
+  let(:course) { create(:course, :published, provider:) }
+
+  before do
+    allow(controller).to receive(:authenticate).and_return(true)
+    controller.instance_variable_set(:@current_user, user)
+  end
+
+  describe "#update" do
+    let(:params) do
+      {
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        code: course.course_code,
+        publish_course_length_form: {
+          course_length: "TwoYears",
+        },
+      }
+    end
+
+    context "when the course is published and confirmation is required" do
+      it "renders the interstitial and does not persist the change" do
+        patch :update, params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("publish.courses.confirm_live_changes.body"))
+        expect(response.body).to include(I18n.t("publish.courses.confirm_live_changes.continue"))
+        expect(course.reload.enrichments.find_or_initialize_draft.course_length).not_to eq("TwoYears")
+      end
+    end
+
+    context "when the course is published and confirmation is given" do
+      it "persists the change and sets the live success flash" do
+        patch :update, params: params.merge(confirm_publish: "true")
+
+        expect(response).to redirect_to(
+          publish_provider_recruitment_cycle_course_path(
+            provider.provider_code,
+            provider.recruitment_cycle_year,
+            course.course_code,
+          ),
+        )
+        expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq("TwoYears")
+        expect(flash[:success_with_body]).to include(
+          "body" => I18n.t("success.changes_now_live"),
+        )
+      end
+    end
+
+    context "when the course is a draft" do
+      let(:course) { create(:course, :draft_enrichment, provider:) }
+
+      it "saves immediately without rendering the interstitial" do
+        patch :update, params: params
+
+        expect(response).to redirect_to(
+          publish_provider_recruitment_cycle_course_path(
+            provider.provider_code,
+            provider.recruitment_cycle_year,
+            course.course_code,
+          ),
+        )
+        expect(response.body).not_to include(I18n.t("publish.courses.confirm_live_changes.body"))
+        expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq("TwoYears")
+      end
+    end
+  end
+end

--- a/spec/forms/publish/course_rollover_form_spec.rb
+++ b/spec/forms/publish/course_rollover_form_spec.rb
@@ -44,7 +44,7 @@ module Publish
       end
     end
 
-    describe "unpublished changes course" do
+    describe "legacy subsequent draft course" do
       let(:course) { create(:course, enrichments: [unpublished_changes_enrichment]) }
 
       it "is invalid" do

--- a/spec/forms/publish/course_study_site_form_spec.rb
+++ b/spec/forms/publish/course_study_site_form_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  RSpec.describe CourseStudySiteForm do
+    let(:provider) { create(:provider, study_sites: [study_site_one, study_site_two]) }
+    let(:study_site_one) { build(:site, :study_site, location_name: "Study site 1") }
+    let(:study_site_two) { build(:site, :study_site, location_name: "Study site 2") }
+    let(:course) { create(:course, :published, provider:, study_sites: [study_site_one]) }
+    let(:previous_timestamp) { 1.day.ago.change(usec: 0) }
+
+    before do
+      course.enrichments.published.update_all(last_published_timestamp_utc: previous_timestamp)
+    end
+
+    describe "#save!" do
+      it "refreshes last_published_at when study sites change" do
+        form = described_class.new(course, params: { study_site_ids: [study_site_one.id, study_site_two.id] })
+
+        expect(form.save!).to be(true)
+        expect(course.reload.last_published_at).to be_within(5.seconds).of(Time.zone.now)
+        expect(course.last_published_at).to be > previous_timestamp
+      end
+
+      it "does not refresh last_published_at when study sites are unchanged" do
+        form = described_class.new(course, params: { study_site_ids: ["", study_site_one.id.to_s] })
+
+        expect(form.save!).to be(true)
+        expect(course.reload.last_published_at).to eq(previous_timestamp)
+      end
+    end
+  end
+end

--- a/spec/models/course/publish_enrichments_spec.rb
+++ b/spec/models/course/publish_enrichments_spec.rb
@@ -60,7 +60,7 @@ describe "#enrichments" do
     context "for a course with published enrichments and a draft one" do
       let(:enrichments) { [build(:course_enrichment, :published), build(:course_enrichment, :subsequent_draft)] }
 
-      its(:content_status) { is_expected.to eq(:published_with_unpublished_changes) }
+      its(:content_status) { is_expected.to eq(:published) }
     end
   end
 

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -149,6 +149,40 @@ RSpec.describe CourseEnrichment do
   #
   # Existing specs we already had
   #
+  describe "live edits to published enrichments" do
+    subject(:record) do
+      create(
+        :course_enrichment,
+        :published,
+        last_published_timestamp_utc: 1.day.ago,
+        theoretical_training_activities: "Old content",
+      )
+    end
+
+    it "refreshes last_published_timestamp_utc when content changes" do
+      record.update!(theoretical_training_activities: "Updated content")
+
+      expect(record.reload.last_published_timestamp_utc).to be_within(5.seconds).of(Time.zone.now)
+    end
+
+    it "does not refresh last_published_timestamp_utc when only metadata changes" do
+      previous_timestamp = record.last_published_timestamp_utc
+
+      record.update!(updated_by_user_id: create(:user).id)
+
+      expect(record.reload.last_published_timestamp_utc).to be_within(1.second).of(previous_timestamp)
+    end
+
+    it "does not refresh last_published_timestamp_utc when reassigned to another course" do
+      previous_timestamp = record.last_published_timestamp_utc
+      other_course = create(:course)
+
+      record.update!(course: other_course)
+
+      expect(record.reload.last_published_timestamp_utc).to be_within(1.second).of(previous_timestamp)
+    end
+  end
+
   describe "#publish" do
     let(:user) { create(:user) }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2616,6 +2616,29 @@ describe Course do
     end
   end
 
+  describe "live edits to published courses" do
+    let(:course) { create(:course, :published, age_range_in_years: "3_to_7") }
+    let(:previous_timestamp) { 1.day.ago.change(usec: 0) }
+
+    before do
+      course.enrichments.published.update_all(last_published_timestamp_utc: previous_timestamp)
+      course.enrichments.reload
+    end
+
+    it "refreshes last_published_at when basic details change" do
+      course.update!(age_range_in_years: "5_to_11")
+
+      expect(course.reload.last_published_at).to be_within(5.seconds).of(Time.zone.now)
+      expect(course.last_published_at).to be > previous_timestamp
+    end
+
+    it "does not refresh last_published_at when only changed_at is updated" do
+      course.update_columns(changed_at: Time.zone.now)
+
+      expect(course.reload.last_published_at).to eq(previous_timestamp)
+    end
+  end
+
   describe "funding_type and program_type" do
     context "setting the funding to apprenticeship" do
       it "sets the funding to apprenticeship and program_type to pg_teaching_apprenticeship" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -194,15 +194,15 @@ describe Course do
         expect(custom_course.enrichments.find_or_initialize_draft.version).to eq(2)
       end
 
-      it "has a published enrichment with version 1 and creates v2 draft" do
+      it "returns the published enrichment for in-place edit" do
         enrichment = create(:course_enrichment, version: 1, status: "published")
         custom_course = create(:course, course_code: "CUST1", enrichments: [enrichment])
         expect(enrichment.version).to eq(1)
 
-        expect(
-          custom_course.enrichments.find_or_initialize_draft.attributes.except("id", "created_at", "updated_at", "version", "status", "json_data"),
-        ).to eq(enrichment.attributes.except("id", "created_at", "updated_at", "version", "status", "json_data"))
-        expect(custom_course.enrichments.find_or_initialize_draft.version).to eq(2)
+        editable = custom_course.enrichments.find_or_initialize_draft
+        expect(editable).to eq(enrichment)
+        expect(editable).to be_published
+        expect(editable.version).to eq(1)
       end
     end
   end
@@ -1453,7 +1453,7 @@ describe Course do
     let(:course) { create(:course, enrichments: [enrichment1, enrichment2]) }
     let(:enrichment1) {  build(:course_enrichment, :subsequent_draft, created_at: Time.zone.now) }
     let(:enrichment2) {  build(:course_enrichment, :published, created_at: 1.minute.ago) }
-    let(:service_spy) { spy(execute: :published_with_unpublished_changes) }
+    let(:service_spy) { spy(execute: :published) }
     let(:content_status) { course.content_status }
 
     it "Delegate the method to the service" do
@@ -1727,13 +1727,13 @@ describe Course do
         let(:enrichments) { [published_enrichment] }
         let(:expected_enrichment_attributes) { published_enrichment.attributes.slice(*copyable_enrichment_attributes) }
 
-        it "has all the same attributes as the published enrichment" do
+        it "returns the published enrichment for in-place edit" do
           expect(actual_enrichment_attributes).to eq expected_enrichment_attributes
         end
 
-        its(:id) { is_expected.to be_nil }
-        its(:last_published_timestamp_utc) { is_expected.to be_nil }
-        its(:status) { is_expected.to eq "draft" }
+        its(:id) { is_expected.to eq published_enrichment.id }
+        its(:last_published_timestamp_utc) { is_expected.to be_within(1.second).of published_enrichment.last_published_timestamp_utc }
+        its(:status) { is_expected.to eq "published" }
       end
 
       context "with a draft and published enrichment" do
@@ -2046,12 +2046,12 @@ describe Course do
       end
     end
 
-    context "course is published with unpublished changes" do
+    context "course is published with a legacy subsequent draft" do
       let(:enrichment) { create(:course_enrichment, :subsequent_draft) }
       let(:course) { create(:course, enrichments: [enrichment]) }
 
       it "returns true" do
-        expect(course.content_status).to eq(:published_with_unpublished_changes)
+        expect(course.content_status).to eq(:published)
         expect(course.is_published?).to be(true)
       end
     end
@@ -2250,7 +2250,7 @@ describe Course do
       it { is_expected.to be(true) }
     end
 
-    context "course is published with unpublished changes" do
+    context "course is published with a legacy subsequent draft" do
       let(:enrichment) { create(:course_enrichment, :subsequent_draft) }
 
       it { is_expected.to be(true) }

--- a/spec/services/courses/content_status_service_spec.rb
+++ b/spec/services/courses/content_status_service_spec.rb
@@ -43,8 +43,8 @@ describe Courses::ContentStatusService do
   context "when the enrichment has been been published previously" do
     let(:enrichment) { build(:course_enrichment, :subsequent_draft) }
 
-    it "returns published_with_unpublished_changes" do
-      expect(execute_service).to eq :published_with_unpublished_changes
+    it "returns published" do
+      expect(execute_service).to eq :published
     end
   end
 

--- a/spec/services/publish/courses/query_spec.rb
+++ b/spec/services/publish/courses/query_spec.rb
@@ -627,12 +627,8 @@ RSpec.describe Publish::Courses::Query do
     end
   end
 
-  describe "content_status / has_unpublished_changes columns match the canonical Ruby" do
+  describe "content_status column matches the canonical Ruby" do
     let(:provider) { create(:provider, :accredited_provider) }
-
-    def boolean(value)
-      ActiveModel::Type::Boolean.new.cast(value)
-    end
 
     {
       "no enrichment" => -> { create(:course, provider:) },
@@ -646,11 +642,10 @@ RSpec.describe Publish::Courses::Query do
       context "with #{description}" do
         before { instance_exec(&setup) }
 
-        it "agrees with Course#content_status and #has_unpublished_changes?" do
+        it "agrees with Course#content_status" do
           row = described_class.call(provider: provider.reload).first
 
           expect(row[:content_status]).to eq(row.content_status.to_s)
-          expect(boolean(row[:has_unpublished_changes])).to eq(row.has_unpublished_changes?)
         end
       end
     end

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -80,10 +80,22 @@ module Publish
           context "when course is published" do
             let(:course) { create(:course, :published, provider:, site_statuses: [site_status]) }
             let(:site_status) { build(:site_status, :running, :published, site: site_one) }
+            let(:previous_timestamp) { 1.day.ago.change(usec: 0) }
+
+            before do
+              course.enrichments.published.update_all(last_published_timestamp_utc: previous_timestamp)
+            end
 
             it "sets all site_statuses to running" do
               service_call
               expect(course.reload.site_statuses.pluck(:status)).to match(%w[running running])
+            end
+
+            it "refreshes last_published_at" do
+              service_call
+
+              expect(course.reload.last_published_at).to be_within(5.seconds).of(Time.zone.now)
+              expect(course.last_published_at).to be > previous_timestamp
             end
           end
         end

--- a/spec/support/feature_helpers/confirm_live_changes.rb
+++ b/spec/support/feature_helpers/confirm_live_changes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FeatureHelpers
+  module ConfirmLiveChanges
+    def and_i_confirm_publishing_live_changes
+      expect(page).to have_content(I18n.t("publish.courses.confirm_live_changes.body"))
+      click_button I18n.t("publish.courses.confirm_live_changes.continue")
+    end
+
+    def then_i_should_not_see_the_live_changes_interstitial
+      expect(page).to have_no_content(I18n.t("publish.courses.confirm_live_changes.body"))
+      expect(page).to have_no_button(I18n.t("publish.courses.confirm_live_changes.continue"))
+    end
+  end
+end

--- a/spec/support/feature_helpers/confirm_live_changes.rb
+++ b/spec/support/feature_helpers/confirm_live_changes.rb
@@ -3,13 +3,13 @@
 module FeatureHelpers
   module ConfirmLiveChanges
     def and_i_confirm_publishing_live_changes
-      expect(page).to have_content(I18n.t("publish.courses.confirm_live_changes.body"))
-      click_button I18n.t("publish.courses.confirm_live_changes.continue")
+      expect(page).to have_content("Your changes will go live immediately.")
+      click_button "Continue and publish changes"
     end
 
     def then_i_should_not_see_the_live_changes_interstitial
-      expect(page).to have_no_content(I18n.t("publish.courses.confirm_live_changes.body"))
-      expect(page).to have_no_button(I18n.t("publish.courses.confirm_live_changes.continue"))
+      expect(page).to have_no_content("Your changes will go live immediately.")
+      expect(page).to have_no_button("Continue and publish changes")
     end
   end
 end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -5,6 +5,7 @@ RSpec.configure do |config|
   config.include FeatureHelpers::NewCourseParam, type: :system
   config.include FeatureHelpers::GovukComponents, type: :system
   config.include FeatureHelpers::CourseSteps, type: :system
+  config.include FeatureHelpers::ConfirmLiveChanges, type: :system
   config.include FeatureHelpers::PageWithQuery, type: :system
   config.include DfESignInUserHelper, type: :system
   config.include FeatureHelpers::PageObject::Support, :support_features

--- a/spec/system/find/viewing_courses_in_various_states_spec.rb
+++ b/spec/system/find/viewing_courses_in_various_states_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "viewing courses in various states" do
     then_i_should_see_the_course
   end
 
-  scenario "viewing a published with unpublished changes course" do
-    given_there_is_a_published_with_unpublished_changes_course
+  scenario "viewing a published course with a legacy subsequent draft" do
+    given_there_is_a_published_course_with_a_legacy_subsequent_draft
     when_i_visit_the_course_page
     then_i_should_see_the_course
   end
@@ -85,7 +85,7 @@ RSpec.describe "viewing courses in various states" do
     )
   end
 
-  def given_there_is_a_published_with_unpublished_changes_course
+  def given_there_is_a_published_course_with_a_legacy_subsequent_draft
     @course ||= create(
       :course,
       enrichments: [

--- a/spec/system/publish/courses/confirm_live_changes_spec.rb
+++ b/spec/system/publish/courses/confirm_live_changes_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Confirming live changes before publishing course edits" do
+  before do
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  scenario "published course shows interstitial for what you will study, then saves on confirm" do
+    given_a_published_course
+    when_i_edit_what_you_will_study
+    then_i_see_the_live_changes_interstitial(section: "What you will study")
+    and_the_what_you_will_study_content_is_not_saved_yet
+
+    when_i_confirm_publishing_live_changes
+    then_i_see_the_live_changes_success_message(section: "What you will study")
+    and_the_what_you_will_study_content_is_saved
+  end
+
+  scenario "draft course skips the interstitial for what you will study" do
+    given_a_draft_course
+    when_i_edit_what_you_will_study
+    then_i_should_not_see_the_live_changes_interstitial
+    then_i_see_a_simple_success_message(section: "What you will study")
+    and_the_what_you_will_study_content_is_saved
+  end
+
+  scenario "published course shows interstitial for age range, then saves on confirm" do
+    given_a_published_course
+    when_i_edit_age_range
+    then_i_see_the_live_changes_interstitial(section: "Age range")
+    and_the_age_range_is_not_saved_yet
+
+    when_i_confirm_publishing_live_changes
+    then_i_see_the_live_changes_success_message(section: "Age range")
+    and_the_age_range_is_saved
+  end
+
+  scenario "schools update on a published course does not show the interstitial" do
+    given_a_published_course_with_schools
+    when_i_update_course_schools
+    then_i_should_not_see_the_live_changes_interstitial
+    expect(page).to have_content("Schools updated")
+  end
+
+private
+
+  def given_a_published_course
+    given_a_course_exists(:published)
+  end
+
+  def given_a_draft_course
+    given_a_course_exists(:draft_enrichment)
+  end
+
+  def given_a_published_course_with_schools
+    site = create(:site, location_name: "Site 1", provider:)
+    given_a_course_exists(:published, sites: [site])
+    create(:site, location_name: "Site 2", provider:)
+  end
+
+  def when_i_edit_what_you_will_study
+    visit fields_what_you_will_study_publish_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      provider.recruitment_cycle_year,
+      course.course_code,
+    )
+
+    @theoretical_training = "Trainees will attend seminars and workshops"
+    fill_in "What will trainees do during their theoretical training?", with: @theoretical_training
+    click_button "Update what you will study"
+  end
+
+  def when_i_edit_age_range
+    publish_courses_age_range_edit_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      course_code: course.course_code,
+    )
+    publish_courses_age_range_edit_page.five_to_eleven.click
+    publish_courses_age_range_edit_page.continue.click
+  end
+
+  def when_i_update_course_schools
+    publish_course_school_edit_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      course_code: course.course_code,
+    )
+    publish_course_school_edit_page.vacancies.find { |el|
+      el.find(".govuk-label").text == "Site 2"
+    }.check
+    publish_course_school_edit_page.submit.click
+  end
+
+  def then_i_see_the_live_changes_interstitial(section:)
+    expect(page).to have_content(
+      I18n.t("publish.courses.confirm_live_changes.heading", section:),
+    )
+    expect(page).to have_content(I18n.t("publish.courses.confirm_live_changes.body"))
+  end
+
+  def when_i_confirm_publishing_live_changes
+    and_i_confirm_publishing_live_changes
+  end
+
+  def then_i_see_the_live_changes_success_message(section:)
+    expect(page).to have_content("#{section} updated")
+    expect(page).to have_content(I18n.t("success.changes_now_live"))
+  end
+
+  def then_i_see_a_simple_success_message(section:)
+    expect(page).to have_content(I18n.t("success.saved", value: section))
+    expect(page).to have_no_content(I18n.t("success.changes_now_live"))
+  end
+
+  def and_the_what_you_will_study_content_is_not_saved_yet
+    expect(course.reload.enrichments.find_or_initialize_draft.theoretical_training_activities)
+      .not_to eq(@theoretical_training)
+  end
+
+  def and_the_what_you_will_study_content_is_saved
+    expect(course.reload.enrichments.find_or_initialize_draft.theoretical_training_activities)
+      .to eq(@theoretical_training)
+  end
+
+  def and_the_age_range_is_not_saved_yet
+    expect(course.reload.age_range_in_years).to eq("3_to_7")
+  end
+
+  def and_the_age_range_is_saved
+    expect(course.reload.age_range_in_years).to eq("5_to_11")
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/system/publish/courses/confirm_live_changes_spec.rb
+++ b/spec/system/publish/courses/confirm_live_changes_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Confirming live changes before publishing course edits" do
 
   scenario "published course shows interstitial for what you will study, then saves on confirm" do
     given_a_published_course
+    and_the_course_was_last_published_yesterday
     when_i_edit_what_you_will_study
     then_i_see_the_live_changes_interstitial(section: "What you will study")
     and_the_what_you_will_study_content_is_not_saved_yet
@@ -16,6 +17,7 @@ RSpec.describe "Confirming live changes before publishing course edits" do
     when_i_confirm_publishing_live_changes
     then_i_see_the_live_changes_success_message(section: "What you will study")
     and_the_what_you_will_study_content_is_saved
+    and_the_last_updated_timestamp_is_refreshed
   end
 
   scenario "draft course skips the interstitial for what you will study" do
@@ -28,6 +30,7 @@ RSpec.describe "Confirming live changes before publishing course edits" do
 
   scenario "published course shows interstitial for age range, then saves on confirm" do
     given_a_published_course
+    and_the_course_was_last_published_yesterday
     when_i_edit_age_range
     then_i_see_the_live_changes_interstitial(section: "Age range")
     and_the_age_range_is_not_saved_yet
@@ -35,19 +38,27 @@ RSpec.describe "Confirming live changes before publishing course edits" do
     when_i_confirm_publishing_live_changes
     then_i_see_the_live_changes_success_message(section: "Age range")
     and_the_age_range_is_saved
+    and_the_last_updated_timestamp_is_refreshed
   end
 
   scenario "schools update on a published course does not show the interstitial" do
     given_a_published_course_with_schools
+    and_the_course_was_last_published_yesterday
     when_i_update_course_schools
     then_i_should_not_see_the_live_changes_interstitial
     expect(page).to have_content("Schools updated")
+    and_the_last_updated_timestamp_is_refreshed
   end
 
 private
 
   def given_a_published_course
     given_a_course_exists(:published)
+  end
+
+  def and_the_course_was_last_published_yesterday
+    @previous_last_published_at = 1.day.ago.change(usec: 0)
+    course.enrichments.published.update_all(last_published_timestamp_utc: @previous_last_published_at)
   end
 
   def given_a_draft_course
@@ -131,6 +142,11 @@ private
 
   def and_the_age_range_is_saved
     expect(course.reload.age_range_in_years).to eq("5_to_11")
+  end
+
+  def and_the_last_updated_timestamp_is_refreshed
+    expect(course.reload.last_published_at).to be_within(5.seconds).of(Time.zone.now)
+    expect(course.last_published_at).to be > @previous_last_published_at
   end
 
   def provider

--- a/spec/system/publish/courses/editing_course_funding_type_spec.rb
+++ b/spec/system/publish/courses/editing_course_funding_type_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Editing funding type" do
       when_i_visit_the_fees_and_financial_support_page
       and_i_update_the_fee
       and_i_submit_fees_and_financial_support
+      and_i_confirm_publishing_live_changes
       then_i_should_see_the_correct_success_message("Fees and financial support updated")
       and_the_course_fee_is_updated
     end
@@ -32,6 +33,7 @@ RSpec.describe "Editing funding type" do
       when_i_visit_the_course_salary_page
       and_i_update_the_salary_details
       and_i_submit_the(publish_course_salary_edit_page)
+      and_i_confirm_publishing_live_changes
       then_i_should_see_the_correct_success_message("Course salary updated")
       and_the_course_salary_is_updated
     end

--- a/spec/system/publish/courses/editing_course_interview_process_spec.rb
+++ b/spec/system/publish/courses/editing_course_interview_process_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Editing interview process section" do
 
     when_i_enter_information_into_the_interview_process_field
     and_i_submit_the_form
+    and_i_confirm_publishing_live_changes
     then_interview_process_data_has_changed
 
     when_i_visit_the_interview_process_edit_page

--- a/spec/system/publish/courses/editing_course_length_spec.rb
+++ b/spec/system/publish/courses/editing_course_length_spec.rb
@@ -19,13 +19,14 @@ RSpec.describe "Editing course length" do
 
     when_i_update_the_length_to_2_years
     and_i_submit_the_form
+    and_i_confirm_publishing_live_changes
     then_i_see_a_success_message
     and_the_course_length_is_two_years
 
     when_i_visit_the_course_length_edit_page
     then_i_see_two_years_selected
 
-    when_i_view_the_published_course_it_is_not_updated_yet
+    when_i_view_the_published_course_it_is_updated
   end
 
   scenario "I update the course length with a custom length" do
@@ -36,6 +37,7 @@ RSpec.describe "Editing course length" do
 
     when_i_update_the_length_to_a_custom_length
     and_i_submit_the_form
+    and_i_confirm_publishing_live_changes
     then_i_see_a_success_message
     and_the_course_length_is_the_custom_length
 
@@ -118,13 +120,13 @@ private
     expect(find_field("Course length", visible: false).value).to eq "Three years"
   end
 
-  def when_i_view_the_published_course_it_is_not_updated_yet
+  def when_i_view_the_published_course_it_is_updated
     open_new_window
 
     window = Capybara::Window.new(page, page.driver.window_handles.last)
     within_window(window) do
       visit find_course_url(provider_code: provider.provider_code, course_code: course.course_code)
-      expect(page).to have_content("1 year - full time")
+      expect(page).to have_content("Up to 2 years - full time")
     end
   end
 
@@ -138,6 +140,7 @@ private
 
   def then_i_see_a_success_message
     expect(page).to have_content("Course length updated")
+    expect(page).to have_content(I18n.t("success.changes_now_live"))
   end
 
   def and_the_course_length_is_two_years

--- a/spec/system/publish/courses/editing_course_school_placements_spec.rb
+++ b/spec/system/publish/courses/editing_course_school_placements_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Editing how placements work" do
 
     when_i_enter_school_placements_information
     and_i_submit
+    and_i_confirm_publishing_live_changes
     then_i_see_a_success_message
     and_the_course_information_is_updated
   end

--- a/spec/system/publish/courses/publishing_a_course_spec.rb
+++ b/spec/system/publish/courses/publishing_a_course_spec.rb
@@ -150,6 +150,7 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     fill_in "What is the interview process? (optional)", with: "some new interview process content"
     choose "Online"
     click_on "Update interview process"
+    and_i_confirm_publishing_live_changes
 
     # What you will study
     visit fields_what_you_will_study_publish_provider_recruitment_cycle_course_path(
@@ -160,6 +161,7 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     fill_in "What will trainees do during their theoretical training?", with: "some new theoretical training content"
     fill_in "How will they be assessed? (optional)", with: "some new assessment methods content"
     click_on "Update what you will study"
+    and_i_confirm_publishing_live_changes
 
     # What you will do on school placements
     visit fields_school_placement_publish_provider_recruitment_cycle_course_path(
@@ -170,6 +172,7 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     fill_in "What will trainees do while in their placement schools?", with: "some new what will trainees do on placements content"
     fill_in "How will they be supported and mentored? (optional)", with: "some new how will they be supported and mentored content"
     click_on "Update what you will do on school placements"
+    and_i_confirm_publishing_live_changes
 
     # Where you will train
     visit fields_where_you_will_train_publish_provider_recruitment_cycle_course_path(
@@ -182,6 +185,7 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     fill_in "Where will theoretical training take place? (optional)", with: "some new where will theoretical training take place content"
     fill_in "How much time will they spend in theoretical training? (optional)", with: "some new how much time will they spend in theoretical training content"
     click_on "Update where you will train"
+    and_i_confirm_publishing_live_changes
 
     # Fees and financial support
     visit fields_fees_and_financial_support_publish_provider_recruitment_cycle_course_path(
@@ -195,6 +199,7 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     fill_in "Are there any additional fees or costs? (optional)", with: "some new additional fees or costs content"
     fill_in "Does your organisation offer any financial support? (optional)", with: "some new financial support content"
     click_on "Update fees and financial support"
+    and_i_confirm_publishing_live_changes
   end
 
   def then_i_see_the_changes_are_now_live_message

--- a/spec/system/publish/courses/publishing_a_course_spec.rb
+++ b/spec/system/publish/courses/publishing_a_course_spec.rb
@@ -25,16 +25,22 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     and_the_course_is_open
   end
 
-  scenario "i can re-publish a course" do
+  scenario "changes to an open published course go live immediately" do
     and_i_have_previously_published_a_course
     when_i_make_some_new_changes
-    then_i_should_see_the_unpublished_changes_message
-    and_i_visit_the_course_page
-    and_i_do_not_see_the_unpublished_content_on_find
-    when_i_return_to_publish
-    and_i_should_see_the_publish_button
-    and_i_click_the_publish_link
+    then_i_see_the_changes_are_now_live_message
+    and_i_do_not_see_the_publish_button
     then_i_see_the_content_on_find
+    and_the_course_is_open
+  end
+
+  scenario "changes to a closed published course go live without opening the course" do
+    and_i_have_previously_published_a_closed_course
+    when_i_make_some_new_changes
+    then_i_see_the_changes_are_now_live_message
+    and_i_do_not_see_the_publish_button
+    then_i_see_the_content_on_find
+    and_the_course_is_closed
   end
 
   scenario "attempting to publish with errors" do
@@ -63,6 +69,11 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     and_i_click_the_publish_link
     then_i_should_see_a_success_message
     and_the_course_is_published
+  end
+
+  def and_i_have_previously_published_a_closed_course
+    and_i_have_previously_published_a_course
+    course.update!(application_status: :closed)
   end
 
   def and_there_is_a_draft_course_i_want_to_publish
@@ -125,6 +136,10 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     expect(course.reload).to be_application_status_open
   end
 
+  def and_the_course_is_closed
+    expect(course.reload).to be_application_status_closed
+  end
+
   def when_i_make_some_new_changes
     # Interview process and location
     visit fields_interview_process_publish_provider_recruitment_cycle_course_path(
@@ -182,34 +197,20 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     click_on "Update fees and financial support"
   end
 
-  def then_i_should_see_the_unpublished_changes_message
-    expect(page).to have_content("* Unpublished changes")
+  def then_i_see_the_changes_are_now_live_message
+    within(".govuk-notification-banner--success") do
+      expect(page).to have_content("These changes are now live.")
+      expect(page).to have_no_content("* Unpublished changes")
+    end
+  end
+
+  def and_i_do_not_see_the_publish_button
+    when_i_return_to_publish
+    expect(publish_provider_courses_show_page.course_button_panel).to have_no_publish_button
   end
 
   def and_i_visit_the_course_page
     visit find_course_url(provider.provider_code, course.course_code)
-  end
-
-  def and_i_do_not_see_the_unpublished_content_on_find
-    expect(page).to have_no_content("some new interview process content")
-    expect(page).to have_no_content("Online interviews are available for this course")
-
-    expect(page).to have_no_content("some new theoretical training content")
-    expect(page).to have_no_content("some new assessment methods content")
-
-    expect(page).to have_no_content("some new what will trainees do on placements content")
-    expect(page).to have_no_content("some new how will they be supported and mentored content")
-
-    expect(page).to have_no_content("some new how do you decide which schools to place trainees in content")
-    expect(page).to have_no_content("some new how much time will they spend in each school content")
-    expect(page).to have_no_content("some new where will theoretical training take place content")
-    expect(page).to have_no_content("some new how much time will they spend in theoretical training content")
-
-    expect(page).to have_no_content("£10,000")
-    expect(page).to have_no_content("£9,000")
-    expect(page).to have_no_content("some new when are the fees due content")
-    expect(page).to have_no_content("some new additional fees or costs content")
-    expect(page).to have_no_content("some new financial support content")
   end
 
   def then_i_see_the_content_on_find
@@ -240,10 +241,6 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
     publish_provider_courses_show_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
     )
-  end
-
-  def and_i_should_see_the_publish_button
-    expect(publish_provider_courses_show_page.course_button_panel.publish_button).to be_visible
   end
 
   def then_i_should_see_an_error_message_for_the_gcses

--- a/spec/system/publish/courses/publishing_a_course_spec.rb
+++ b/spec/system/publish/courses/publishing_a_course_spec.rb
@@ -205,7 +205,6 @@ RSpec.describe "Publishing courses", travel: mid_cycle(2026) do
   def then_i_see_the_changes_are_now_live_message
     within(".govuk-notification-banner--success") do
       expect(page).to have_content("These changes are now live.")
-      expect(page).to have_no_content("* Unpublished changes")
     end
   end
 

--- a/spec/system/publish/editing_fees_and_financial_support_spec.rb
+++ b/spec/system/publish/editing_fees_and_financial_support_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Editing fees and financial support section" do
 
     when_i_enter_information_into_the_fees_and_financial_support_field
     and_i_submit_the_form
+    and_i_confirm_publishing_live_changes
     then_fees_and_financial_support_data_has_changed
 
     when_i_visit_the_fees_and_financial_support_edit_page

--- a/spec/system/publish/viewing_a_course_spec.rb
+++ b/spec/system/publish/viewing_a_course_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe "Course show" do
     end
   end
 
-  describe "with a published with unpublished changes course" do
-    scenario "i can view the unpublished partial" do
-      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_unpublished_changes], funding_type: "salary"))
+  describe "with a published course that has a legacy subsequent draft" do
+    scenario "i can view the published partial" do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [build(:course_enrichment, :published), course_enrichment_unpublished_changes], funding_type: "salary"))
       when_i_visit_the_course_page
       then_i_should_see_the_description_of_the_unpublished_changes_course
       and_i_should_see_the_course_button_panel
-      and_i_should_see_the_unpublished_with_changes_partial
+      and_i_should_see_the_published_partial
       and_i_should_not_see_the_rollover_button
     end
   end
@@ -207,14 +207,6 @@ private
 
   alias_method :then_i_should_see_the_course_button_panel, :and_i_should_see_the_course_button_panel
 
-  def and_i_should_see_the_unpublished_with_changes_partial
-    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
-      expect(course_button_panel).to have_publish_button
-      expect(course_button_panel).to have_withdraw_link
-      expect(course_button_panel).to have_last_publish_date
-    end
-  end
-
   def and_i_should_see_the_unpublished_partial
     publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
       expect(course_button_panel).to have_publish_button
@@ -229,6 +221,7 @@ private
       expect(course_button_panel).to have_withdraw_link
       expect(course_button_panel).to have_last_publish_date
       expect(course_button_panel).not_to have_delete_link
+      expect(course_button_panel).not_to have_publish_button
     end
   end
 

--- a/spec/system/publish/viewing_a_course_spec.rb
+++ b/spec/system/publish/viewing_a_course_spec.rb
@@ -61,7 +61,15 @@ RSpec.describe "Course show" do
 
   describe "with a published course that has a legacy subsequent draft" do
     scenario "i can view the published partial" do
-      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [build(:course_enrichment, :published), course_enrichment_unpublished_changes], funding_type: "salary"))
+      given_i_am_authenticated_as_a_provider_user(
+        course: build(
+          :course,
+          :salary,
+          enrichments: [build(:course_enrichment, :published), course_enrichment_unpublished_changes],
+          application_status: "open",
+          site_statuses: [build(:site_status, :findable)],
+        ),
+      )
       when_i_visit_the_course_page
       then_i_should_see_the_description_of_the_unpublished_changes_course
       and_i_should_see_the_course_button_panel

--- a/spec/view_objects/publish/courses/confirm_live_changes_view_spec.rb
+++ b/spec/view_objects/publish/courses/confirm_live_changes_view_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Publish::Courses::ConfirmLiveChangesView do
+  subject(:view) do
+    described_class.new(
+      course:,
+      section_name:,
+      form:,
+      form_param_key:,
+      fields:,
+      update_path: "/update",
+      back_path: "/back",
+      cancel_path: "/cancel",
+      method: :patch,
+      extra_hidden_fields:,
+    )
+  end
+
+  let(:course) { build(:course, name: "Primary", course_code: "X123") }
+  let(:section_name) { "What you will study" }
+  let(:form_param_key) { :publish_fields_what_you_will_study_form }
+  let(:fields) { %i[theoretical_training_activities subjects] }
+  let(:extra_hidden_fields) { { "#{form_param_key}[goto_preview]" => "true" } }
+  let(:form) do
+    Struct.new(:theoretical_training_activities, :subjects).new(
+      "Seminars and workshops",
+      %w[maths english],
+    )
+  end
+
+  describe "#page_title" do
+    it "returns the translated page title for the section" do
+      expect(view.page_title).to eq(
+        "Are you sure you want to publish your changes to 'What you will study'?",
+      )
+    end
+  end
+
+  describe "#heading" do
+    it "returns the translated heading for the section" do
+      expect(view.heading).to eq(
+        "Are you sure you want to publish your changes to 'What you will study'?",
+      )
+    end
+  end
+
+  describe "#body" do
+    it "returns the translated body" do
+      expect(view.body).to eq("Your changes will go live immediately.")
+    end
+  end
+
+  describe "#continue_label" do
+    it "returns the translated continue label" do
+      expect(view.continue_label).to eq("Continue and publish changes")
+    end
+  end
+
+  describe "#course_name_and_code" do
+    it "returns the course name and code" do
+      expect(view.course_name_and_code).to eq("Primary (X123)")
+    end
+  end
+
+  describe "#fields" do
+    context "when a single field is passed" do
+      let(:fields) { :theoretical_training_activities }
+
+      it "wraps the field in an array" do
+        expect(view.fields).to eq(%i[theoretical_training_activities])
+      end
+    end
+  end
+
+  describe "#each_hidden_field" do
+    it "yields scalar fields, array fields, and extra hidden fields" do
+      expect { |block| view.each_hidden_field(&block) }.to yield_successive_args(
+        ["#{form_param_key}[theoretical_training_activities]", "Seminars and workshops"],
+        ["#{form_param_key}[subjects][]", "maths"],
+        ["#{form_param_key}[subjects][]", "english"],
+        ["#{form_param_key}[goto_preview]", "true"],
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

Providers currently edit published courses into a separate draft enrichment (“unpublished changes”), then must click **Publish course** again for Find to update. That second publish also opens the course if it was closed.

We want edits to already-published courses to go live on Find as soon as they’re saved, without a republish step, and without opening a closed course. Draft / rolled-over courses still need an explicit first publish.

- Saving a published course no longer creates a subsequent draft enrichment — we edit the published enrichment in place.
- Closed published courses still update Find content; `application_status` is unchanged.
- Existing subsequent drafts are **deleted** on go-live (not published), so leftover unpublished content does not appear on Find.
- Before save, published-course section edits show a confirmation interstitial (“Your changes will go live immediately.”). Schools and study sites are excluded.

## Changes proposed in this pull request

**Remove unpublished changes**
- `Course#find_or_initialize_draft` returns the published enrichment for already-published courses.
- `has_unpublished_changes?` is always false; content status / queries / public API no longer expose `published_with_unpublished_changes`.
- Published course UI: remove republish / “unpublished changes” status treatment; preview / view-live behaviour stays.
- Success flash for published edits: “These changes are now live.”
- Data migration deletes subsequent draft enrichments (`last_published_timestamp_utc` set).

**Live-changes interstitial**
- Shared concern + view object + confirm page; values re-posted via hidden fields + `confirm_publish=true`.
- Wired into eligible course section updates; **not** schools / study sites, open/close, withdraw, delete, rollover, or first publish.
- Draft courses still save immediately (no interstitial).

## Guidance to review

1. **Published open course** — edit e.g. What you will study / age range → interstitial → continue → Find shows the change; success body “These changes are now live.”
2. **Published closed course** — same edit path; Find content updates; course stays closed.
3. **Draft course** — edit saves with no interstitial; still needs Publish course to open.
4. **Schools** — update on a published course has **no** interstitial.
5. **Cancel / Back** on interstitial — cancel to course show/details; back to the edit page; nothing saved until confirm.
6. Spot-check course list status filters still treat published (incl. legacy subsequent drafts as published) correctly.

Worth extra scrutiny: `Publish::Courses::Query` content-status SQL after the main rebase, and the delete migration (destructive for leftover subsequent drafts).

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.