### PR TITLE
Improve copy course content

### DIFF
--- a/app/controllers/concerns/copy_course_content.rb
+++ b/app/controllers/concerns/copy_course_content.rb
@@ -43,5 +43,21 @@ private
 
     @courses_by_accrediting_provider&.transform_values! { |v| v.reject { |x| x.id == course.id } }
     @self_accredited_courses = @self_accredited_courses&.reject { |c| c.id == course.id }
+
+    set_visible_course_information_fields
+  end
+
+  def set_visible_course_information_fields
+    courses =
+      Array(@self_accredited_courses) +
+      @courses_by_accrediting_provider.values.flatten
+
+    @visible_course_information_fields =
+      Publish::CourseList::FIELDS.keys.select do |key|
+        courses
+          .map(&Publish::CourseList::FIELDS.fetch(key))
+          .uniq
+          .size > 1
+      end
   end
 end

--- a/app/views/publish/courses/_course_select_option.html.erb
+++ b/app/views/publish/courses/_course_select_option.html.erb
@@ -1,1 +1,14 @@
-<option value="<%= other_course.course_code %>"><%= other_course.name %> (<%= other_course.course_code %>)</option>
+<% age_range =
+     other_course.primary_course? ?
+     "Ages #{other_course.age_range}" :
+     nil %>
+<option value="<%= other_course.course_code %>">
+  <%= [
+    other_course.name_and_code,
+    age_range,
+    I18n.t("publish.courses.course_table.funding.#{other_course.funding}"),
+    other_course.qualifications_summary,
+    other_course.study_mode_description.capitalize,
+    I18n.l(other_course.start_date.to_date, format: :short)
+  ].compact.join(", ") %>
+</option>

--- a/app/views/publish/courses/_course_select_option.html.erb
+++ b/app/views/publish/courses/_course_select_option.html.erb
@@ -1,14 +1,17 @@
-<% age_range =
-     other_course.primary_course? ?
-     "Ages #{other_course.age_range}" :
-     nil %>
+<%# Build the copy-content dropdown option text. Course name/code and primary age range are always shown. Other course information is only shown when it differs across the available courses. %>
+<%
+  option_text = [other_course.name_and_code]
+
+  option_text << "Ages #{other_course.age_range}" if other_course.primary_course?
+
+  option_text << I18n.t("publish.courses.course_table.funding.#{other_course.funding}") if visible_course_information_fields.include?(:funding)
+
+  option_text << other_course.qualifications_summary if visible_course_information_fields.include?(:qualification)
+
+  option_text << other_course.study_mode_description.capitalize if visible_course_information_fields.include?(:study_mode)
+
+  option_text << I18n.l(other_course.start_date.to_date, format: :short) if visible_course_information_fields.include?(:start_date)
+%>
 <option value="<%= other_course.course_code %>">
-  <%= [
-    other_course.name_and_code,
-    age_range,
-    I18n.t("publish.courses.course_table.funding.#{other_course.funding}"),
-    other_course.qualifications_summary,
-    other_course.study_mode_description.capitalize,
-    I18n.l(other_course.start_date.to_date, format: :short)
-  ].compact.join(", ") %>
+  <%= option_text.join(", ") %>
 </option>

--- a/app/views/publish/courses/_course_select_option.html.erb
+++ b/app/views/publish/courses/_course_select_option.html.erb
@@ -1,17 +1,13 @@
-<%# Build the copy-content dropdown option text. Course name/code and primary age range are always shown. Other course information is only shown when it differs across the available courses. %>
-<%
-  option_text = [other_course.name_and_code]
-
-  option_text << "Ages #{other_course.age_range}" if other_course.primary_course?
-
-  option_text << I18n.t("publish.courses.course_table.funding.#{other_course.funding}") if visible_course_information_fields.include?(:funding)
-
-  option_text << other_course.qualifications_summary if visible_course_information_fields.include?(:qualification)
-
-  option_text << other_course.study_mode_description.capitalize if visible_course_information_fields.include?(:study_mode)
-
-  option_text << I18n.l(other_course.start_date.to_date, format: :short) if visible_course_information_fields.include?(:start_date)
-%>
+<%# Course name/code and primary age range are always shown.
+    Other course information is only shown when it differs across
+    the courses available for copying. %>
 <option value="<%= other_course.course_code %>">
-  <%= option_text.join(", ") %>
+  <%= [
+    other_course.name_and_code,
+    (other_course.primary_course? ? "Ages #{other_course.age_range}" : nil),
+    (I18n.t("publish.courses.course_table.funding.#{other_course.funding}") if visible_course_information_fields.include?(:funding)),
+    (other_course.qualifications_summary if visible_course_information_fields.include?(:qualification)),
+    (other_course.study_mode_description.capitalize if visible_course_information_fields.include?(:study_mode)),
+    (I18n.l(other_course.start_date.to_date, format: :short) if visible_course_information_fields.include?(:start_date)),
+  ].compact.join(", ") %>
 </option>

--- a/app/views/publish/courses/_course_select_option.html.erb
+++ b/app/views/publish/courses/_course_select_option.html.erb
@@ -4,7 +4,7 @@
 <option value="<%= other_course.course_code %>">
   <%= [
     other_course.name_and_code,
-    (other_course.primary_course? ? "Ages #{other_course.age_range}" : nil),
+    (other_course.primary_course? ? I18n.t("publish.courses.course_table.primary_age_range", age_range: other_course.age_range) : nil),
     (I18n.t("publish.courses.course_table.funding.#{other_course.funding}") if visible_course_information_fields.include?(:funding)),
     (other_course.qualifications_summary if visible_course_information_fields.include?(:qualification)),
     (other_course.study_mode_description.capitalize if visible_course_information_fields.include?(:study_mode)),

--- a/app/views/publish/courses/_related_sidebar.html.erb
+++ b/app/views/publish/courses/_related_sidebar.html.erb
@@ -10,13 +10,13 @@
           <option value="" selected="selected">Pick a course</option>
           <% if @self_accredited_courses %>
             <%= render partial: "publish/courses/course_select_option", collection: @self_accredited_courses, as: :other_course, locals: {
-              visible_course_information_fields: @visible_course_information_fields
+              visible_course_information_fields: @visible_course_information_fields,
               } %>
           <% end %>
           <% @courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
             <optgroup label="<%= accrediting_provider %>">
               <%= render partial: "publish/courses/course_select_option", collection: courses, as: :other_course, locals: {
-                visible_course_information_fields: @visible_course_information_fields
+                visible_course_information_fields: @visible_course_information_fields,
               } %>
             </optgroup>
           <% end %>

--- a/app/views/publish/courses/_related_sidebar.html.erb
+++ b/app/views/publish/courses/_related_sidebar.html.erb
@@ -9,12 +9,15 @@
         <select id="copy-from" name="copy_from" class="govuk-select">
           <option value="" selected="selected">Pick a course</option>
           <% if @self_accredited_courses %>
-            <%= render partial: "publish/courses/course_select_option", collection: @self_accredited_courses, as: :other_course %>
+            <%= render partial: "publish/courses/course_select_option", collection: @self_accredited_courses, as: :other_course, locals: {
+              visible_course_information_fields: @visible_course_information_fields
+              } %>
           <% end %>
-
           <% @courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
             <optgroup label="<%= accrediting_provider %>">
-              <%= render partial: "publish/courses/course_select_option", collection: courses, as: :other_course %>
+              <%= render partial: "publish/courses/course_select_option", collection: courses, as: :other_course, locals: {
+                visible_course_information_fields: @visible_course_information_fields
+              } %>
             </optgroup>
           <% end %>
         </select>

--- a/config/locales/en/publish/courses/course_table.yml
+++ b/config/locales/en/publish/courses/course_table.yml
@@ -9,3 +9,5 @@ en:
           fee: Fee-paying
           salary: Salaried
           apprenticeship: Apprenticeship
+        primary_age_range: "Ages %{age_range}"
+        

--- a/spec/system/publish/courses/copy_from_list_spec.rb
+++ b/spec/system/publish/courses/copy_from_list_spec.rb
@@ -40,6 +40,61 @@ RSpec.describe "Copying course information" do
     end
   end
 
+  context "when courses differ by funding and study mode" do
+    before do
+      given_i_am_authenticated_as_a_provider_user
+      # The current course is excluded from the copy list.
+      # The two copyable courses share qualification and start date,
+      # so only funding and study mode should be displayed.
+      given_a_course_exists(
+        funding: :fee,
+        qualification: "qts",
+        study_mode: :full_time,
+        start_date: Date.new(2026, 9, 1),
+        enrichments: [build(:course_enrichment, :published)],
+      )
+
+      create(
+        :course,
+        provider: provider,
+        name: "Biology",
+        funding: :fee,
+        study_mode: :full_time,
+        qualification: "pgce_with_qts",
+        start_date: Date.new(2026, 9, 1),
+        enrichments: [build(:course_enrichment)],
+      )
+
+      create(
+        :course,
+        provider: provider,
+        name: "Biology",
+        funding: :salary,
+        study_mode: :part_time,
+        qualification: "pgce_with_qts",
+        start_date: Date.new(2026, 9, 1),
+        enrichments: [build(:course_enrichment)],
+      )
+    end
+
+    scenario "shows only course information that differs between copyable courses" do
+      when_i_visit_the_how_school_placements_work_page
+
+      list_options = publish_course_information_edit_page.copy_content.copy_options
+
+      dropdown_text = list_options.join(" ")
+
+      expect(dropdown_text).to include("Fee-paying")
+      expect(dropdown_text).to include("Salaried")
+
+      expect(dropdown_text).to include("Full time")
+      expect(dropdown_text).to include("Part time")
+
+      expect(dropdown_text).not_to include("QTS with PGCE")
+      expect(dropdown_text).not_to include("September 2026")
+    end
+  end
+
   def given_i_am_authenticated_as_a_provider_user
     given_i_am_authenticated(user: create(:user, :with_provider))
   end
@@ -74,10 +129,17 @@ RSpec.describe "Copying course information" do
 
   def then_the_correct_courses_are_available_to_select
     list_options = publish_course_information_edit_page.copy_content.copy_options
+
     expect(Course.count).to eq 3
     expect(list_options.size).to eq 3
     expect(list_options.shift).to eq("Pick a course")
     expect(list_options.any? { |x| x[@course.name] }).to be_falsey
+
+    # remaining options should always contain a course code
+    expect(list_options).to all(match(/\([A-Z0-9]+\)/))
+
+    # primary courses should show age range
+    expect(list_options.join(" ")).to include("Ages")
   end
 
   def when_i_select_a_course_to_copy
@@ -91,8 +153,14 @@ RSpec.describe "Copying course information" do
   end
 
   def then_i_see_an_alert_that_the_changes_are_not_saved_yet
+    copied_course_code = @course_to_copy.match(/\((.*?)\)/)[1]
+    copied_course = Course.find_by(course_code: copied_course_code)
+
     expect(page).to have_content "Your changes are not yet saved"
-    expect(page).to have_content "We have copied these fields from #{@course_to_copy}"
+
+    expect(page).to have_content(
+      "We have copied these fields from #{copied_course.name} (#{copied_course.course_code})",
+    )
   end
 
   def and_i_can_see_the_new_content


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/QXPEnJTC/1839-improve-copy-course-content

When selecting a course to copy from, the select options don’t have enough course information to identify the correct course.

## Changes proposed in this pull request

**Dropdown option content**
Each course option now displays:

- Course name and course code (always)
- Age range for primary courses (always)
- Funding type (only when it differs across available courses)
- Qualification (only when it differs across available courses)
- Study mode (only when it differs across available courses)
- Start date (only when it differs across available courses)

The logic for determining whether a field should be shown reuses the existing **Publish::CourseList::FIELDS** definitions.

Only the courses available in the copy-content dropdown are considered when determining whether a field varies. The course currently being edited is excluded from this comparison, as it is not present in the dropdown.

**Drop down with course information**

<img width="740" height="636" alt="Screenshot 2026-08-04 at 13 17 08" src="https://github.com/user-attachments/assets/25bf5ad3-581b-44e3-8b68-f4a22306c764" />

**Showing age range on primary courses**

<img width="631" height="244" alt="Screenshot 2026-08-04 at 13 18 14" src="https://github.com/user-attachments/assets/d052f23a-9e4a-4869-b43d-3e9af3f1e7a5" />


## Guidance to review

- Login as Colin on Publish and select a provider
- Choose on a course and click on 'Change' under 'Where you will train'
- Check the copy course content drop down displays any course information that differs and you can copy course content successully from another course

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
