### PR TITLE
Prevent closed schools from being rolled over

### DIFF
--- a/app/models/course/school.rb
+++ b/app/models/course/school.rb
@@ -11,6 +11,10 @@ class Course::School < ApplicationRecord
   belongs_to :gias_school
   belongs_to :provider_school, class_name: "Provider::School", inverse_of: :course_schools
 
+  # Course schools whose GIAS record is still available (i.e. not closed).
+  # Used to keep closed schools out of the rollover copy path.
+  scope :with_available_gias_school, -> { joins(:gias_school).merge(GiasSchool.available) }
+
   delegate :provider, :recruitment_cycle, to: :course, allow_nil: true
 
   validates :provider_school_id, uniqueness: { scope: :course_id }

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -14,6 +14,10 @@ class Provider::School < ApplicationRecord
 
   has_many :course_schools, class_name: "Course::School", inverse_of: :provider_school, dependent: :destroy
 
+  # Provider schools whose GIAS record is still available (i.e. not closed).
+  # Used to keep closed schools out of the rollover.
+  scope :with_available_gias_school, -> { joins(:gias_school).merge(GiasSchool.available) }
+
   delegate :recruitment_cycle, :provider_code, to: :provider, allow_nil: true
   delegate :urn, :address1, :address2, :address3, :town, :postcode, to: :gias_school
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -60,6 +60,18 @@ class Site < ApplicationRecord
 
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil) }
 
+  # Sites backed by an available GIAS school. Effectively a join on urn (Site
+  # has no foreign key to gias_school) without selecting the GIAS columns, so a
+  # urn matching no GIAS row is excluded rather than passed through - from 2026
+  # every school site's urn matches a GIAS record, and an earlier cycle's
+  # unmatched urn is uncleansed data, not a school we can vouch for.
+  #
+  # Main sites are the one exemption: they are legitimately urn-less
+  # (see the urn presence validation above), so they are always kept.
+  scope :with_available_gias_school, lambda {
+    where(urn: nil).or(where(urn: GiasSchool.available.select(:urn)))
+  }
+
   attr_accessor :skip_geocoding
 
   after_commit :geocode_site, unless: :skip_geocoding

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -161,13 +161,8 @@ module Courses
       @school_sites ||= sites.select(&:school?)
     end
 
-    # Only map selectable (non-closed) GIAS schools into the new model. A site
-    # can still point at a school the GIAS import later flipped to closed; we
-    # intentionally leave that school out of course.schools (the legacy
-    # course.sites write above still keeps the site) so the new model never
-    # gains a closed school. `available` excludes only `closed`.
     def gias_schools_by_urn
-      @gias_schools_by_urn ||= GiasSchool.available
+      @gias_schools_by_urn ||= GiasSchool
         .where(urn: school_sites.map(&:urn).compact_blank)
         .index_by(&:urn)
     end

--- a/app/services/rollover/schools/course_copier.rb
+++ b/app/services/rollover/schools/course_copier.rb
@@ -7,7 +7,7 @@ module Rollover
         lookup = new_provider_schools(new_provider)
         existing = new_course.schools.index_by(&:provider_school_id)
 
-        course.schools.includes(:provider_school).find_each do |course_school|
+        course.schools.with_available_gias_school.includes(:provider_school).find_each do |course_school|
           old_provider_school = course_school.provider_school
           new_provider_school = lookup[[old_provider_school.gias_school_id, old_provider_school.site_code]]
 

--- a/app/services/rollover/schools/legacy_course_copier.rb
+++ b/app/services/rollover/schools/legacy_course_copier.rb
@@ -10,7 +10,7 @@ module Rollover
       def call(course:, new_provider:, new_course:)
         lookup = new_provider_sites(new_provider)
 
-        course.sites.each do |site|
+        course.sites.with_available_gias_school.each do |site|
           new_site = lookup[site.code]
           site_copier.call(new_site:, new_course:) if new_site.present?
         end

--- a/app/services/rollover/schools/legacy_provider_copier.rb
+++ b/app/services/rollover/schools/legacy_provider_copier.rb
@@ -10,7 +10,7 @@ module Rollover
       def execute(provider:, new_provider:)
         result = { copied: 0, skipped: [] }
 
-        provider.sites.each do |site|
+        provider.sites.with_available_gias_school.each do |site|
           site_result = site_copier.execute(site:, new_provider:)
 
           if site_result.success?

--- a/app/services/rollover/schools/provider_copier.rb
+++ b/app/services/rollover/schools/provider_copier.rb
@@ -5,8 +5,9 @@ module Rollover
     class ProviderCopier
       def execute(provider:, new_provider:)
         existing = new_provider.schools.index_by { |school| [school.gias_school_id, school.site_code] }
+        schools = provider.schools.with_available_gias_school
 
-        provider.schools.each do |provider_school|
+        schools.each do |provider_school|
           key = [provider_school.gias_school_id, provider_school.site_code]
           next if existing.key?(key)
 
@@ -16,7 +17,7 @@ module Rollover
           )
         end
 
-        { copied: provider.schools.size, skipped: [] }
+        { copied: schools.size, skipped: [] }
       end
     end
   end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -22,6 +22,15 @@ FactoryBot.define do
       age { nil }
     end
 
+    # Only needed by specs exercising Site.with_available_gias_school, i.e. the
+    # legacy rollover copiers. An existing row for the urn is never replaced, so
+    # a spec wanting a closed school creates it first.
+    trait :with_gias_school do
+      after(:build) do |site|
+        create(:gias_school, :open, urn: site.urn) unless GiasSchool.exists?(urn: site.urn)
+      end
+    end
+
     trait :study_site do
       site_type { "study_site" }
     end

--- a/spec/models/course/school_spec.rb
+++ b/spec/models/course/school_spec.rb
@@ -11,6 +11,15 @@ describe Course::School do
     it { is_expected.to belong_to(:provider_school).class_name("Provider::School").required }
   end
 
+  describe ".with_available_gias_school" do
+    it "excludes course schools whose GIAS record is closed" do
+      available = create(:course_school, gias_school: create(:gias_school, :open))
+      create(:course_school, gias_school: create(:gias_school, :closed))
+
+      expect(described_class.with_available_gias_school).to contain_exactly(available)
+    end
+  end
+
   describe "validations" do
     it "creates a valid record" do
       expect(course_school).to be_valid

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -11,6 +11,15 @@ describe Provider::School do
     it { is_expected.to have_many(:course_schools).class_name("Course::School").dependent(:destroy) }
   end
 
+  describe ".with_available_gias_school" do
+    it "excludes provider schools whose GIAS record is closed" do
+      available = create(:provider_school, gias_school: create(:gias_school, :open))
+      create(:provider_school, gias_school: create(:gias_school, :closed))
+
+      expect(described_class.with_available_gias_school).to contain_exactly(available)
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:site_code) }
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -13,6 +13,29 @@ describe Site do
     it { is_expected.to be_audited.associated_with(:provider) }
   end
 
+  describe ".with_available_gias_school" do
+    it "excludes a site whose GIAS school has closed" do
+      create(:gias_school, :closed, urn: "654321")
+      closed_site = create(:site, provider:, urn: "654321")
+      available_site = create(:site, provider:, urn: create(:gias_school, :open).urn)
+
+      expect(described_class.with_available_gias_school).to include(available_site)
+      expect(described_class.with_available_gias_school).not_to include(closed_site)
+    end
+
+    it "excludes a site whose URN matches no GIAS school" do
+      unmatched_site = create(:site, provider:, urn: "999999")
+
+      expect(described_class.with_available_gias_school).not_to include(unmatched_site)
+    end
+
+    it "keeps a main site, which is legitimately urn-less" do
+      main_site = create(:site, :main_site, provider:)
+
+      expect(described_class.with_available_gias_school).to include(main_site)
+    end
+  end
+
   describe "school" do
     it { is_expected.to validate_presence_of(:location_name) }
     it { is_expected.to validate_presence_of(:address1) }

--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe "Support::CopyCourses" do
     end
 
     context "with schools" do
+      # The copier only carries over sites backed by an available GIAS school,
+      # and the course factory's sites use a urn sequence that matches none.
+      before do
+        source_provider.courses.flat_map(&:sites).each { |site| create(:gias_school, :open, urn: site.urn) }
+      end
+
       it "copies the courses with schools" do
         login_user(user)
         post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { "course[autocompleted_provider_code]" => source_provider.provider_code, schools: "1" }

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe Courses::CopyToProviderService do
   end
 
   context "the original course has schools" do
-    let(:site) { create(:site, :school, provider:) }
+    let(:site) { create(:site, :school, :with_gias_school, provider:) }
     let!(:new_site) { create(:site, :school, provider: new_provider, code: site.code) }
     let!(:site_status) do
       create(:site_status,

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -564,8 +564,8 @@ describe Courses::CreationService do
 
     context "when the selected site's GIAS school is closed" do
       # A site can still point at a school the GIAS import later flipped to
-      # closed. We must not build a Course::School for it, but the legacy site
-      # is still attached.
+      # closed. Both models have to record it, or the course would lose the
+      # school the moment the new-school-model flag is switched on.
       let!(:gias_school) { create(:gias_school, :closed, urn: site.urn) }
       let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: "-") }
 
@@ -574,8 +574,8 @@ describe Courses::CreationService do
         allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(false)
       end
 
-      it "builds no Course::School but still attaches the legacy site" do
-        expect(created_course.schools).to be_empty
+      it "builds the Course::School alongside the legacy site" do
+        expect(created_course.schools.map(&:gias_school_id)).to eq([gias_school.id])
         expect(created_course.sites.map(&:id)).to eq([site.id])
       end
     end

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe Providers::CopyToRecruitmentCycleService do
   describe "#execute" do
-    let(:site) { build(:site, :school) }
+    let(:site) { build(:site, :school, :with_gias_school) }
     let(:study_site) { build(:site, :study_site) }
     let(:published_course_enrichment) { build(:course_enrichment, :published) }
     let(:course_enrichments) { [published_course_enrichment] }

--- a/spec/services/rollover/schools/course_copier_spec.rb
+++ b/spec/services/rollover/schools/course_copier_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe Rollover::Schools::CourseCopier do
   it "does not create legacy site statuses" do
     expect { copy_schools }.not_to change(new_course.site_statuses, :count)
   end
+
+  context "when a course school's GIAS record has closed" do
+    let(:closed_gias_school) { create(:gias_school, :closed) }
+    let!(:closed_course_school) do
+      closed_provider_school = create(:provider_school, provider:, gias_school: closed_gias_school, site_code: "Z")
+      create(:course_school, course:, provider_school: closed_provider_school, gias_school: closed_gias_school, site_code: "Z")
+    end
+    # Deliberately no matching Provider::School on new_provider: the closed school
+    # is not rolled over, so CourseCopier must skip it rather than raise.
+
+    it "does not copy it and does not raise" do
+      expect { copy_schools }.not_to raise_error
+
+      expect(new_course.schools.pluck(:gias_school_id)).not_to include(closed_gias_school.id)
+    end
+  end
 end

--- a/spec/services/rollover/schools/dual_course_copier_spec.rb
+++ b/spec/services/rollover/schools/dual_course_copier_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Rollover::Schools::DualCourseCopier do
 
   let(:provider) { create(:provider) }
   let(:new_provider) { create(:provider, recruitment_cycle: create(:recruitment_cycle, :next)) }
-  let!(:legacy_site) { create(:site, provider:, code: "S") }
+  let!(:legacy_site) { create(:site, :with_gias_school, provider:, code: "S") }
   let!(:provider_school) { create(:provider_school, provider:, site_code: "B") }
   let(:course) { create(:course, provider:) }
   let!(:site_status) { create(:site_status, course:, site: legacy_site, status: :running) }
@@ -59,5 +59,23 @@ RSpec.describe Rollover::Schools::DualCourseCopier do
       provider_school_id: new_provider_school.id,
       gias_school_id: course_school.gias_school_id,
     )
+  end
+
+  it "copies neither the SiteStatus nor the Course::School when the GIAS record has closed" do
+    closed_gias_school = create(:gias_school, :closed)
+
+    closed_site = create(:site, provider:, code: "Z", urn: closed_gias_school.urn)
+    create(:site_status, course:, site: closed_site, status: :running)
+    # A matching new site exists, so exclusion must come from the availability
+    # filter rather than merely a missing destination site.
+    create(:site, provider: new_provider, code: "Z", urn: closed_gias_school.urn)
+
+    closed_provider_school = create(:provider_school, provider:, gias_school: closed_gias_school, site_code: "Y")
+    create(:course_school, course:, provider_school: closed_provider_school, gias_school: closed_gias_school, site_code: "Y")
+
+    copy_schools
+
+    expect(new_course.site_statuses.map { |site_status| site_status.site.code }).not_to include("Z")
+    expect(new_course.schools.pluck(:gias_school_id)).not_to include(closed_gias_school.id)
   end
 end

--- a/spec/services/rollover/schools/dual_provider_copier_spec.rb
+++ b/spec/services/rollover/schools/dual_provider_copier_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Rollover::Schools::DualProviderCopier do
 
   let(:provider) { create(:provider) }
   let(:new_provider) { create(:provider, recruitment_cycle: create(:recruitment_cycle, :next)) }
-  let!(:legacy_site) { create(:site, provider:, code: "S") }
+  let!(:legacy_site) { create(:site, :with_gias_school, provider:, code: "S") }
   let!(:provider_school) { create(:provider_school, provider:, site_code: "B") }
 
   it "copies both legacy Site and new Provider::School records" do
@@ -28,5 +28,16 @@ RSpec.describe Rollover::Schools::DualProviderCopier do
 
   it "returns the legacy result used by rollover reporting" do
     expect(copy_schools).to eq(copied: 1, skipped: [])
+  end
+
+  it "copies neither the legacy Site nor the Provider::School when the GIAS record has closed" do
+    closed_gias_school = create(:gias_school, :closed)
+    create(:site, provider:, code: "Z", urn: closed_gias_school.urn)
+    create(:provider_school, provider:, gias_school: closed_gias_school, site_code: "Z")
+
+    copy_schools
+
+    expect(new_provider.sites.pluck(:code)).to contain_exactly(legacy_site.code)
+    expect(new_provider.schools.pluck(:site_code)).to contain_exactly(provider_school.site_code)
   end
 end

--- a/spec/services/rollover/schools/provider_copier_spec.rb
+++ b/spec/services/rollover/schools/provider_copier_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe Rollover::Schools::ProviderCopier do
 
     expect(new_provider.schools.count).to eq(2)
   end
+
+  it "does not copy a provider school whose GIAS record has closed" do
+    create(:provider_school, provider:, gias_school: create(:gias_school, :closed), site_code: "C")
+
+    copy_schools
+
+    expect(new_provider.schools.pluck(:site_code)).not_to include("C")
+  end
 end


### PR DESCRIPTION
## Context

Rollover carried every school forward regardless of its GIAS status, so a
school that closed during the cycle reappeared on the new provider and its
courses, and had to be removed by hand.


## Changes proposed in this pull request


- Add scopes that can identify Sites and schools that have closed GIAS schools.
Those schools will not be rolled over to the new cycle.
- Allow closed schools to be added to the a new course by removing the `available` scope on the `Course::CreationService` so that sites and schools stay consistent.

This process will be communicated to the providers in rollover comms.



## Guidance to review

I ran rollover on this review app and tested that no closed schools were rolled over.

<img width="887" height="454" alt="image" src="https://github.com/user-attachments/assets/0c549de0-075d-4af7-8bf2-b771462010a2" />


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
