### PR TITLE
Add appliations open filter and label

### DIFF
--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -30,6 +30,11 @@ module Courses
         ])
       end
 
+      status_tag = course.decorate.saved_status_tag
+      status_block = (content_tag(:div, status_tag, class: "app-saved-course__status-tag") if status_tag.present?)
+
+      title_content = safe_join([course_link, status_block].compact)
+
       classes = [
         ("govuk-grid-column-one-half" if save_toggle_button),
         ("govuk-!-padding-left-2" unless save_toggle_button),
@@ -37,7 +42,7 @@ module Courses
 
       content_tag(:div, class: "govuk-grid-row") do
         safe_join([
-          content_tag(:div, course_link, class: classes),
+          content_tag(:div, title_content, class: classes),
           content_tag(:div, save_toggle_button || "", class: "govuk-grid-column-one-half govuk-!-padding-top-2 govuk-!-padding-right-0"),
         ])
       end

--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -30,7 +30,7 @@ module Courses
         ])
       end
 
-      status_tag = course.decorate.saved_status_tag
+      status_tag = application_status_tag
       status_block = (content_tag(:div, status_tag, class: "app-saved-course__status-tag") if status_tag.present?)
 
       title_content = safe_join([course_link, status_block].compact)
@@ -53,6 +53,15 @@ module Courses
 
       saved_course = @candidate&.saved_courses&.find_by(course_id: course.id)
       render("find/saved_courses/save_toggle", course: course, saved_course: saved_course)
+    end
+
+    # Find result cards only show closed / after-deadline status. The grey
+    # "Not yet open" cycle-phase tag is kept on Saved courses only.
+    def application_status_tag
+      text, colour = course.decorate.saved_status_text_and_colour
+      return if text.blank? || colour == "grey"
+
+      helpers.govuk_tag(text:, colour:)
     end
 
     def candidate_accounts_enabled?

--- a/app/controllers/concerns/default_applications_open.rb
+++ b/app/controllers/concerns/default_applications_open.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module DefaultApplicationsOpen
-  def default_applications_open
-    form_params["applications_open"].nil? ? "true" : form_params["applications_open"]
-  end
-end

--- a/app/controllers/find/primary_subjects_controller.rb
+++ b/app/controllers/find/primary_subjects_controller.rb
@@ -10,7 +10,7 @@ module Find
 
     def submit
       if @form.valid?
-        redirect_to find_results_path({ subjects: @form.subjects, applications_open: true }.merge(track_params))
+        redirect_to find_results_path({ subjects: @form.subjects }.merge(track_params))
       else
         @primary_subject_options = Subject.primary
         render :index

--- a/app/controllers/find/secondary_subjects_controller.rb
+++ b/app/controllers/find/secondary_subjects_controller.rb
@@ -10,7 +10,7 @@ module Find
 
     def submit
       if @form.valid?
-        redirect_to find_results_path({ subjects: @form.subjects, applications_open: true }.merge(track_params))
+        redirect_to find_results_path({ subjects: @form.subjects }.merge(track_params))
       else
         @secondary_subject_options = formatted_secondary_subject_options
         render :index

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -62,6 +62,7 @@ module Courses
 
     def filter_counts
       {
+        applications_open: boolean_filter_count(applications_open),
         degree: degree_filter_count,
         funding: funding&.count,
         interview: boolean_filter_count(interview_location),

--- a/app/services/courses/active_filters/extractor.rb
+++ b/app/services/courses/active_filters/extractor.rb
@@ -18,6 +18,7 @@ module Courses
         minimum_degree_required
         can_sponsor_visa
         interview_location
+        applications_open
         start_date
       ].freeze
 

--- a/app/services/courses/active_filters/hash_extractor.rb
+++ b/app/services/courses/active_filters/hash_extractor.rb
@@ -4,7 +4,6 @@ module Courses
   module ActiveFilters
     class HashExtractor
       SKIP_KEYS = %w[
-        applications_open
         radius
         location
         formatted_address
@@ -32,6 +31,7 @@ module Courses
         minimum_degree_required
         can_sponsor_visa
         interview_location
+        applications_open
         start_date
         order
       ].freeze

--- a/app/services/find/search_param_defaults.rb
+++ b/app/services/find/search_param_defaults.rb
@@ -26,7 +26,6 @@ module Find
 
     def defaults
       {
-        "applications_open" => "true",
         "minimum_degree_required" => "show_all_courses",
         "order" => proc { |params|
           ::Courses::OrderingStrategy.default_for(::Courses::SearchLocation.from_params(params))

--- a/app/views/find/homepage/index.html.erb
+++ b/app/views/find/homepage/index.html.erb
@@ -7,7 +7,6 @@
     <%= form_with model: @search_courses_form, scope: "", url: find_results_path, method: :get, class: "app-homepage-search-form-container" do |form| %>
       <%= form.hidden_field :utm_source, value: "home" %>
       <%= form.hidden_field :utm_medium, value: "main_search" %>
-      <%= form.hidden_field :applications_open, value: "true" %>
 
       <div class="app-homepage-search-input-container">
         <div class="app-homepage-search-input" data-controller="dfe-autocomplete" data-dfe-autocomplete-name-value="subject_name" data-dfe-autocomplete-min-length-value="2">
@@ -98,7 +97,7 @@
         <p class="govuk-body"><%= t("find.search.apprenticeships.no_degree_html",
           tda_link: govuk_link_to(t("find.search.apprenticeships.tda_link_text"),
                                find_track_click_path(url: t("find.get_into_teaching.url_tda")))) %></p>
-        <p class="govuk-body"><%= govuk_link_to(t("find.search.apprenticeships.browse_apprenticeships_courses"), find_results_path({ minimum_degree_required: "show_all_courses", funding: %w[apprenticeship], utm_source: "home", utm_medium: "all_apprenticeship_courses", applications_open: true })) %></p>
+        <p class="govuk-body"><%= govuk_link_to(t("find.search.apprenticeships.browse_apprenticeships_courses"), find_results_path({ minimum_degree_required: "show_all_courses", funding: %w[apprenticeship], utm_source: "home", utm_medium: "all_apprenticeship_courses" })) %></p>
         <p class="govuk-body"><%= t("find.search.apprenticeships.find_the_right_apprenticeship") %></p>
       <% end %>
 
@@ -109,7 +108,6 @@
           t("find.search.send.browse_primary_send"),
           find_results_path(
             {
-              applications_open: true,
               send_courses: true,
               subjects: @search_courses_form.primary_subject_codes,
               utm_source: "home",
@@ -123,7 +121,6 @@
           t("find.search.send.browse_secondary_send"),
           find_results_path(
             {
-              applications_open: true,
               send_courses: true,
               subjects: @search_courses_form.secondary_subject_codes,
               utm_source: "home",
@@ -144,7 +141,7 @@
         <h4 class="govuk-heading-s"><%= t("find.search.other_stages.further_ed.title") %></h4>
 
         <p class="govuk-body"><%= t("find.search.other_stages.further_ed.teach_young_people") %></p>
-        <p class="govuk-body"><%= govuk_link_to(t("find.search.other_stages.further_ed.browse_further_ed"), find_results_path({ level: "further_education", utm_source: "home", utm_medium: "further_education_courses", applications_open: true })) %></p>
+        <p class="govuk-body"><%= govuk_link_to(t("find.search.other_stages.further_ed.browse_further_ed"), find_results_path({ level: "further_education", utm_source: "home", utm_medium: "further_education_courses" })) %></p>
         <p class="govuk-body"><%= t("find.search.learn_about") %> <%= govuk_link_to(t("find.search.other_stages.further_ed.teaching_further_ed"), find_track_click_path(url: t("find.get_into_teaching.further_ed"))) %>.</p>
       <% end %>
     <% end %>

--- a/app/views/find/results/filters/_all.html.erb
+++ b/app/views/find/results/filters/_all.html.erb
@@ -358,6 +358,30 @@
       </div>
     </details>
 
+    <%# Applications open %>
+    <details class="app-c-filter-section">
+      <summary class="app-c-filter-section__summary">
+        <h3 class="app-c-filter-section__summary-heading">
+          <span class="govuk-visually-hidden"><%= t(".filter_by") %></span>
+          <%= t(".filter_title_applications_open") %>
+        </h3>
+        <% if @filter_counts[:applications_open].present? %>
+          <span class="app-c-filter-section__count govuk-hint">
+            <%= @filter_counts[:applications_open] %> selected
+          </span>
+        <% end %>
+      </summary>
+      <div class="app-c-filter-section__content">
+        <%= form.govuk_check_boxes_fieldset :applications_open,
+        multiple: false,
+        legend: { text: t(".applications_open_html"), hidden: true },
+        class: "govuk-checkboxes--small",
+        hidden: false do %>
+          <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t(".applications_open") }, form: form_id %>
+        <% end %>
+      </div>
+    </details>
+
     <%# Start date %>
     <details class="app-c-filter-section">
       <summary class="app-c-filter-section__summary">

--- a/config/locales/en/find/active_filters.yml
+++ b/config/locales/en/find/active_filters.yml
@@ -1,6 +1,8 @@
 en:
   courses:
     active_filters:
+      applications_open:
+        true: Courses open for applications
       can_sponsor_visa:
         true: Courses with visa sponsorship
       engineers_teach_physics:

--- a/config/locales/en/find/candidates/email_alerts.yml
+++ b/config/locales/en/find/candidates/email_alerts.yml
@@ -29,6 +29,7 @@ en:
             minimum_degree_required: Degree required
             can_sponsor_visa: Visa sponsorship
             interview_location: Online interview
+            applications_open: Applications open
             start_date: Start date
             provider_code: Provider
         create:

--- a/config/locales/en/find/results/filters/all.yml
+++ b/config/locales/en/find/results/filters/all.yml
@@ -24,6 +24,7 @@ en:
           filter_title_degree: Degree grade
           filter_title_visa: Visa sponsorship
           filter_title_interviews: Online interviews
+          filter_title_applications_open: Applications open
           filter_title_start_date: Start date
           filter_title_provider: Training provider
           set_up_email_alert: Email me courses like this

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     context "when the course is not yet open", travel: 1.day.after(find_opens) do
       let(:course) { create(:course, :open, name: "Mathematics", course_code: "37CP") }
 
-      it "renders the not yet open status tag" do
-        expect(summary_card).to have_css(".app-saved-course__status-tag", text: "Not yet open")
+      it "does not render the not yet open status tag" do
+        expect(summary_card).not_to have_css(".app-saved-course__status-tag", text: "Not yet open")
       end
     end
   end

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -43,6 +43,22 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     it "renders the course name and code with the correct class" do
       expect(summary_card).to have_css(".app-search-result__course-name", text: "Mathematics (37CP)")
     end
+
+    context "when the course is closed" do
+      let(:course) { create(:course, :closed, name: "Mathematics", course_code: "37CP") }
+
+      it "renders the not accepting applications status tag" do
+        expect(summary_card).to have_css(".app-saved-course__status-tag", text: "Not accepting applications")
+      end
+    end
+
+    context "when the course is not yet open", travel: 1.day.after(find_opens) do
+      let(:course) { create(:course, :open, name: "Mathematics", course_code: "37CP") }
+
+      it "renders the not yet open status tag" do
+        expect(summary_card).to have_css(".app-saved-course__status-tag", text: "Not yet open")
+      end
+    end
   end
 
   shared_examples "school location row" do |funding_type, expected_output|

--- a/spec/components/find/courses/search_title_component_spec.rb
+++ b/spec/components/find/courses/search_title_component_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
   end
 
   context "with a provider name and default keys" do
-    let(:search_attributes) { { "provider_name" => "Manchester Metropolitan University (M40)", "applications_open" => "true", "order" => "course_name_ascending" } }
+    let(:search_attributes) { { "provider_name" => "Manchester Metropolitan University (M40)", "order" => "course_name_ascending" } }
 
     it { expect(rendered.text).to eq("courses across England") }
   end
@@ -199,9 +199,15 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
   end
 
   context "with only default filter values" do
-    let(:search_attributes) { { "applications_open" => "true", "minimum_degree_required" => "show_all_courses", "order" => "course_name_ascending" } }
+    let(:search_attributes) { { "minimum_degree_required" => "show_all_courses", "order" => "course_name_ascending" } }
 
     it { expect(rendered.text).to eq("courses across England") }
+  end
+
+  context "with applications_open selected" do
+    let(:search_attributes) { { "applications_open" => "true", "order" => "course_name_ascending" } }
+
+    it { expect(rendered.text).to eq("courses across England (1 filter applied)") }
   end
 
   context "with non-default minimum_degree_required" do

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -413,7 +413,6 @@ RSpec.describe Courses::SearchForm do
       search_form = described_class.new(
         level: "all",
         minimum_degree_required: "show_all_courses",
-        applications_open: true,
         location: "London",
         formatted_address: "London, UK",
         postal_code: "SW1A 1AA",

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -501,6 +501,7 @@ RSpec.describe Courses::SearchForm do
 
       it "returns nil for all counts" do
         expect(form.filter_counts).to eq({
+          applications_open: nil,
           degree: nil,
           funding: nil,
           interview: nil,
@@ -696,6 +697,14 @@ RSpec.describe Courses::SearchForm do
 
       it "returns the count of start dates" do
         expect(form.filter_counts[:start_date]).to eq(2)
+      end
+    end
+
+    context "with applications_open selected" do
+      let(:form) { described_class.new(applications_open: true) }
+
+      it "returns 1 for applications_open" do
+        expect(form.filter_counts[:applications_open]).to eq(1)
       end
     end
 

--- a/spec/services/courses/active_filters/extractor_spec.rb
+++ b/spec/services/courses/active_filters/extractor_spec.rb
@@ -226,20 +226,6 @@ RSpec.describe Courses::ActiveFilters::Extractor do
 
         expect(active_filters).to eq([])
       end
-
-      it "skips default applications_open" do
-        search_form = Courses::SearchForm.new(applications_open: true)
-        search_params = search_form.search_params
-
-        extractor = described_class.new(
-          search_params:,
-          search_form:,
-        )
-
-        active_filters = extractor.call
-
-        expect(active_filters).to eq([])
-      end
     end
 
     context "when params have non-default values" do
@@ -284,10 +270,33 @@ RSpec.describe Courses::ActiveFilters::Extractor do
 
         expect(active_filters).to eq([expected_filter])
       end
+    end
 
-      it "returns nil for applications_open false" do
-        search_form = Courses::SearchForm.new(applications_open: false)
+    context "with applications_open" do
+      it "returns a filter when applications_open is true" do
+        search_form = Courses::SearchForm.new(applications_open: true)
         search_params = search_form.search_params
+
+        extractor = described_class.new(
+          search_params:,
+          search_form:,
+        )
+
+        active_filters = extractor.call
+
+        expected_filter = Courses::ActiveFilter.new(
+          id: :applications_open,
+          raw_value: true,
+          value: true,
+          remove_params: { applications_open: nil },
+        )
+
+        expect(active_filters).to eq([expected_filter])
+      end
+
+      it "skips applications_open when false" do
+        search_form = Courses::SearchForm.new
+        search_params = { applications_open: false }
 
         extractor = described_class.new(
           search_params:,

--- a/spec/services/courses/active_filters/hash_extractor_spec.rb
+++ b/spec/services/courses/active_filters/hash_extractor_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe Courses::ActiveFilters::HashExtractor do
       end
     end
 
+    context "with applications_open" do
+      let(:attrs) { { "applications_open" => "true" } }
+
+      it "translates via active_filters.yml" do
+        expect(formatted_values).to eq(["Courses open for applications"])
+      end
+    end
+
     context "with funding" do
       let(:attrs) { { "funding" => %w[salary] } }
 
@@ -142,7 +150,7 @@ RSpec.describe Courses::ActiveFilters::HashExtractor do
     end
 
     context "with skipped keys" do
-      let(:attrs) { { "applications_open" => "true", "radius" => "15", "subject_code" => "C1" } }
+      let(:attrs) { { "radius" => "15", "subject_code" => "C1" } }
 
       it "ignores all skipped keys" do
         expect(filters).to be_empty

--- a/spec/services/find/recent_search_recorder_spec.rb
+++ b/spec/services/find/recent_search_recorder_spec.rb
@@ -24,6 +24,21 @@ RSpec.describe Find::RecentSearchRecorder do
         expect(candidate.recent_searches.count).to eq(0)
       end
 
+      it "does not record a search with empty subjects and location" do
+        result = described_class.call(
+          candidate:,
+          search_params: {
+            order: "course_name_ascending",
+            minimum_degree_required: "show_all_courses",
+            subjects: [],
+            location: "",
+          },
+        )
+
+        expect(result).to be_nil
+        expect(candidate.recent_searches.count).to eq(0)
+      end
+
       it "records a search when applications_open is selected" do
         result = described_class.call(
           candidate:,

--- a/spec/services/find/recent_search_recorder_spec.rb
+++ b/spec/services/find/recent_search_recorder_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe Find::RecentSearchRecorder do
         expect(candidate.recent_searches.count).to eq(0)
       end
 
-      it "does not record a search with empty subjects and location" do
+      it "records a search when applications_open is selected" do
         result = described_class.call(
           candidate:,
           search_params: { order: "course_name_ascending", minimum_degree_required: "show_all_courses", applications_open: "true" },
         )
 
-        expect(result).to be_nil
-        expect(candidate.recent_searches.count).to eq(0)
+        expect(result).to be_a(RecentSearch)
+        expect(result).to be_persisted
       end
 
       it "records a search when minimum_degree_required is non-default" do

--- a/spec/services/find/search_param_defaults_spec.rb
+++ b/spec/services/find/search_param_defaults_spec.rb
@@ -4,14 +4,9 @@ require "rails_helper"
 
 RSpec.describe Find::SearchParamDefaults do
   describe "#default_value?" do
-    it "returns true for applications_open=true" do
+    it "returns false for applications_open=true (not a silent default)" do
       defaults = described_class.new(applications_open: "true")
-      expect(defaults.default_value?("applications_open", "true")).to be true
-    end
-
-    it "returns false for applications_open=false" do
-      defaults = described_class.new(applications_open: "false")
-      expect(defaults.default_value?("applications_open", "false")).to be false
+      expect(defaults.default_value?("applications_open", "true")).to be false
     end
 
     it "returns true for minimum_degree_required=show_all_courses" do

--- a/spec/system/find/homepage/london_subject_and_location_spec.rb
+++ b/spec/system/find/homepage/london_subject_and_location_spec.rb
@@ -74,14 +74,13 @@ RSpec.describe "Search results by subject and location", :js, service: :find do
   def and_i_am_on_the_results_page_with_london_location_as_parameter
     and_i_am_on_the_results_page
 
-    expect(search_params).to eq(applications_open: "true", subject_name: "", subject_code: "", location: "London", provider_name: "", provider_code: "")
+    expect(search_params).to eq(subject_name: "", subject_code: "", location: "London", provider_name: "", provider_code: "")
   end
 
   def and_i_am_on_the_results_page_with_mathematics_subject_and_london_location_and_sponsor_visa_as_parameter
     and_i_am_on_the_results_page
 
     expect(search_params).to eq(
-      applications_open: "true",
       subject_name: "Mathematics",
       subject_code: "G1",
       location: "London",

--- a/spec/system/find/homepage/postcode_location_spec.rb
+++ b/spec/system/find/homepage/postcode_location_spec.rb
@@ -128,14 +128,13 @@ RSpec.describe "Search results by subject and location", :js, service: :find do
   def and_i_am_on_the_results_page_with_postcode_location_as_parameter
     and_i_am_on_the_results_page
 
-    expect(search_params).to eq(applications_open: "true", subject_name: "", subject_code: "", location: "Beacon Road, Marazion TR17 0HF", provider_name: "", provider_code: "")
+    expect(search_params).to eq(subject_name: "", subject_code: "", location: "Beacon Road, Marazion TR17 0HF", provider_name: "", provider_code: "")
   end
 
   def and_i_am_on_the_results_page_with_mathematics_subject_and_postcode_location_and_sponsor_visa_as_parameter
     and_i_am_on_the_results_page
 
     expect(search_params).to eq(
-      applications_open: "true",
       subject_name: "Mathematics",
       subject_code: "G1",
       location: "Beacon Road, Marazion TR17 0HF",

--- a/spec/system/find/homepage/tracking_spec.rb
+++ b/spec/system/find/homepage/tracking_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Search results tracking", :js, service: :find do
         hash_including(
           total: 7,
           page: 1,
-          search_params: hash_including(applications_open: true),
+          search_params: hash_including(order: "course_name_ascending"),
           track_params: hash_including(utm_source: "home", utm_medium: "main_search"),
           results: array_including(
             have_attributes(course_code: "F314", provider_code: "RO1"),
@@ -189,7 +189,7 @@ RSpec.describe "Search results tracking", :js, service: :find do
         hash_including(
           total: 2,
           page: 1,
-          search_params: hash_including(applications_open: true, subjects: %w[00]),
+          search_params: hash_including(subjects: %w[00]),
           track_params: hash_including(utm_source: "home", utm_medium: "primary_courses"),
           results: array_including(
             have_attributes(course_code: "Y565", provider_code: "1UR"),
@@ -218,7 +218,7 @@ RSpec.describe "Search results tracking", :js, service: :find do
         hash_including(
           total: 1,
           page: 1,
-          search_params: hash_including(applications_open: true, subjects: %w[W1]),
+          search_params: hash_including(subjects: %w[W1]),
           track_params: hash_including(utm_source: "home", utm_medium: "secondary_courses"),
           results: array_including(
             have_attributes(course_code: "F314", provider_code: "RO1"),
@@ -243,7 +243,7 @@ RSpec.describe "Search results tracking", :js, service: :find do
         hash_including(
           total: 1,
           page: 1,
-          search_params: hash_including(applications_open: true, minimum_degree_required: "show_all_courses", funding: %w[apprenticeship]),
+          search_params: hash_including(minimum_degree_required: "show_all_courses", funding: %w[apprenticeship]),
           track_params: hash_including(utm_source: "home", utm_medium: "all_apprenticeship_courses"),
           results: array_including(
             have_attributes(course_code: "TDA1", provider_code: "23T"),
@@ -278,7 +278,7 @@ RSpec.describe "Search results tracking", :js, service: :find do
         hash_including(
           total: 1,
           page: 1,
-          search_params: hash_including(applications_open: true, send_courses: true, subjects: Subject.primary_subject_codes),
+          search_params: hash_including(send_courses: true, subjects: Subject.primary_subject_codes),
           track_params: hash_including(utm_source: "home", utm_medium: "send_primary_courses"),
           results: array_including(
             have_attributes(course_code: "P123", provider_code: "PO1"),
@@ -294,7 +294,7 @@ RSpec.describe "Search results tracking", :js, service: :find do
         hash_including(
           total: 1,
           page: 1,
-          search_params: hash_including(applications_open: true, send_courses: true, subjects: Subject.secondary_subject_codes_with_incentives),
+          search_params: hash_including(send_courses: true, subjects: Subject.secondary_subject_codes_with_incentives),
           track_params: hash_including(utm_source: "home", utm_medium: "send_secondary_courses"),
           results: array_including(
             have_attributes(course_code: "F314", provider_code: "RO1"),
@@ -315,7 +315,7 @@ RSpec.describe "Search results tracking", :js, service: :find do
         hash_including(
           total: 1,
           page: 1,
-          search_params: hash_including(applications_open: true, level: "further_education"),
+          search_params: hash_including(level: "further_education"),
           track_params: hash_including(utm_source: "home", utm_medium: "further_education_courses"),
           results: array_including(
             have_attributes(course_code: "F3D", provider_code: "JL1"),

--- a/spec/system/find/results/active_filters_spec.rb
+++ b/spec/system/find/results/active_filters_spec.rb
@@ -141,6 +141,11 @@ RSpec.describe "Courses search with active filters", :js, service: :find do
         then_send_courses_filter_is_displayed
       end
 
+      scenario "applications_open filter is shown when true" do
+        given_the_user_enables_applications_open_filter
+        then_applications_open_filter_is_displayed
+      end
+
       scenario "engineers_teach_physics filter is shown when true" do
         given_the_user_enables_engineers_teach_physics_filter
         then_the_active_filters_are_visible("Engineers teach physics")
@@ -151,6 +156,9 @@ RSpec.describe "Courses search with active filters", :js, service: :find do
         then_no_active_filters_are_displayed
 
         given_the_user_visits_results_without_send_courses
+        then_no_active_filters_are_displayed
+
+        given_the_user_visits_results_without_applications_open
         then_no_active_filters_are_displayed
 
         given_the_user_visits_results_without_engineers_teach_physics
@@ -313,6 +321,14 @@ RSpec.describe "Courses search with active filters", :js, service: :find do
 
   def given_the_user_visits_results_without_send_courses
     visit find_results_path(send_courses: "false")
+  end
+
+  def given_the_user_enables_applications_open_filter
+    visit find_results_path(applications_open: "true")
+  end
+
+  def given_the_user_visits_results_without_applications_open
+    visit find_results_path(applications_open: "false")
   end
 
   def given_the_user_enables_engineers_teach_physics_filter
@@ -504,6 +520,10 @@ RSpec.describe "Courses search with active filters", :js, service: :find do
 
   def then_send_courses_filter_is_displayed
     expect(active_filters).to include("Courses with a SEND specialism")
+  end
+
+  def then_applications_open_filter_is_displayed
+    expect(active_filters).to include("Courses open for applications")
   end
 
   def then_further_education_level_filter_is_displayed

--- a/spec/system/find/results/filter_counts_spec.rb
+++ b/spec/system/find/results/filter_counts_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe "Filter counts on search results", :js, service: :find do
     then_i_see_the_visa_filter_count
   end
 
+  scenario "when I filter by applications open, the count is shown" do
+    given_there_are_courses
+    when_i_visit_the_find_results_page
+    and_i_filter_by_applications_open
+    then_i_see_the_applications_open_filter_count
+  end
+
   scenario "when I filter by degree requirement, the count is shown" do
     given_there_are_courses
     when_i_visit_the_find_results_page
@@ -123,6 +130,12 @@ RSpec.describe "Filter counts on search results", :js, service: :find do
     and_i_apply_the_filters
   end
 
+  def and_i_filter_by_applications_open
+    page.find("h3", text: "Filter by\nApplications open").click
+    check "Only show courses open for applications", visible: :all
+    and_i_apply_the_filters
+  end
+
   def and_i_filter_by_degree_requirement
     page.find("h3", text: "Filter by\nDegree grade").click
     choose "2:1 or First", visible: :all
@@ -175,6 +188,12 @@ RSpec.describe "Filter counts on search results", :js, service: :find do
 
   def then_i_see_the_visa_filter_count
     within("details", text: "Visa sponsorship") do
+      expect(page).to have_content("1 selected")
+    end
+  end
+
+  def then_i_see_the_applications_open_filter_count
+    within("details", text: "Applications open") do
       expect(page).to have_content("1 selected")
     end
   end

--- a/spec/system/find/results/filtering/applications_open_spec.rb
+++ b/spec/system/find/results/filtering/applications_open_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../filtering_helper"
+
+RSpec.describe "when filtering by applications open", :js, service: :find do
+  include FilteringHelper
+
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+    given_there_are_open_and_closed_courses
+  end
+
+  scenario "applications open is checked by default from search entry" do
+    when_i_visit_the_find_results_page_from_search_entry
+    then_i_see_only_open_courses
+    and_the_applications_open_filter_is_checked
+    and_i_see_the_applications_open_filter_count
+  end
+
+  scenario "unchecking applications open shows closed courses with status tag" do
+    when_i_visit_the_find_results_page_from_search_entry
+    and_i_uncheck_applications_open
+    then_i_see_open_and_closed_courses
+    and_i_see_the_not_accepting_applications_tag_for_the_closed_course
+  end
+
+  def given_there_are_open_and_closed_courses
+    create(:course, :open, :with_full_time_sites, name: "Biology", course_code: "S872")
+    create(:course, :closed, :with_full_time_sites, name: "Chemistry", course_code: "K592")
+  end
+
+  def when_i_visit_the_find_results_page_from_search_entry
+    visit find_results_path(applications_open: true)
+  end
+
+  def and_i_uncheck_applications_open
+    page.find("h3", text: "Filter by\nApplications open").click
+    uncheck "Only show courses open for applications", visible: :all
+    and_i_apply_the_filters
+  end
+
+  def then_i_see_only_open_courses
+    with_retry do
+      expect(results).to have_content("Biology (S872)")
+      expect(results).to have_no_content("Chemistry (K592)")
+    end
+  end
+
+  def then_i_see_open_and_closed_courses
+    with_retry do
+      expect(results).to have_content("Biology (S872)")
+      expect(results).to have_content("Chemistry (K592)")
+    end
+  end
+
+  def and_the_applications_open_filter_is_checked
+    expect(page).to have_checked_field("Only show courses open for applications", visible: :all)
+  end
+
+  def and_i_see_the_applications_open_filter_count
+    within("details", text: "Applications open") do
+      expect(page).to have_content("1 selected")
+    end
+  end
+
+  def and_i_see_the_not_accepting_applications_tag_for_the_closed_course
+    within(".app-search-results") do
+      expect(page).to have_css(".app-saved-course__status-tag", text: "Not accepting applications")
+    end
+  end
+end

--- a/spec/system/find/results/filtering/applications_open_spec.rb
+++ b/spec/system/find/results/filtering/applications_open_spec.rb
@@ -39,17 +39,13 @@ RSpec.describe "when filtering by applications open", :js, service: :find do
   end
 
   def then_i_see_only_open_courses
-    with_retry do
-      expect(results).to have_content("Biology (S872)")
-      expect(results).to have_no_content("Chemistry (K592)")
-    end
+    expect(results).to have_content("Biology (S872)")
+    expect(results).to have_no_content("Chemistry (K592)")
   end
 
   def then_i_see_open_and_closed_courses
-    with_retry do
-      expect(results).to have_content("Biology (S872)")
-      expect(results).to have_content("Chemistry (K592)")
-    end
+    expect(results).to have_content("Biology (S872)")
+    expect(results).to have_content("Chemistry (K592)")
   end
 
   def and_the_applications_open_filter_is_checked

--- a/spec/system/find/results/filtering/applications_open_spec.rb
+++ b/spec/system/find/results/filtering/applications_open_spec.rb
@@ -11,19 +11,20 @@ RSpec.describe "when filtering by applications open", :js, service: :find do
     given_there_are_open_and_closed_courses
   end
 
-  scenario "applications open is checked by default from search entry" do
-    when_i_visit_the_find_results_page_from_search_entry
+  scenario "applications open is unchecked by default" do
+    when_i_visit_the_find_results_page
+    then_i_see_open_and_closed_courses
+    and_the_applications_open_filter_is_unchecked
+    and_i_see_the_not_accepting_applications_tag_for_the_closed_course
+  end
+
+  scenario "checking applications open hides closed courses and shows the chip" do
+    when_i_visit_the_find_results_page
+    and_i_check_applications_open
     then_i_see_only_open_courses
     and_the_applications_open_filter_is_checked
     and_i_see_the_applications_open_filter_count
     and_i_see_the_applications_open_active_filter_chip
-  end
-
-  scenario "unchecking applications open shows closed courses with status tag" do
-    when_i_visit_the_find_results_page_from_search_entry
-    and_i_uncheck_applications_open
-    then_i_see_open_and_closed_courses
-    and_i_see_the_not_accepting_applications_tag_for_the_closed_course
   end
 
   def given_there_are_open_and_closed_courses
@@ -31,13 +32,9 @@ RSpec.describe "when filtering by applications open", :js, service: :find do
     create(:course, :closed, :with_full_time_sites, name: "Chemistry", course_code: "K592")
   end
 
-  def when_i_visit_the_find_results_page_from_search_entry
-    visit find_results_path(applications_open: true)
-  end
-
-  def and_i_uncheck_applications_open
+  def and_i_check_applications_open
     page.find("h3", text: "Filter by\nApplications open").click
-    uncheck "Only show courses open for applications", visible: :all
+    check "Only show courses open for applications", visible: :all
     and_i_apply_the_filters
   end
 
@@ -57,6 +54,10 @@ RSpec.describe "when filtering by applications open", :js, service: :find do
 
   def and_the_applications_open_filter_is_checked
     expect(page).to have_checked_field("Only show courses open for applications", visible: :all)
+  end
+
+  def and_the_applications_open_filter_is_unchecked
+    expect(page).to have_unchecked_field("Only show courses open for applications", visible: :all)
   end
 
   def and_i_see_the_applications_open_filter_count

--- a/spec/system/find/results/filtering/applications_open_spec.rb
+++ b/spec/system/find/results/filtering/applications_open_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "when filtering by applications open", :js, service: :find do
     then_i_see_only_open_courses
     and_the_applications_open_filter_is_checked
     and_i_see_the_applications_open_filter_count
+    and_i_see_the_applications_open_active_filter_chip
   end
 
   scenario "unchecking applications open shows closed courses with status tag" do
@@ -62,6 +63,10 @@ RSpec.describe "when filtering by applications open", :js, service: :find do
     within("details", text: "Applications open") do
       expect(page).to have_content("1 selected")
     end
+  end
+
+  def and_i_see_the_applications_open_active_filter_chip
+    expect(page).to have_css(".app-active-filters", text: "Courses open for applications")
   end
 
   def and_i_see_the_not_accepting_applications_tag_for_the_closed_course

--- a/spec/system/find/results/ordering/ordering_helper.rb
+++ b/spec/system/find/results/ordering/ordering_helper.rb
@@ -27,6 +27,8 @@ module OrderingHelper
   end
 
   def result_titles
-    page.all(".govuk-summary-card__title", minimum: 1).map { |element| element.text.split("\n").join(" ") }
+    # Use the course link only so status tags (e.g. "Not accepting applications")
+    # in the title area do not affect ordering assertions.
+    page.all(".govuk-summary-card__title a.govuk-link", minimum: 1).map { |element| element.text.split("\n").join(" ") }
   end
 end

--- a/spec/system/find/results_helper.rb
+++ b/spec/system/find/results_helper.rb
@@ -522,14 +522,13 @@ module ResultsHelper
   def and_i_am_on_the_results_page_with_cornwall_location_as_parameter
     and_i_am_on_the_results_page
 
-    expect(search_params).to eq(applications_open: "true", subject_name: "", subject_code: "", location: "Cornwall", provider_name: "", provider_code: "")
+    expect(search_params).to eq(subject_name: "", subject_code: "", location: "Cornwall", provider_name: "", provider_code: "")
   end
 
   def and_i_am_on_the_results_page_with_mathematics_subject_and_cornwall_location_and_sponsor_visa_as_parameter
     and_i_am_on_the_results_page
 
     expect(search_params).to eq(
-      applications_open: "true",
       subject_name: "Mathematics",
       subject_code: "G1",
       location: "Cornwall",


### PR DESCRIPTION
## Context

Restores the Find results **Applications open** filter and closed-course status tags on search result cards. Backend support (`applications_open` params and query scope) was still in place; the results filter UI, active-filter chip, and card status tag were missing after an earlier removal. The filter is **not** selected by default — candidates opt in to hide closed courses.

## Changes proposed in this pull request

- Re-add the **Applications open** checkbox on Find search results (near Online interviews / Visa sponsorship), with selected count.
- Leave the filter **unchecked by default** (removed from homepage search, browse links, and primary/secondary subject redirects).
- When selected, show an active-filter chip: **Courses open for applications**.
- Show a red **Not accepting applications** status tag on closed / after-deadline courses on result cards.
- Do **not** show the grey **Not yet open** cycle-phase tag on Find results (Saved courses keep that behaviour).
- Include Applications open in email-alert summary labels when that filter is set.
- Specs for filter behaviour, chip, status tag, filter counts, and related title/recent-search/active-filter updates.

## Guidance to review

- From homepage/subject search, confirm **Applications open** is unchecked, open and closed courses both appear, and closed courses show **Not accepting applications**.
- Check the filter, apply, and confirm closed courses are hidden and the chip is shown.
- Remove the chip / uncheck the filter and confirm closed courses reappear with the status tag.
- Confirm Find result cards do **not** show grey **Not yet open** between Find opening and Apply opening.
- Spot-check layout of the status tag next to the course title / save toggle.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.