### PR TITLE
Fix unique course validator

### DIFF
--- a/app/validators/unique_course_validator.rb
+++ b/app/validators/unique_course_validator.rb
@@ -10,7 +10,9 @@ class UniqueCourseValidator < ActiveModel::Validator
 private
 
   def course_is_unique?(new_course)
-    existing_courses = new_course.provider.courses
+    existing_courses = new_course&.provider&.courses
+    return true if existing_courses.blank?
+
     new_course_attributes = new_course.attributes.slice(*attributes_to_compare)
     existing_courses.none? do |existing_course|
       existing_course_attributes = existing_course.attributes.slice(*attributes_to_compare)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -31,6 +31,12 @@ describe Course do
     end
   end
 
+  describe "new course is invalid for new validations" do
+    subject { described_class.new }
+
+    it { is_expected.to be_invalid(:new) }
+  end
+
   describe "#campaign_name" do
     it "assigns the campaign" do
       course.engineers_teach_physics!


### PR DESCRIPTION
## Context

  Without returning early, the code will trigger exceptions calling
  methods on the course and allegeed associations.
  If the new course doesn't have a provider assigned,
  new_course.provider returns nil

## Changes proposed in this pull request

Do not let the unique course validator raise NoMethodError when validating

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
