### PR TITLE
Dual write schools indefinitely

### DIFF
--- a/app/controllers/publish/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/publish/providers/schools/check_multiple_controller.rb
@@ -14,7 +14,7 @@ module Publish
 
           gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
-              saved_schools << create_provider_school(gias_school:)
+              saved_schools << create_provider_school_and_legacy_site(gias_school:)
             end
           end
 
@@ -53,19 +53,6 @@ module Publish
 
         def provider
           @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
-        end
-
-        def create_provider_school(gias_school:)
-          # We stop creating legacy sites in 2027, this if statement takes care of this
-          if provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
-            create_only_provider_school(gias_school:)
-          else
-            create_provider_school_and_legacy_site(gias_school:)
-          end
-        end
-
-        def create_only_provider_school(gias_school:)
-          ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
         end
 
         # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective

--- a/app/controllers/publish/providers/schools/checks_controller.rb
+++ b/app/controllers/publish/providers/schools/checks_controller.rb
@@ -11,7 +11,7 @@ module Publish
 
         def update
           provider_school = ActiveRecord::Base.transaction do
-            create_provider_school
+            create_provider_school_and_legacy_site
           end
 
           redirect_to publish_provider_recruitment_cycle_schools_path,
@@ -21,19 +21,6 @@ module Publish
         end
 
       private
-
-        def create_provider_school
-          # We stop creating legacy sites in 2027, this if statement takes care of this
-          if provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
-            create_only_provider_school
-          else
-            create_provider_school_and_legacy_site
-          end
-        end
-
-        def create_only_provider_school
-          ::ProviderSchools::Creator.call(provider: @provider, gias_school_id: school_id)
-        end
 
         # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
         # TODO School data remodel removal - remove this legacy Site write when publish creates Provider::School directly.

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -43,24 +43,11 @@ module Support
 
           gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
-              saved_schools << create_provider_school(gias_school:)
+              saved_schools << create_provider_school_and_legacy_site(gias_school:)
             end
           end
 
           schools_added_message(saved_schools)
-        end
-
-        def create_provider_school(gias_school:)
-          # We stop creating legacy sites in 2027, this if statement takes care of this
-          if provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
-            create_only_provider_school(gias_school:)
-          else
-            create_provider_school_and_legacy_site(gias_school:)
-          end
-        end
-
-        def create_only_provider_school(gias_school:)
-          ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
         end
 
         # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -12,7 +12,7 @@ module Support
           saved = false
 
           ActiveRecord::Base.transaction do
-            saved = create_provider_school
+            saved = create_provider_school_with_legacy_site
           end
 
           if saved
@@ -27,15 +27,6 @@ module Support
 
         def new_form
           @school_form = SchoolForm.new(provider, site, params: { gias_school_id: params[:school_id] })
-        end
-
-        def create_provider_school
-          # We stop creating legacy sites in 2027, this if statement takes care of this
-          if provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
-            create_provider_school_without_legacy_site
-          else
-            create_provider_school_with_legacy_site
-          end
         end
 
         def create_provider_school_with_legacy_site
@@ -54,11 +45,6 @@ module Support
           end
 
           saved
-        end
-
-        def create_provider_school_without_legacy_site
-          ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
-          true
         end
 
         # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective

--- a/spec/system/publish/providers/schools/add_school_spec.rb
+++ b/spec/system/publish/providers/schools/add_school_spec.rb
@@ -37,20 +37,6 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
     and_the_provider_school_row_is_created
   end
 
-  scenario "with new school after the schools remodel cycle" do
-    given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
-    when_i_visit_the_schools_page
-    when_i_click_add_a_school
-    then_i_am_on_the_school_search_page
-
-    when_i_search_with_an_partial_query
-    when_i_choose_the_school_i_want_to_add
-    when_i_click_add_school
-
-    then_i_see_a_confirmation_message
-    and_only_the_provider_school_row_is_created
-  end
-
   scenario "attempting to add a school with duplicate URN" do
     given_the_provider_already_has_a_school_with_the_same_urn
 
@@ -74,12 +60,6 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
       town: "Newtown",
       postcode: "RD9 0AN",
     })
-  end
-
-  def given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
-    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
-    future_provider = create(:provider, recruitment_cycle:)
-    given_i_am_authenticated(user: create(:user, providers: [future_provider]))
   end
 
   def given_i_see_the_schools_guidance_text
@@ -209,14 +189,5 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
 
   def and_no_provider_school_row_is_created
     expect(provider.schools.where(gias_school_id: @gias_school.id)).to be_empty
-  end
-
-  def and_only_the_provider_school_row_is_created
-    expect(provider.sites.find_by(urn: @gias_school.urn)).to be_nil
-
-    provider_school = provider.schools.find_by(gias_school_id: @gias_school.id)
-    expect(provider_school).to be_present
-    expect(provider_school.site_code).to be_present
-    expect(provider_school.uuid).to be_present
   end
 end

--- a/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
@@ -32,19 +32,6 @@ RSpec.describe "Multiple schools" do
     and_i_see_the_success_message
   end
 
-  scenario "when adding schools after the schools remodel cycle" do
-    given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
-
-    when_i_visit_the_multiple_schools_new_page
-    and_i_fill_in_the_urns_with_a_mixture_of_new_lines_and_comma
-    and_i_click_continue
-    when_i_click_add_schools
-
-    then_i_am_redirected_to_the_school_index
-    and_only_provider_school_rows_are_created_for_each
-    and_i_see_the_success_message
-  end
-
   scenario "when there are over 50 urns" do
     when_i_visit_the_multiple_schools_new_page
     and_i_enter_51_urns
@@ -126,12 +113,6 @@ RSpec.describe "Multiple schools" do
     @gias_schools = create_list(:gias_school, 3)
   end
 
-  def given_i_am_authenticated_as_a_provider_user_after_the_schools_remodel_cycle
-    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
-    future_provider = create(:provider, recruitment_cycle:)
-    given_i_am_authenticated(user: create(:user, providers: [future_provider]))
-  end
-
   def and_i_fill_in_the_urns_with_a_mixture_of_new_lines_and_comma
     urns = @gias_schools.map(&:urn)
     input = "  #{urns[0]},#{urns[1]}\n\n#{urns[2]}"
@@ -155,17 +136,6 @@ RSpec.describe "Multiple schools" do
       expect(provider_school).to be_present
       expect(provider_school.site_code).to eq(site.code)
       expect(provider_school.uuid).to eq(site.uuid)
-    end
-  end
-
-  def and_only_provider_school_rows_are_created_for_each
-    @gias_schools.each do |gias_school|
-      expect(provider.sites.find_by(urn: gias_school.urn)).to be_nil
-
-      provider_school = provider.schools.find_by(gias_school_id: gias_school.id)
-      expect(provider_school).to be_present
-      expect(provider_school.site_code).to be_present
-      expect(provider_school.uuid).to be_present
     end
   end
 

--- a/spec/system/support/providers/schools/add_school_to_provider_spec.rb
+++ b/spec/system/support/providers/schools/add_school_to_provider_spec.rb
@@ -34,19 +34,6 @@ RSpec.describe "Adding school to provider as an admin" do
       and_the_provider_school_row_is_created
     end
 
-    scenario "with new school after the schools remodel cycle" do
-      and_there_is_a_provider_after_the_schools_remodel_cycle
-
-      given_i_visit_the_support_provider_schools_index_page
-      and_i_click_add_school
-      when_i_search_with_an_partial_query
-      when_i_choose_the_school_i_want_to_add
-      when_i_click_add_school
-
-      then_i_see_a_confirmation_message
-      and_only_the_provider_school_row_is_created
-    end
-
     scenario "i can select a school using the autocomplete", :js do
       given_i_visit_the_support_provider_schools_index_page
       and_i_click_add_school
@@ -105,11 +92,6 @@ RSpec.describe "Adding school to provider as an admin" do
 
   def and_there_is_a_provider
     @provider = create(:provider, provider_name: "School of Cats", provider_code: "V01")
-  end
-
-  def and_there_is_a_provider_after_the_schools_remodel_cycle
-    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
-    @provider = create(:provider, provider_name: "School of Cats", provider_code: "V02", recruitment_cycle:)
   end
 
   def and_there_is_a_gias_school
@@ -226,14 +208,5 @@ RSpec.describe "Adding school to provider as an admin" do
     expect(provider_school).to be_present
     expect(provider_school.site_code).to eq(added_site.code)
     expect(provider_school.uuid).to eq(added_site.uuid)
-  end
-
-  def and_only_the_provider_school_row_is_created
-    expect(@provider.sites.find_by(urn: @gias_school.urn)).to be_nil
-
-    provider_school = @provider.schools.find_by(gias_school_id: @gias_school.id)
-    expect(provider_school).to be_present
-    expect(provider_school.site_code).to be_present
-    expect(provider_school.uuid).to be_present
   end
 end

--- a/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
@@ -30,19 +30,6 @@ RSpec.describe "Multiple schools" do
     and_i_see_the_success_message
   end
 
-  scenario "when adding schools after the schools remodel cycle" do
-    given_the_provider_is_after_the_schools_remodel_cycle
-
-    when_i_visit_the_multiple_schools_new_page
-    and_i_fill_in_the_urns_with_a_mixture_of_new_lines_and_comma
-    and_i_click_continue
-    when_i_click_add_schools
-
-    then_i_am_redirected_to_the_school_index
-    and_only_provider_school_rows_are_created_for_each
-    and_i_see_the_success_message
-  end
-
   scenario "when there are over 50 urns" do
     when_i_visit_the_multiple_schools_new_page
     and_i_enter_51_urns
@@ -117,11 +104,6 @@ RSpec.describe "Multiple schools" do
     @gias_schools = create_list(:gias_school, 3)
   end
 
-  def given_the_provider_is_after_the_schools_remodel_cycle
-    recruitment_cycle = create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
-    @provider = create(:provider, recruitment_cycle:)
-  end
-
   def and_i_fill_in_the_urns_with_a_mixture_of_new_lines_and_comma
     urns = @gias_schools.map(&:urn)
     input = "  #{urns[0]},#{urns[1]}\n\n#{urns[2]}"
@@ -145,17 +127,6 @@ RSpec.describe "Multiple schools" do
       expect(provider_school).to be_present
       expect(provider_school.site_code).to eq(site.code)
       expect(provider_school.uuid).to eq(site.uuid)
-    end
-  end
-
-  def and_only_provider_school_rows_are_created_for_each
-    @gias_schools.each do |gias_school|
-      expect(@provider.sites.find_by(urn: gias_school.urn)).to be_nil
-
-      provider_school = @provider.schools.find_by(gias_school_id: gias_school.id)
-      expect(provider_school).to be_present
-      expect(provider_school.site_code).to be_present
-      expect(provider_school.uuid).to be_present
     end
   end
 


### PR DESCRIPTION
## Context

We have now planned to continue dual writing Site and Provider::School next cycle.

## Changes proposed in this pull request

Continue to dual write both Site and Provider::School models regardless of RecruitmentCycle.
I can't find anyother places that need correcting.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
