### PR TITLE
School data - Update Schools in Basic details component

### DIFF
--- a/app/controllers/publish/courses/schools_controller.rb
+++ b/app/controllers/publish/courses/schools_controller.rb
@@ -27,9 +27,12 @@ module Publish
         @course_school_form = Publish::CourseSchoolForm.new(@course, params: school_params)
 
         if @course_school_form.valid?
-          Publish::Schools::UpdateCourseSchoolsService.call_or_enqueue(course: @course, params: school_params)
+          Publish::Schools::UpdateCourseSchoolsService.call_or_enqueue(
+            course: @course,
+            school_uuids: selected_school_uuids,
+          )
 
-          flash[:success] = if selected_school_uuids_count > Publish::Schools::UpdateCourseSchoolsService::ENQUEUE_THRESHOLD
+          flash[:success] = if selected_school_uuids.size > Publish::Schools::UpdateCourseSchoolsService::ENQUEUE_THRESHOLD
                               I18n.t("success.enqueued_schools")
                             else
                               I18n.t("success.saved", value: section_key)
@@ -75,9 +78,15 @@ module Publish
       end
 
       def school_params
-        return { school_uuids: nil } if params[:publish_course_school_form][:school_uuids].all?(&:empty?)
+        @school_params ||= params
+          .expect(publish_course_school_form: [{ school_uuids: [] }])
+          .tap do |permitted_params|
+            permitted_params[:school_uuids] = nil if permitted_params[:school_uuids].all?(&:empty?)
+          end
+      end
 
-        params.expect(publish_course_school_form: [:schools_validated, { school_uuids: [] }])
+      def selected_school_uuids
+        @selected_school_uuids ||= Array(school_params[:school_uuids]).compact_blank.uniq
       end
 
       def build_course
@@ -85,11 +94,7 @@ module Publish
       end
 
       def section_key
-        "School".pluralize(selected_school_uuids_count)
-      end
-
-      def selected_school_uuids_count
-        Array(school_params[:school_uuids]).compact_blank.uniq.count
+        "School".pluralize(selected_school_uuids.size)
       end
     end
   end

--- a/app/controllers/publish/courses/schools_controller.rb
+++ b/app/controllers/publish/courses/schools_controller.rb
@@ -29,7 +29,7 @@ module Publish
         if @course_school_form.valid?
           Publish::Schools::UpdateCourseSchoolsService.call_or_enqueue(course: @course, params: school_params)
 
-          flash[:success] = if Array(@course_school_form.site_ids).size > Publish::Schools::UpdateCourseSchoolsService::ENQUEUE_THRESHOLD
+          flash[:success] = if selected_school_uuids_count > Publish::Schools::UpdateCourseSchoolsService::ENQUEUE_THRESHOLD
                               I18n.t("success.enqueued_schools")
                             else
                               I18n.t("success.saved", value: section_key)
@@ -43,6 +43,11 @@ module Publish
         else
           render :edit
         end
+      rescue Publish::Schools::UpdateCourseSchoolsService::UnresolvedProviderSchoolsError,
+             Publish::Schools::UpdateCourseSiteStatusesService::UnresolvedSitesError => e
+        Sentry.capture_exception(e)
+        @course_school_form.errors.add(:school_uuids, :school_uuids_invalid)
+        render :edit, status: :unprocessable_entity
       end
 
       def back
@@ -70,9 +75,9 @@ module Publish
       end
 
       def school_params
-        return { site_ids: nil } if params[:publish_course_school_form][:site_ids].all?(&:empty?)
+        return { school_uuids: nil } if params[:publish_course_school_form][:school_uuids].all?(&:empty?)
 
-        params.expect(publish_course_school_form: [:schools_validated, { site_ids: [] }])
+        params.expect(publish_course_school_form: [:schools_validated, { school_uuids: [] }])
       end
 
       def build_course
@@ -80,7 +85,11 @@ module Publish
       end
 
       def section_key
-        "School".pluralize(Array(school_params[:site_ids]).compact_blank.count)
+        "School".pluralize(selected_school_uuids_count)
+      end
+
+      def selected_school_uuids_count
+        Array(school_params[:school_uuids]).compact_blank.uniq.count
       end
     end
   end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -167,14 +167,9 @@ class CourseDecorator < ApplicationDecorator
     names.sort_by(&:downcase)
   end
 
-  # Count of schools currently attached to the course, reading from whichever
-  # data model is live per the :course_publishing_uses_new_school_model flag.
+  # Count of Course::School records currently attached to the course.
   def attached_schools_count
-    if FeatureFlag.active?(:course_publishing_uses_new_school_model)
-      object.schools.count
-    else
-      object.sites.school.count
-    end
+    object.schools.count
   end
 
   def alphabetically_sorted_study_sites

--- a/app/forms/publish/course_school_form.rb
+++ b/app/forms/publish/course_school_form.rb
@@ -2,19 +2,22 @@
 
 module Publish
   class CourseSchoolForm < BaseCourseForm
-    FIELDS = %i[site_ids schools_validated].freeze
+    FIELDS = %i[school_uuids schools_validated].freeze
 
     attr_accessor(*FIELDS)
 
     validate :no_schools_selected
+    validate :school_uuids_belong_to_provider
 
     def compute_fields
-      { site_ids: course.site_ids }.merge(new_attributes)
+      { school_uuids: current_school_uuids }.merge(new_attributes)
     end
 
     # Every school the provider could attach, in the order they are listed.
-    def sites
-      @sites ||= course.provider.sites.sort_by(&:location_name)
+    def schools
+      @schools ||= provider_schools
+        .includes(:gias_school)
+        .order("gias_school.name")
     end
 
     def schools_collapse_threshold
@@ -22,21 +25,43 @@ module Publish
     end
 
     def collapse_schools?
-      sites.size > schools_collapse_threshold
+      schools.size > schools_collapse_threshold
     end
 
   private
 
+    def current_school_uuids
+      course.schools.joins(:provider_school).pluck("provider_school.uuid")
+    end
+
     def no_schools_selected
-      return if params[:site_ids].present?
+      return if params[:school_uuids].present?
       return if ::Courses::PublishRules::SchoolPresenceExemption.applies?(course)
 
       if course.recruitment_cycle_rollover_period_2026?
-        errors.add(:site_ids, :check_schools) if course.sites.school.present?
-        errors.add(:site_ids, :enter_schools) if course.sites.school.blank?
+        error = course.schools.exists? ? :check_schools : :enter_schools
+        errors.add(:school_uuids, error)
       else
-        errors.add(:site_ids, :no_schools)
+        errors.add(:school_uuids, :no_schools)
       end
+    end
+
+    def school_uuids_belong_to_provider
+      school_uuids = Array(params[:school_uuids]).compact_blank.uniq
+      return if school_uuids.empty?
+
+      known_school_uuids = provider_schools
+        .where(uuid: school_uuids)
+        .pluck("provider_school.uuid")
+      return if (school_uuids - known_school_uuids).empty?
+
+      errors.add(:school_uuids, :school_uuids_invalid)
+    end
+
+    # Rollover controls which schools exist for the cycle. Once a
+    # Provider::School exists, it can be attached regardless of GIAS status.
+    def provider_schools
+      course.provider.schools.joins(:gias_school)
     end
   end
 end

--- a/app/jobs/update_course_schools_job.rb
+++ b/app/jobs/update_course_schools_job.rb
@@ -4,6 +4,10 @@ class UpdateCourseSchoolsJob
   def perform(course_id, params)
     course = Course.find(course_id)
 
-    Publish::Schools::UpdateCourseSchoolsService.call(course:, params:)
+    Publish::Schools::UpdateCourseSchoolsService.call(
+      course:,
+      params:,
+      raise_on_missing_provider_schools: false,
+    )
   end
 end

--- a/app/jobs/update_course_schools_job.rb
+++ b/app/jobs/update_course_schools_job.rb
@@ -4,6 +4,6 @@ class UpdateCourseSchoolsJob
   def perform(course_id, params)
     course = Course.find(course_id)
 
-    Publish::Schools::UpdateCourseSchoolsService.new(course:, params:).call
+    Publish::Schools::UpdateCourseSchoolsService.call(course:, params:)
   end
 end

--- a/app/jobs/update_course_schools_job.rb
+++ b/app/jobs/update_course_schools_job.rb
@@ -1,12 +1,12 @@
 class UpdateCourseSchoolsJob
   include Sidekiq::Job
 
-  def perform(course_id, params)
+  def perform(course_id, school_uuids)
     course = Course.find(course_id)
 
     Publish::Schools::UpdateCourseSchoolsService.call(
       course:,
-      params:,
+      school_uuids:,
       raise_on_missing_provider_schools: false,
     )
   end

--- a/app/services/publish/schools/update_course_provider_schools_service.rb
+++ b/app/services/publish/schools/update_course_provider_schools_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Publish
+  module Schools
+    # Syncs Course::School rows to an already-resolved Provider::School selection.
+    # UUID resolution and queued-update policy belong to UpdateCourseSchoolsService.
+    class UpdateCourseProviderSchoolsService
+      include ServicePattern
+
+      # @param course [Course] course whose Course::School rows should be synced
+      # @param provider_schools [Array<Provider::School>] complete desired selection
+      def initialize(course:, provider_schools:)
+        @course = course
+        @provider_schools = provider_schools
+      end
+
+      def call
+        return if provider_school_ids_to_attach.empty? && provider_school_ids_to_remove.empty?
+
+        provider_schools_to_attach.each { |provider_school| attach_provider_school(provider_school) }
+        course.schools.where(provider_school_id: provider_school_ids_to_remove).destroy_all
+        course.schools.reload
+      end
+
+    private
+
+      attr_reader :course, :provider_schools
+
+      def attach_provider_school(provider_school)
+        course.schools.create_or_find_by!(provider_school:) do |course_school|
+          course_school.gias_school = provider_school.gias_school
+        end
+      end
+
+      def submitted_provider_school_ids
+        @submitted_provider_school_ids ||= provider_schools.map(&:id)
+      end
+
+      def current_provider_school_ids
+        @current_provider_school_ids ||= course.schools.pluck(:provider_school_id)
+      end
+
+      def provider_school_ids_to_attach
+        @provider_school_ids_to_attach ||= submitted_provider_school_ids - current_provider_school_ids
+      end
+
+      def provider_school_ids_to_remove
+        @provider_school_ids_to_remove ||= current_provider_school_ids - submitted_provider_school_ids
+      end
+
+      def provider_schools_to_attach
+        schools_by_id = provider_schools.index_by(&:id)
+        provider_school_ids_to_attach.map { |id| schools_by_id.fetch(id) }
+      end
+    end
+  end
+end

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -131,7 +131,7 @@ module Publish
       end
 
       def school_names_for_notification
-        course.schools.includes(:provider_school)
+        course.schools.includes(provider_school: :gias_school)
           .map { |course_school| course_school.provider_school.location_name }
           .sort
       end

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -1,141 +1,139 @@
+# frozen_string_literal: true
+
 module Publish
   module Schools
+    # Coordinates course school updates from Publish by writing Course::School
+    # and legacy SiteStatus rows from the same Provider::School UUIDs.
+    # This service also updates the course and provider so that Apply syncs course changes.
     class UpdateCourseSchoolsService
+      include ServicePattern
+
       ENQUEUE_THRESHOLD = 30
 
-      def self.call_or_enqueue(course:, params:)
-        site_ids_count = Array(params[:site_ids]).size
+      class UnresolvedProviderSchoolsError < StandardError; end
 
-        if site_ids_count > ENQUEUE_THRESHOLD
+      def self.call_or_enqueue(course:, params:)
+        if Array(params[:school_uuids]).compact_blank.uniq.size > ENQUEUE_THRESHOLD
           UpdateCourseSchoolsJob.perform_async(course.id, params.to_h)
         else
-          new(course:, params:).call
+          call(course:, params:)
         end
       end
 
+      # @param course [Course] course whose school selection should be updated
+      # @param params [Hash, ActionController::Parameters] course attributes and
+      #   submitted Provider::School UUIDs
       def initialize(course:, params:)
         @course = course
-        @params = { site_ids: course.site_ids }.merge(params.to_h.deep_symbolize_keys)
-        @previous_site_names = course.sites.map(&:location_name)
+        @params = params.to_h.deep_symbolize_keys
+        @submitted_school_uuids = Array(@params.fetch(:school_uuids)).compact_blank.uniq
       end
 
       def call
+        previous_school_names = school_names_for_notification
+        previous_provider_school_ids = provider_school_ids
+
         ActiveRecord::Base.transaction do
-          assign_attributes_to_course
-          sync_schools
-          apply_publish_status_to_site_statuses
+          provider_schools = resolve_provider_schools
+
+          course.assign_attributes(course_attributes)
+          update_site_statuses(provider_schools)
+          update_provider_schools(provider_schools)
+
+          # This persists schools_validated and deliberately touches the course
+          # and provider. Apply watches provider.changed_at to decide whether it
+          # needs to sync the provider's courses.
           course.save!
         end
 
-        refresh_last_published_at_if_sites_changed
-        send_notifications
+        updated_school_names = school_names_for_notification
+        refresh_last_published_at_if_schools_changed(
+          previous_provider_school_ids:,
+          updated_provider_school_ids: provider_school_ids,
+        )
+        send_notifications(
+          previous_school_names:,
+          updated_school_names:,
+        )
       end
 
     private
 
-      attr_reader :course, :params, :previous_site_names
+      attr_reader :course, :params, :submitted_school_uuids
 
-      def assign_attributes_to_course
-        course.assign_attributes(params.except(:site_ids))
+      def course_attributes
+        params.except(:school_uuids)
       end
 
-      def sync_schools
-        return if sites_to_attach_ids.empty? && sites_to_remove_ids.empty?
+      def resolve_provider_schools
+        # Prevent a concurrent removal from deleting a school after resolution
+        # but before both relationship writers have completed.
+        provider_schools_by_uuid = course.provider.schools
+          .includes(:gias_school)
+          .where(uuid: submitted_school_uuids)
+          .lock
+          .index_by(&:uuid)
 
-        sites_to_attach_ids.each { |id| attach_school(sites_by_id[id]) }
-        sites_to_remove_ids.each { |id| detach_school(sites_by_id[id]) }
+        missing_school_uuids = submitted_school_uuids - provider_schools_by_uuid.keys
+        handle_missing_provider_schools(missing_school_uuids)
 
-        course.sites.reload
+        submitted_school_uuids.filter_map { |uuid| provider_schools_by_uuid[uuid] }
       end
 
-      def refresh_last_published_at_if_sites_changed
-        return if sites_to_attach_ids.empty? && sites_to_remove_ids.empty?
+      def refresh_last_published_at_if_schools_changed(previous_provider_school_ids:, updated_provider_school_ids:)
+        return if previous_provider_school_ids == updated_provider_school_ids
 
         course.refresh_last_published_at!
       end
 
-      def submitted_site_ids
-        @submitted_site_ids ||= Array(params[:site_ids]).compact_blank.map(&:to_i)
+      def handle_missing_provider_schools(missing_school_uuids)
+        return if missing_school_uuids.empty?
+
+        message = "no provider_school for provider=#{course.provider.id} " \
+          "school_uuids=#{missing_school_uuids.join(',')}"
+        raise UnresolvedProviderSchoolsError, message
       end
 
-      def current_site_ids
-        @current_site_ids ||= course.site_ids
-      end
-
-      def sites_to_attach_ids
-        @sites_to_attach_ids ||= submitted_site_ids - current_site_ids
-      end
-
-      def sites_to_remove_ids
-        @sites_to_remove_ids ||= current_site_ids - submitted_site_ids
-      end
-
-      def sites_by_id
-        @sites_by_id ||= Site.where(id: sites_to_attach_ids + sites_to_remove_ids).index_by(&:id)
-      end
-
-      def gias_schools_by_urn
-        @gias_schools_by_urn ||= GiasSchool
-          .where(urn: sites_by_id.values.map(&:urn).compact_blank)
-          .index_by(&:urn)
-      end
-
-      def attach_school(site)
-        ::CourseSchools::LegacySiteStatusCreator.call(course:, site:)
-
-        gias_school = gias_schools_by_urn[site.urn]
-        return unless gias_school
-
-        ::CourseSchools::Creator.call(course:, gias_school_id: gias_school.id)
-      rescue ActiveRecord::RecordNotFound
-        # No matching Provider::School yet — environment hasn't been fully
-        # backfilled or the provider's site predates the dual-write. Skip
-        # the new-model write rather than 404'ing the request; the schools
-        # backfill (or the next provider-side dual-write) reconciles later.
-        Rails.logger.warn(
-          "[CourseSchools] skipped course_school write — no provider_school for " \
-          "course=#{course.id} provider=#{course.provider_id} gias_school=#{gias_school.id}",
+      def update_provider_schools(provider_schools)
+        UpdateCourseProviderSchoolsService.call(
+          course:,
+          provider_schools:,
         )
       end
 
-      def detach_school(site)
-        ::CourseSchools::LegacySiteStatusRemover.call(course:, site:)
-
-        gias_school = gias_schools_by_urn[site.urn]
-        return unless gias_school
-
-        ::CourseSchools::Remover.call(course:, gias_school_id: gias_school.id)
+      # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+      # TODO School data remodel removal - remove this legacy write once all school reads use Course::School.
+      # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+      def update_site_statuses(provider_schools)
+        UpdateCourseSiteStatusesService.call(
+          course:,
+          school_uuids: provider_schools.map(&:uuid),
+        )
       end
 
-      def apply_publish_status_to_site_statuses
-        # Reload + scope to new_or_running so we never touch site_statuses
-        # that sync_schools just suspended or destroyed. Iterating the
-        # cached collection used to flip a freshly-suspended row back to
-        # running, leaving the unticked school still attached on the
-        # rendered page.
-        course.site_statuses.reload.new_or_running.each do |site_status|
-          site_status.assign_attributes(site_status_attributes)
-        end
+      def send_notifications(previous_school_names:, updated_school_names:)
+        return if previous_school_names == updated_school_names
+        return unless FeatureFlag.active?(:course_sites_updated_email_notification)
+
+        # The notification service still uses legacy "site" argument names.
+        # Keep that contract here until the notification API is renamed.
+        NotificationService::CourseSitesUpdated.call(
+          course:,
+          previous_site_names: previous_school_names,
+          updated_site_names: updated_school_names,
+        )
       end
 
-      def site_status_attributes
-        return { publish: :published, status: :running } if course.findable?
-
-        { publish: :unpublished, status: :new_status }
+      def school_names_for_notification
+        course.schools.includes(:provider_school)
+          .map { |course_school| course_school.provider_school.location_name }
+          .sort
       end
 
-      def send_notifications
-        updated_site_names = course.sites.map(&:location_name)
-        return if previous_site_names == updated_site_names
-
-        if FeatureFlag.active?(:course_sites_updated_email_notification)
-          NotificationService::CourseSitesUpdated.call(
-            course: course,
-            previous_site_names: previous_site_names,
-            updated_site_names: updated_site_names,
-          )
-        end
+      def provider_school_ids
+        course.schools.pluck(:provider_school_id).sort
       end
+
     end
   end
 end

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -12,24 +12,24 @@ module Publish
 
       class UnresolvedProviderSchoolsError < StandardError; end
 
-      def self.call_or_enqueue(course:, params:)
-        if Array(params[:school_uuids]).compact_blank.uniq.size > ENQUEUE_THRESHOLD
-          UpdateCourseSchoolsJob.perform_async(course.id, params.to_h)
+      def self.call_or_enqueue(course:, school_uuids:)
+        school_uuids = Array(school_uuids).compact_blank.uniq
+
+        if school_uuids.size > ENQUEUE_THRESHOLD
+          UpdateCourseSchoolsJob.perform_async(course.id, school_uuids)
         else
-          call(course:, params:)
+          call(course:, school_uuids:)
         end
       end
 
       # @param course [Course] course whose school selection should be updated
-      # @param params [Hash, ActionController::Parameters] course attributes and
-      #   submitted Provider::School UUIDs
+      # @param school_uuids [Array<String>] submitted Provider::School UUIDs
       # @param raise_on_missing_provider_schools [Boolean] inline requests pass
       #   true; queued requests pass false because a school may be removed while
       #   the job is waiting to run
-      def initialize(course:, params:, raise_on_missing_provider_schools: true)
+      def initialize(course:, school_uuids:, raise_on_missing_provider_schools: true)
         @course = course
-        @params = params.to_h.deep_symbolize_keys
-        @submitted_school_uuids = Array(@params.fetch(:school_uuids)).compact_blank.uniq
+        @submitted_school_uuids = Array(school_uuids).compact_blank.uniq
         @raise_on_missing_provider_schools = raise_on_missing_provider_schools
       end
 
@@ -40,15 +40,15 @@ module Publish
         ActiveRecord::Base.transaction do
           provider_schools = resolve_provider_schools
 
-          # TODO: We need to remove the school validated work from last cycle
-          course.assign_attributes(schools_validated: true)
+          # TODO: Schools validated is from a depricated feature, we'll have to remove this
+          course.schools_validated = true
 
           update_site_statuses(provider_schools)
-          update_provider_schools(provider_schools)
+          sync_course_schools(provider_schools)
 
-          # This persists schools_validated and deliberately touches the course
-          # and provider. Apply watches provider.changed_at to decide whether it
-          # needs to sync the provider's courses.
+          # TouchCourse uses update_columns, which bypasses TouchProvider. Saving
+          # here persists schools_validated and updates provider.changed_at so
+          # Apply knows that it needs to sync the provider's courses.
           course.save!
         end
 
@@ -65,11 +65,7 @@ module Publish
 
     private
 
-      attr_reader :course, :params, :submitted_school_uuids
-
-      def course_attributes
-        params.except(:school_uuids)
-      end
+      attr_reader :course, :submitted_school_uuids
 
       def resolve_provider_schools
         # Prevent a concurrent removal from deleting a school after resolution
@@ -102,7 +98,7 @@ module Publish
         Rails.logger.warn("[CourseSchools] skipped stale provider_school UUIDs - #{message}")
       end
 
-      def update_provider_schools(provider_schools)
+      def sync_course_schools(provider_schools)
         UpdateCourseProviderSchoolsService.call(
           course:,
           provider_schools:,

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -40,7 +40,9 @@ module Publish
         ActiveRecord::Base.transaction do
           provider_schools = resolve_provider_schools
 
-          course.assign_attributes(course_attributes)
+          # TODO: We need to remove the school validated work from last cycle
+          course.assign_attributes(schools_validated: true)
+
           update_site_statuses(provider_schools)
           update_provider_schools(provider_schools)
 

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -23,10 +23,14 @@ module Publish
       # @param course [Course] course whose school selection should be updated
       # @param params [Hash, ActionController::Parameters] course attributes and
       #   submitted Provider::School UUIDs
-      def initialize(course:, params:)
+      # @param raise_on_missing_provider_schools [Boolean] inline requests pass
+      #   true; queued requests pass false because a school may be removed while
+      #   the job is waiting to run
+      def initialize(course:, params:, raise_on_missing_provider_schools: true)
         @course = course
         @params = params.to_h.deep_symbolize_keys
         @submitted_school_uuids = Array(@params.fetch(:school_uuids)).compact_blank.uniq
+        @raise_on_missing_provider_schools = raise_on_missing_provider_schools
       end
 
       def call
@@ -91,7 +95,9 @@ module Publish
 
         message = "no provider_school for provider=#{course.provider.id} " \
           "school_uuids=#{missing_school_uuids.join(',')}"
-        raise UnresolvedProviderSchoolsError, message
+        raise UnresolvedProviderSchoolsError, message if raise_on_missing_provider_schools?
+
+        Rails.logger.warn("[CourseSchools] skipped stale provider_school UUIDs - #{message}")
       end
 
       def update_provider_schools(provider_schools)
@@ -134,6 +140,9 @@ module Publish
         course.schools.pluck(:provider_school_id).sort
       end
 
+      def raise_on_missing_provider_schools?
+        @raise_on_missing_provider_schools
+      end
     end
   end
 end

--- a/app/services/publish/schools/update_course_site_statuses_service.rb
+++ b/app/services/publish/schools/update_course_site_statuses_service.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Publish
+  module Schools
+    # rubocop:disable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+    # TODO School data remodel removal - remove this legacy SiteStatus sync service when school associations
+    # are written only through Provider::School and Course::School.
+    # Mirrors submitted Provider::School UUIDs to legacy SiteStatus rows while
+    # parts of Publish and the API still read the legacy school model.
+    class UpdateCourseSiteStatusesService
+      include ServicePattern
+
+      class UnresolvedSitesError < StandardError; end
+
+      def initialize(course:, school_uuids:)
+        @course = course
+        @submitted_school_uuids = Array(school_uuids).compact_blank.uniq
+      end
+
+      def call
+        sync_schools
+        apply_publish_status_to_site_statuses
+      end
+
+    private
+
+      attr_reader :course, :submitted_school_uuids
+
+      def sync_schools
+        return if sites_to_attach_uuids.empty? && sites_to_remove_uuids.empty?
+
+        validate_sites_to_attach!
+
+        sites_to_attach_uuids.each { |uuid| attach_school(sites_to_attach_by_uuid.fetch(uuid)) }
+        sites_to_remove_uuids.each { |uuid| detach_school(current_sites_by_uuid.fetch(uuid)) }
+
+        course.sites.reload
+      end
+
+      def current_site_uuids
+        current_sites_by_uuid.keys
+      end
+
+      def current_sites_by_uuid
+        @current_sites_by_uuid ||= course.sites.index_by(&:uuid)
+      end
+
+      # TODO School data remodel removal - remove once course school updates no longer diff legacy Site UUIDs.
+      def sites_to_attach_uuids
+        @sites_to_attach_uuids ||= submitted_school_uuids - current_site_uuids
+      end
+
+      # TODO School data remodel removal - remove once course school updates no longer diff legacy Site UUIDs.
+      def sites_to_remove_uuids
+        @sites_to_remove_uuids ||= current_site_uuids - submitted_school_uuids
+      end
+
+      # TODO School data remodel removal - remove when Provider::School UUIDs no longer need mapping to legacy Sites.
+      def sites_to_attach_by_uuid
+        @sites_to_attach_by_uuid ||= course.provider.sites
+          .where(uuid: sites_to_attach_uuids)
+          .index_by(&:uuid)
+      end
+
+      def validate_sites_to_attach!
+        missing_site_uuids = sites_to_attach_uuids - sites_to_attach_by_uuid.keys
+        return if missing_site_uuids.empty?
+
+        raise UnresolvedSitesError,
+              "no legacy site for provider=#{course.provider.id} " \
+              "course=#{course.id} school_uuids=#{missing_site_uuids.join(',')}"
+      end
+
+      # TODO School data remodel removal - remove with the legacy SiteStatus write path.
+      def attach_school(site)
+        ::CourseSchools::LegacySiteStatusCreator.call(course:, site:)
+      end
+
+      # TODO School data remodel removal - remove with the legacy SiteStatus write path.
+      def detach_school(site)
+        ::CourseSchools::LegacySiteStatusRemover.call(course:, site:)
+      end
+
+      # TODO School data remodel removal - remove when publish status no longer has to be mirrored to SiteStatus.
+      def apply_publish_status_to_site_statuses
+        # Reload + scope to new_or_running so we never touch site_statuses
+        # that sync_schools just suspended or destroyed. Iterating the
+        # cached collection used to flip a freshly-suspended row back to
+        # running, leaving the unticked school still attached on the
+        # rendered page.
+        course.site_statuses.reload.new_or_running.each do |site_status|
+          site_status.update!(site_status_attributes)
+        end
+      end
+
+      def site_status_attributes
+        return { publish: :published, status: :running } if course.findable?
+
+        { publish: :unpublished, status: :new_status }
+      end
+      # rubocop:enable Style/CommentAnnotation, Lint/RedundantCopDisableDirective
+    end
+  end
+end

--- a/app/views/publish/courses/schools/edit.html.erb
+++ b/app/views/publish/courses/schools/edit.html.erb
@@ -24,57 +24,57 @@
         provider: @provider,
       ) %>
 
-    <%= f.govuk_check_boxes_fieldset :site_ids,
-        legend:
-        {
-          text: "#{render CaptionText.new(text: course.name_and_code)} #{school_label_for(course)}".html_safe,
-          tag: "h1",
-          size: "l",
-        },
-        form_group: { data: { controller: "select-all-checkboxes show-all-schools", show_all_schools_visible_value: @course_school_form.schools_collapse_threshold } } do %>
+      <%= f.govuk_check_boxes_fieldset :school_uuids,
+          legend:
+          {
+            text: "#{render CaptionText.new(text: course.name_and_code)} #{school_label_for(course)}".html_safe,
+            tag: "h1",
+            size: "l",
+          },
+          form_group: { data: { controller: "select-all-checkboxes show-all-schools", show_all_schools_visible_value: @course_school_form.schools_collapse_threshold } } do %>
 
-          <p class="govuk-body">
-            <%= t("publish.courses.schools.attached_count", count: course.attached_schools_count) %>
-          </p>
+            <p class="govuk-body">
+              <%= t("publish.courses.schools.attached_count", count: course.attached_schools_count) %>
+            </p>
 
-          <div class="govuk-checkboxes__item">
-            <input type="checkbox"
-                   class="govuk-checkboxes__input"
-                   id="select-all-schools"
-                   data-select-all-checkboxes-target="selectAll"
-                   data-action="select-all-checkboxes#toggleAll">
+            <div class="govuk-checkboxes__item">
+              <input type="checkbox"
+                     class="govuk-checkboxes__input"
+                     id="select-all-schools"
+                     data-select-all-checkboxes-target="selectAll"
+                     data-action="select-all-checkboxes#toggleAll">
 
-            <label class="govuk-label govuk-checkboxes__label" for="select-all-schools">
-              <%= t("publish.courses.schools.select_all") %>
-            </label>
-          </div>
+              <label class="govuk-label govuk-checkboxes__label" for="select-all-schools">
+                <%= t("publish.courses.schools.select_all") %>
+              </label>
+            </div>
 
-          <div class="govuk-body govuk-!-margin-left-2">or</div>
-          <div class="govuk-hint"><%= t("publish.courses.schools.new.selection") %></div>
+            <div class="govuk-body govuk-!-margin-left-2">or</div>
+            <div class="govuk-hint"><%= t("publish.courses.schools.new.selection") %></div>
 
-          <% @course_school_form.sites.each_with_index do |site, index| %>
-            <%= f.govuk_check_box :site_ids,
-                site.id,
-                label: { text: [site.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
-                hint: { text: site.decorate.full_address, class: "govuk-!-font-size-16" },
-                link_errors: index.zero?,
-                data: {
-                  select_all_checkboxes_target: "checkbox",
-                  show_all_schools_target: "school",
-                  action: "select-all-checkboxes#updateSelectAll",
-                } %>
-         <% end %>
+            <% @course_school_form.schools.each_with_index do |school, index| %>
+              <%= f.govuk_check_box :school_uuids,
+                  school.uuid,
+                  label: { text: [school.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: school))].compact_blank.join(" ").html_safe },
+                  hint: { text: school.decorate.full_address, class: "govuk-!-font-size-16" },
+                  link_errors: index.zero?,
+                  data: {
+                    select_all_checkboxes_target: "checkbox",
+                    show_all_schools_target: "school",
+                    action: "select-all-checkboxes#updateSelectAll",
+                  } %>
+           <% end %>
 
-          <% if @course_school_form.collapse_schools? %>
-            <button type="button"
-                    class="app-button-link govuk-!-font-size-19 govuk-!-margin-top-4"
-                    hidden
-                    data-show-all-schools-target="showAll"
-                    data-action="show-all-schools#showAll">
-              <%= t("publish.courses.schools.show_all") %>
-            </button>
-          <% end %>
-      <% end %>
+            <% if @course_school_form.collapse_schools? %>
+              <button type="button"
+                      class="app-button-link govuk-!-font-size-19 govuk-!-margin-top-4"
+                      hidden
+                      data-show-all-schools-target="showAll"
+                      data-action="show-all-schools#showAll">
+                <%= t("publish.courses.schools.show_all") %>
+              </button>
+            <% end %>
+        <% end %>
 
       <%= f.govuk_submit "Update #{page_title.downcase}" %>
     <% end %>

--- a/app/views/publish/courses/schools/edit.html.erb
+++ b/app/views/publish/courses/schools/edit.html.erb
@@ -13,10 +13,6 @@
 ) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% if @course.recruitment_cycle_rollover_period_2026? %>
-    <%= f.hidden_field :schools_validated, value: "true" %>
-  <% end %>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render ::Publish::Schools::NotificationBannerComponent.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1229,10 +1229,11 @@ en:
               too_long: "Reduce the word count for salary details"
         publish/course_school_form:
           attributes:
-            site_ids:
+            school_uuids:
               no_schools: "Select at least one school"
               enter_schools: "Enter schools for this course"
               check_schools: "Review the schools for this course"
+              school_uuids_invalid: "The schools you submitted couldn’t be validated. Please try again. If the problem persists, please contact support."
         publish/course_study_site_form:
           attributes:
             study_site_ids:

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -905,32 +905,14 @@ describe CourseDecorator do
   end
 
   describe "#attached_schools_count" do
-    context "when the new school model flag is off (legacy sites)" do
-      let(:course) do
-        create(:course, sites: [
-          build(:site, location_name: "Zebra School"),
-          build(:site, location_name: "alpha school"),
-        ])
-      end
+    let(:course) { create(:course) }
 
-      it "counts the school-type sites attached to the course" do
-        expect(course.decorate.attached_schools_count).to eq(2)
-      end
+    before do
+      create_list(:course_school, 3, course:)
     end
 
-    context "when the new school model flag is on (Course::School / GiasSchool)" do
-      let(:course) { create(:course) }
-
-      before do
-        FeatureFlag.activate(:course_publishing_uses_new_school_model)
-        create(:course_school, course:, gias_school: build(:gias_school, name: "Zebra School"))
-        create(:course_school, course:, gias_school: build(:gias_school, name: "alpha school"))
-        create(:course_school, course:, gias_school: build(:gias_school, name: "Mango School"))
-      end
-
-      it "counts the course schools attached to the course" do
-        expect(course.decorate.attached_schools_count).to eq(3)
-      end
+    it "counts the course schools attached to the course" do
+      expect(course.decorate.attached_schools_count).to eq(3)
     end
   end
 end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -42,13 +42,25 @@ FactoryBot.define do
     # school to the wrong provider.
     trait :with_provider_school do
       after(:create) do |site|
-        create(
-          :provider_school,
+        gias_school = GiasSchool.find_or_create_by!(urn: site.urn) do |school|
+          school.name = site.location_name
+          school.address1 = site.address1
+          school.address2 = site.address2
+          school.address3 = site.address3
+          school.town = site.town
+          school.county = site.address4
+          school.postcode = site.postcode
+          school.region_code = site.region_code
+          school.status_code = GiasSchool.status_codes["open"]
+        end
+
+        Provider::School.find_or_create_by!(
           provider: site.provider,
-          gias_school: GiasSchool.find_by(urn: site.urn) || create(:gias_school, urn: site.urn),
+          gias_school:,
           site_code: site.code,
-          uuid: site.uuid,
-        )
+        ) do |provider_school|
+          provider_school.uuid = site.uuid
+        end
       end
     end
 

--- a/spec/forms/publish/course_school_form_spec.rb
+++ b/spec/forms/publish/course_school_form_spec.rb
@@ -4,72 +4,133 @@ require "rails_helper"
 
 module Publish
   describe CourseSchoolForm, type: :model do
+    let(:provider) { create(:provider) }
+    let(:provider_school_one) do
+      create(:provider_school, provider:, gias_school: create(:gias_school, name: "B School"))
+    end
+    let(:provider_school_two) do
+      create(:provider_school, provider:, gias_school: create(:gias_school, name: "A School"))
+    end
+    let(:course) { create(:course, provider:) }
     let(:params) { {} }
-    let(:site1) { build(:site, location_name: "location 1") }
-    let(:site2) { build(:site, location_name: "location 2") }
-    let(:site_status) { build(:site_status, :new_status, :unpublished, site: site1) }
 
-    let(:provider) { build(:provider, sites: [site1, site2]) }
-    let(:course) { create(:course, provider:, site_statuses: [site_status]) }
+    subject(:form) { described_class.new(course, params:) }
 
-    subject { described_class.new(course, params:) }
+    describe "#schools" do
+      it "returns the provider's Provider::School records ordered by name" do
+        provider_school_one
+        provider_school_two
 
-    describe "#sites" do
-      it "returns the provider's schools sorted by location name" do
-        provider = create(:provider, sites: [build(:site, location_name: "B School"), build(:site, location_name: "A School")])
-        form = described_class.new(create(:course, provider:), params: {})
+        expect(form.schools).to eq([provider_school_two, provider_school_one])
+      end
 
-        expect(form.sites.map(&:location_name)).to eq(["A School", "B School"])
+      it "returns a closed GIAS school when its Provider::School exists" do
+        closed_provider_school = create(
+          :provider_school,
+          provider:,
+          gias_school: create(:gias_school, :closed),
+        )
+
+        expect(form.schools).to include(closed_provider_school)
+      end
+    end
+
+    describe "#school_uuids" do
+      before do
+        create(
+          :course_school,
+          course:,
+          provider_school: provider_school_one,
+          gias_school: provider_school_one.gias_school,
+        )
+      end
+
+      it "uses the selected Provider::School UUIDs" do
+        expect(form.school_uuids).to eq([provider_school_one.uuid])
       end
     end
 
     describe "#collapse_schools?" do
-      it "is false when the provider has 20 schools or fewer" do
-        provider = create(:provider, sites: build_list(:site, 20))
-        form = described_class.new(create(:course, provider:), params: {})
+      let(:provider) { create(:provider) }
+      let!(:provider_schools) { create_list(:provider_school, school_count, provider:) }
 
-        expect(form.collapse_schools?).to be(false)
+      context "with 20 schools" do
+        let(:school_count) { 20 }
+
+        it "is false" do
+          expect(form.collapse_schools?).to be(false)
+        end
       end
 
-      it "is true when the provider has more than 20 schools" do
-        provider = create(:provider, sites: build_list(:site, 21))
-        form = described_class.new(create(:course, provider:), params: {})
+      context "with 21 schools" do
+        let(:school_count) { 21 }
 
-        expect(form.collapse_schools?).to be(true)
+        it "is true without loading all the schools" do
+          schools = form.schools
+
+          expect(schools).not_to be_loaded
+          expect(form.collapse_schools?).to be(true)
+          expect(schools).not_to be_loaded
+        end
       end
     end
 
     describe "validations", travel: Find::CycleTimetable.mid_cycle(2026) do
-      before { subject.valid? }
-
-      it "validates :site_ids" do
-        expect(subject.errors[:site_ids]).to include(I18n.t("activemodel.errors.models.publish/course_school_form.attributes.site_ids.no_schools"))
+      it "requires a school" do
+        expect(form).not_to be_valid
+        expect(form.errors[:school_uuids]).to include(
+          I18n.t("activemodel.errors.models.publish/course_school_form.attributes.school_uuids.no_schools"),
+        )
       end
 
-      context "when the course is exempt from needing a school (publish without schools allowed)" do
+      it "rejects an unknown UUID" do
+        invalid_form = described_class.new(course, params: { school_uuids: [SecureRandom.uuid] })
+
+        expect(invalid_form).not_to be_valid
+        expect(invalid_form.errors[:school_uuids]).to include(
+          I18n.t("activemodel.errors.models.publish/course_school_form.attributes.school_uuids.school_uuids_invalid"),
+        )
+      end
+
+      it "rejects a Provider::School UUID belonging to another provider" do
+        other_provider_school = create(:provider_school)
+        invalid_form = described_class.new(course, params: { school_uuids: [other_provider_school.uuid] })
+
+        expect(invalid_form).not_to be_valid
+        expect(invalid_form.errors[:school_uuids]).to include(
+          I18n.t("activemodel.errors.models.publish/course_school_form.attributes.school_uuids.school_uuids_invalid"),
+        )
+      end
+
+      it "accepts a Provider::School UUID belonging to the provider" do
+        valid_form = described_class.new(course, params: { school_uuids: [provider_school_one.uuid] })
+
+        expect(valid_form).to be_valid
+      end
+
+      it "accepts a closed GIAS school when its Provider::School belongs to the provider" do
+        closed_provider_school = create(
+          :provider_school,
+          provider:,
+          gias_school: create(:gias_school, :closed),
+        )
+        valid_form = described_class.new(course, params: { school_uuids: [closed_provider_school.uuid] })
+
+        expect(valid_form).to be_valid
+      end
+
+      context "when the course is exempt from needing a school" do
         let(:course) do
-          create(:course, :with_salary, provider:, site_statuses: [site_status], publish_without_schools_allowed: true)
+          create(
+            :course,
+            :with_salary,
+            provider:,
+            publish_without_schools_allowed: true,
+          )
         end
 
-        before { FeatureFlag.activate(:course_publishing_uses_new_school_model) }
-
-        it "does not require at least one school" do
-          subject.valid?
-
-          expect(subject.errors[:site_ids]).to be_empty
-        end
-
-        context "when the new school model flag is OFF" do
-          # Support has approved this course to publish without schools; that
-          # decision should hold regardless of the course_publishing_uses_new_school_model
-          # rollout flag. (Flag deliberately NOT activated here.)
-          before { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
-
-          it "still does not require at least one school" do
-            subject.valid?
-
-            expect(subject.errors[:site_ids]).to be_empty
-          end
+        it "does not require a school" do
+          expect(form).to be_valid
         end
       end
     end

--- a/spec/jobs/update_course_schools_job_spec.rb
+++ b/spec/jobs/update_course_schools_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UpdateCourseSchoolsJob, type: :job do
   let(:course) { create(:course) }
   let(:params) { { "school_uuids" => [SecureRandom.uuid] } }
 
-  it "calls the course school update service" do
+  it "allows the service to skip Provider::Schools removed while the job was queued" do
     allow(Course).to receive(:find).and_return(course)
     allow(Publish::Schools::UpdateCourseSchoolsService).to receive(:call)
 
@@ -13,6 +13,6 @@ RSpec.describe UpdateCourseSchoolsJob, type: :job do
     expect(Course).to have_received(:find).with(course.id)
     expect(Publish::Schools::UpdateCourseSchoolsService)
       .to have_received(:call)
-      .with(course:, params:)
+      .with(course:, params:, raise_on_missing_provider_schools: false)
   end
 end

--- a/spec/jobs/update_course_schools_job_spec.rb
+++ b/spec/jobs/update_course_schools_job_spec.rb
@@ -2,23 +2,17 @@ require "rails_helper"
 
 RSpec.describe UpdateCourseSchoolsJob, type: :job do
   let(:course) { create(:course) }
-  let(:params) { { site_ids: [SecureRandom.uuid] } }
+  let(:params) { { "school_uuids" => [SecureRandom.uuid] } }
 
-  it "calls UpdateCourseSchoolsService with the correct arguments" do
-    service_instance = instance_double(Publish::Schools::UpdateCourseSchoolsService)
-
+  it "calls the course school update service" do
     allow(Course).to receive(:find).and_return(course)
-    allow(Publish::Schools::UpdateCourseSchoolsService)
-      .to receive(:new)
-      .and_return(service_instance)
-    allow(service_instance).to receive(:call)
+    allow(Publish::Schools::UpdateCourseSchoolsService).to receive(:call)
 
     described_class.new.perform(course.id, params)
 
     expect(Course).to have_received(:find).with(course.id)
     expect(Publish::Schools::UpdateCourseSchoolsService)
-      .to have_received(:new)
-      .with(course: course, params: params)
-    expect(service_instance).to have_received(:call)
+      .to have_received(:call)
+      .with(course:, params:)
   end
 end

--- a/spec/jobs/update_course_schools_job_spec.rb
+++ b/spec/jobs/update_course_schools_job_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 RSpec.describe UpdateCourseSchoolsJob, type: :job do
   let(:course) { create(:course) }
-  let(:params) { { "school_uuids" => [SecureRandom.uuid] } }
+  let(:school_uuids) { [SecureRandom.uuid] }
 
   it "allows the service to skip Provider::Schools removed while the job was queued" do
     allow(Course).to receive(:find).and_return(course)
     allow(Publish::Schools::UpdateCourseSchoolsService).to receive(:call)
 
-    described_class.new.perform(course.id, params)
+    described_class.new.perform(course.id, school_uuids)
 
     expect(Course).to have_received(:find).with(course.id)
     expect(Publish::Schools::UpdateCourseSchoolsService)
       .to have_received(:call)
-      .with(course:, params:, raise_on_missing_provider_schools: false)
+      .with(course:, school_uuids:, raise_on_missing_provider_schools: false)
   end
 end

--- a/spec/services/publish/schools/update_course_provider_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_provider_schools_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  module Schools
+    RSpec.describe UpdateCourseProviderSchoolsService do
+      let(:site_one) { build(:site, location_name: "Site 1", code: "X") }
+      let(:site_two) { build(:site, location_name: "Site 2", code: "Y") }
+      let(:provider) { create(:provider, sites: [site_one, site_two]) }
+      let(:course) { create(:course, provider:) }
+      let(:gias_school_one) { create(:gias_school, urn: site_one.urn) }
+      let(:gias_school_two) { create(:gias_school, urn: site_two.urn) }
+      let!(:provider_school_one) do
+        create(:provider_school, provider:, gias_school: gias_school_one, site_code: site_one.code, uuid: site_one.uuid)
+      end
+      let!(:provider_school_two) do
+        create(:provider_school, provider:, gias_school: gias_school_two, site_code: site_two.code, uuid: site_two.uuid)
+      end
+
+      describe "#call" do
+        subject(:service_call) { described_class.call(course:, provider_schools:) }
+
+        context "when a provider school is newly attached" do
+          let(:provider_schools) { [provider_school_two] }
+
+          it "creates a Course::School row for the submitted provider school" do
+            expect { service_call }.to change { course.schools.count }.by(1)
+
+            added = course.schools.find_by(provider_school: provider_school_two)
+            expect(added).to be_present
+            expect(added.gias_school).to eq(gias_school_two)
+          end
+        end
+
+        context "when a provider school is detached" do
+          let(:provider_schools) { [] }
+
+          before do
+            create(:course_school, course:, gias_school: gias_school_one, provider_school: provider_school_one)
+          end
+
+          it "destroys the Course::School row for the removed provider school" do
+            expect { service_call }.to change { course.schools.count }.by(-1)
+
+            expect(course.schools.where(provider_school: provider_school_one)).to be_empty
+          end
+        end
+
+        context "when the selection changes" do
+          let(:provider_schools) { [provider_school_two] }
+
+          before do
+            create(:course_school, course:, gias_school: gias_school_one, provider_school: provider_school_one)
+          end
+
+          it "replaces the existing Course::School row" do
+            expect { service_call }
+              .to change { course.schools.reload.pluck(:provider_school_id) }
+              .from([provider_school_one.id])
+              .to([provider_school_two.id])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -20,56 +20,62 @@ module Publish
 
       describe ".call_or_enqueue" do
         context "when the number of school UUIDs exceeds ENQUEUE_THRESHOLD" do
-          let(:params) { { school_uuids: Array.new(31) { SecureRandom.uuid } } }
+          let(:school_uuids) { Array.new(31) { SecureRandom.uuid } }
 
           it "enqueues the update" do
-            expect(UpdateCourseSchoolsJob).to receive(:perform_async).with(course.id, params.to_h)
+            expect(UpdateCourseSchoolsJob).to receive(:perform_async).with(course.id, school_uuids)
 
-            described_class.call_or_enqueue(course:, params:)
+            described_class.call_or_enqueue(course:, school_uuids:)
           end
         end
 
         context "when the number of school UUIDs equals ENQUEUE_THRESHOLD" do
-          let(:params) { { school_uuids: Array.new(30) { SecureRandom.uuid } + [""] } }
+          let(:school_uuids) { Array.new(30) { SecureRandom.uuid } + [""] }
 
           it "runs the update inline" do
             allow(described_class).to receive(:call)
 
-            described_class.call_or_enqueue(course:, params:)
+            described_class.call_or_enqueue(course:, school_uuids:)
 
-            expect(described_class).to have_received(:call).with(course:, params:)
+            expect(described_class).to have_received(:call).with(
+              course:,
+              school_uuids: school_uuids.compact_blank,
+            )
           end
         end
 
         context "when duplicate and blank UUIDs take the submitted count over ENQUEUE_THRESHOLD" do
-          let(:params) { { school_uuids: Array.new(31, provider_school_one.uuid) + [""] } }
+          let(:school_uuids) { Array.new(31, provider_school_one.uuid) + [""] }
 
           it "counts unique non-blank UUIDs and runs the update inline" do
             allow(described_class).to receive(:call)
 
-            described_class.call_or_enqueue(course:, params:)
+            described_class.call_or_enqueue(course:, school_uuids:)
 
-            expect(described_class).to have_received(:call).with(course:, params:)
+            expect(described_class).to have_received(:call).with(
+              course:,
+              school_uuids: [provider_school_one.uuid],
+            )
           end
         end
 
         context "when school UUIDs are nil" do
-          let(:params) { { school_uuids: nil } }
+          let(:school_uuids) { nil }
 
           it "runs the update inline" do
             allow(described_class).to receive(:call)
 
-            described_class.call_or_enqueue(course:, params:)
+            described_class.call_or_enqueue(course:, school_uuids:)
 
-            expect(described_class).to have_received(:call).with(course:, params:)
+            expect(described_class).to have_received(:call).with(course:, school_uuids: [])
           end
         end
       end
 
       describe "#call" do
-        subject(:service_call) { described_class.call(course:, params:) }
+        subject(:service_call) { described_class.call(course:, school_uuids:) }
 
-        let(:params) { { school_uuids: [provider_school_two.uuid] } }
+        let(:school_uuids) { [provider_school_two.uuid] }
 
         it "creates both Course::School and legacy SiteStatus relationships" do
           expect { service_call }
@@ -91,8 +97,7 @@ module Publish
           end
         end
 
-        it "persists course attributes and touches the provider for Apply" do
-          params[:schools_validated] = "true"
+        it "marks the schools as validated and touches the provider for Apply" do
           provider.update_columns(changed_at: 2.days.ago)
           previous_provider_changed_at = provider.changed_at
 
@@ -119,7 +124,7 @@ module Publish
         end
 
         context "when an empty selection is allowed" do
-          let(:params) { { school_uuids: [] } }
+          let(:school_uuids) { [] }
 
           before do
             attach_school(site_one, provider_school_one)
@@ -154,7 +159,7 @@ module Publish
           end
 
           context "when a school is removed" do
-            let(:params) { { school_uuids: [] } }
+            let(:school_uuids) { [] }
 
             before do
               attach_school(site_one, provider_school_one, status: :running, publish: :published)
@@ -215,20 +220,20 @@ module Publish
         end
 
         it "raises inline when a Provider::School UUID cannot be resolved" do
-          expect { described_class.call(course:, params: { school_uuids: [SecureRandom.uuid] }) }
+          expect { described_class.call(course:, school_uuids: [SecureRandom.uuid]) }
             .to raise_error(described_class::UnresolvedProviderSchoolsError)
         end
 
         it "requires the caller to provide school_uuids" do
-          expect { described_class.call(course:, params: { schools_validated: "true" }) }
-            .to raise_error(KeyError, /school_uuids/)
+          expect { described_class.call(course:) }
+            .to raise_error(ArgumentError, /school_uuids/)
         end
 
         context "when the update is run by the queued job" do
           subject(:service_call) do
             described_class.call(
               course:,
-              params:,
+              school_uuids:,
               raise_on_missing_provider_schools: false,
             )
           end
@@ -243,7 +248,7 @@ module Publish
               uuid: site_three.uuid,
             )
           end
-          let(:params) { { school_uuids: [provider_school_two.uuid, provider_school_three.uuid] } }
+          let(:school_uuids) { [provider_school_two.uuid, provider_school_three.uuid] }
 
           before do
             attach_school(site_one, provider_school_one)
@@ -278,7 +283,7 @@ module Publish
           subject(:service_call) do
             described_class.call(
               course:,
-              params:,
+              school_uuids:,
               raise_on_missing_provider_schools: false,
             )
           end
@@ -293,7 +298,7 @@ module Publish
               uuid: site_three.uuid,
             )
           end
-          let(:params) { { school_uuids: [provider_school_two.uuid, provider_school_three.uuid] } }
+          let(:school_uuids) { [provider_school_two.uuid, provider_school_three.uuid] }
 
           before do
             attach_school(site_three, provider_school_three)
@@ -314,7 +319,7 @@ module Publish
           subject(:service_call) do
             described_class.call(
               course:,
-              params:,
+              school_uuids:,
               raise_on_missing_provider_schools: false,
             )
           end
@@ -337,7 +342,7 @@ module Publish
           subject(:service_call) do
             described_class.call(
               course:,
-              params:,
+              school_uuids:,
               raise_on_missing_provider_schools: false,
             )
           end
@@ -358,7 +363,7 @@ module Publish
           subject(:service_call) do
             described_class.call(
               course:,
-              params:,
+              school_uuids:,
               raise_on_missing_provider_schools: false,
             )
           end
@@ -366,7 +371,7 @@ module Publish
           let(:provider_school_without_site) do
             create(:provider_school, provider:, gias_school: create(:gias_school))
           end
-          let(:params) { { school_uuids: [provider_school_without_site.uuid] } }
+          let(:school_uuids) { [provider_school_without_site.uuid] }
 
           it "raises from a queued update and writes neither relationship" do
             expect { service_call }

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -30,7 +30,7 @@ module Publish
         end
 
         context "when the number of school UUIDs equals ENQUEUE_THRESHOLD" do
-          let(:params) { { school_uuids: Array.new(30) { SecureRandom.uuid } } }
+          let(:params) { { school_uuids: Array.new(30) { SecureRandom.uuid } + [""] } }
 
           it "runs the update inline" do
             allow(described_class).to receive(:call)
@@ -41,6 +41,29 @@ module Publish
           end
         end
 
+        context "when duplicate and blank UUIDs take the submitted count over ENQUEUE_THRESHOLD" do
+          let(:params) { { school_uuids: Array.new(31, provider_school_one.uuid) + [""] } }
+
+          it "counts unique non-blank UUIDs and runs the update inline" do
+            allow(described_class).to receive(:call)
+
+            described_class.call_or_enqueue(course:, params:)
+
+            expect(described_class).to have_received(:call).with(course:, params:)
+          end
+        end
+
+        context "when school UUIDs are nil" do
+          let(:params) { { school_uuids: nil } }
+
+          it "runs the update inline" do
+            allow(described_class).to receive(:call)
+
+            described_class.call_or_enqueue(course:, params:)
+
+            expect(described_class).to have_received(:call).with(course:, params:)
+          end
+        end
       end
 
       describe "#call" do
@@ -201,12 +224,129 @@ module Publish
             .to raise_error(KeyError, /school_uuids/)
         end
 
+        context "when the update is run by the queued job" do
+          subject(:service_call) do
+            described_class.call(
+              course:,
+              params:,
+              raise_on_missing_provider_schools: false,
+            )
+          end
+
+          let(:site_three) { create(:site, provider:, location_name: "Site 3") }
+          let(:provider_school_three) do
+            create(
+              :provider_school,
+              provider:,
+              gias_school: create(:gias_school, name: "Site 3", urn: site_three.urn),
+              site_code: site_three.code,
+              uuid: site_three.uuid,
+            )
+          end
+          let(:params) { { school_uuids: [provider_school_two.uuid, provider_school_three.uuid] } }
+
+          before do
+            attach_school(site_one, provider_school_one)
+            provider_school_three.destroy!
+          end
+
+          it "skips a school deleted since submission and saves the remaining selection" do
+            expect(Rails.logger).to receive(:warn).with(/skipped stale provider_school UUIDs/)
+
+            expect { service_call }.not_to raise_error
+            expect(course.reload.schools.pluck(:provider_school_id)).to eq([provider_school_two.id])
+            expect(course.sites).to contain_exactly(site_two)
+          end
+
+          it "notifies using only the schools that still exist" do
+            FeatureFlag.activate(:course_sites_updated_email_notification)
+            allow(Rails.logger).to receive(:warn)
+
+            expect(NotificationService::CourseSitesUpdated).to receive(:call).with(
+              course:,
+              previous_site_names: [provider_school_one.location_name],
+              updated_site_names: [provider_school_two.location_name],
+            )
+
+            service_call
+          ensure
+            FeatureFlag.deactivate(:course_sites_updated_email_notification)
+          end
+        end
+
+        context "when a stale queued school was attached before it was removed" do
+          subject(:service_call) do
+            described_class.call(
+              course:,
+              params:,
+              raise_on_missing_provider_schools: false,
+            )
+          end
+
+          let(:site_three) { create(:site, provider:, location_name: "Site 3") }
+          let(:provider_school_three) do
+            create(
+              :provider_school,
+              provider:,
+              gias_school: create(:gias_school, name: "Site 3", urn: site_three.urn),
+              site_code: site_three.code,
+              uuid: site_three.uuid,
+            )
+          end
+          let(:params) { { school_uuids: [provider_school_two.uuid, provider_school_three.uuid] } }
+
+          before do
+            attach_school(site_three, provider_school_three)
+            provider_school_three.destroy!
+          end
+
+          it "removes the stale legacy relationship and applies the remaining selection" do
+            allow(Rails.logger).to receive(:warn)
+
+            service_call
+
+            expect(course.reload.schools.pluck(:provider_school_id)).to eq([provider_school_two.id])
+            expect(course.sites).to contain_exactly(site_two)
+          end
+        end
+
+        context "when a queued write fails" do
+          subject(:service_call) do
+            described_class.call(
+              course:,
+              params:,
+              raise_on_missing_provider_schools: false,
+            )
+          end
+
+          before do
+            attach_school(site_one, provider_school_one)
+            allow(UpdateCourseProviderSchoolsService).to receive(:call)
+              .and_raise(ActiveRecord::RecordInvalid)
+          end
+
+          it "still rolls back the dual write" do
+            expect { service_call }.to raise_error(ActiveRecord::RecordInvalid)
+
+            expect(course.reload.schools.pluck(:provider_school_id)).to eq([provider_school_one.id])
+            expect(course.sites).to contain_exactly(site_one)
+          end
+        end
+
         context "when the course save fails after both relationship writes" do
+          subject(:service_call) do
+            described_class.call(
+              course:,
+              params:,
+              raise_on_missing_provider_schools: false,
+            )
+          end
+
           before do
             allow(course).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
           end
 
-          it "rolls back both relationship writes" do
+          it "rolls back both queued relationship writes" do
             expect { service_call }.to raise_error(ActiveRecord::RecordInvalid)
 
             expect(course.reload.schools).to be_empty
@@ -215,12 +355,20 @@ module Publish
         end
 
         context "when a Provider::School has no matching legacy Site" do
+          subject(:service_call) do
+            described_class.call(
+              course:,
+              params:,
+              raise_on_missing_provider_schools: false,
+            )
+          end
+
           let(:provider_school_without_site) do
             create(:provider_school, provider:, gias_school: create(:gias_school))
           end
           let(:params) { { school_uuids: [provider_school_without_site.uuid] } }
 
-          it "raises and writes neither relationship" do
+          it "raises from a queued update and writes neither relationship" do
             expect { service_call }
               .to raise_error(UpdateCourseSiteStatusesService::UnresolvedSitesError)
 

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -1,94 +1,146 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module Publish
   module Schools
     RSpec.describe UpdateCourseSchoolsService do
-      let(:site_one) { build(:site, location_name: "location 1") }
-      let(:site_two) { build(:site, location_name: "location 2") }
-      let(:site_status) { build(:site_status, :new_status, :unpublished, site: site_one) }
-      let(:provider) { build(:provider, sites: [site_one, site_two]) }
-      let(:course) { create(:course, provider:, site_statuses: [site_status]) }
-      let(:previous_site_names) { course.sites.map(&:location_name) }
+      let(:site_one) { build(:site, location_name: "Site 1", code: "A") }
+      let(:site_two) { build(:site, location_name: "Site 2", code: "B") }
+      let(:provider) { create(:provider, sites: [site_one, site_two]) }
+      let(:course) { create(:course, provider:) }
+      let(:gias_school_one) { create(:gias_school, name: "Site 1", urn: site_one.urn) }
+      let(:gias_school_two) { create(:gias_school, name: "Site 2", urn: site_two.urn) }
+      let!(:provider_school_one) do
+        create(:provider_school, provider:, gias_school: gias_school_one, site_code: site_one.code, uuid: site_one.uuid)
+      end
+      let!(:provider_school_two) do
+        create(:provider_school, provider:, gias_school: gias_school_two, site_code: site_two.code, uuid: site_two.uuid)
+      end
 
       describe ".call_or_enqueue" do
-        context "when site_ids count exceeds ENQUEUE_THRESHOLD" do
-          let(:params) { { site_ids: Array.new(31) { SecureRandom.uuid } } }
+        context "when the number of school UUIDs exceeds ENQUEUE_THRESHOLD" do
+          let(:params) { { school_uuids: Array.new(31) { SecureRandom.uuid } } }
 
-          it "enqueues the job" do
+          it "enqueues the update" do
             expect(UpdateCourseSchoolsJob).to receive(:perform_async).with(course.id, params.to_h)
-            described_class.call_or_enqueue(course: course, params: params)
+
+            described_class.call_or_enqueue(course:, params:)
           end
         end
 
-        context "when site_ids count is below or equal to ENQUEUE_THRESHOLD" do
-          let(:params) { { site_ids: provider.site_ids } }
+        context "when the number of school UUIDs equals ENQUEUE_THRESHOLD" do
+          let(:params) { { school_uuids: Array.new(30) { SecureRandom.uuid } } }
 
-          it "runs the service inline" do
-            service_instance = instance_double(described_class)
+          it "runs the update inline" do
+            allow(described_class).to receive(:call)
 
-            allow(described_class)
-              .to receive(:new)
-              .with(course: course, params: params)
-              .and_return(service_instance)
+            described_class.call_or_enqueue(course:, params:)
 
-            allow(service_instance).to receive(:call)
-
-            described_class.call_or_enqueue(course: course, params: params)
-
-            expect(described_class)
-              .to have_received(:new)
-              .with(course: course, params: params)
-
-            expect(service_instance).to have_received(:call)
+            expect(described_class).to have_received(:call).with(course:, params:)
           end
         end
+
       end
 
       describe "#call" do
-        subject(:service_call) { described_class.new(course:, params:).call }
+        subject(:service_call) { described_class.call(course:, params:) }
 
-        context "when site_ids are different from course.site_ids" do
-          let(:params) { { site_ids: provider.site_ids } }
-          let(:updated_site_names) { provider.sites.order(:location_name).map(&:location_name) }
+        let(:params) { { school_uuids: [provider_school_two.uuid] } }
 
-          context "when feature flag is enabled" do
-            before { FeatureFlag.activate(:course_sites_updated_email_notification) }
+        it "creates both Course::School and legacy SiteStatus relationships" do
+          expect { service_call }
+            .to change { course.schools.count }.by(1)
+            .and change { course.site_statuses.count }.by(1)
 
-            it "calls the CourseSitesUpdated notification service" do
-              expect(NotificationService::CourseSitesUpdated).to receive(:call)
-                .with(course: course, previous_site_names: previous_site_names, updated_site_names: updated_site_names)
-              service_call
-            end
+          expect(course.reload.schools.find_by(provider_school: provider_school_two)).to be_present
+          expect(course.sites).to contain_exactly(site_two)
+        end
+
+        context "when the Provider::School GIAS school is closed" do
+          let(:gias_school_two) { create(:gias_school, :closed, name: "Site 2", urn: site_two.urn) }
+
+          it "still creates both school relationships" do
+            service_call
+
+            expect(course.reload.schools.find_by(provider_school: provider_school_two)).to be_present
+            expect(course.sites).to contain_exactly(site_two)
+          end
+        end
+
+        it "persists course attributes and touches the provider for Apply" do
+          params[:schools_validated] = "true"
+          provider.update_columns(changed_at: 2.days.ago)
+          previous_provider_changed_at = provider.changed_at
+
+          service_call
+
+          expect(course.reload.schools_validated).to be(true)
+          expect(provider.reload.changed_at).to be > previous_provider_changed_at
+        end
+
+        context "when both school relationships already exist" do
+          before do
+            attach_school(site_one, provider_school_one)
+            attach_school(site_two, provider_school_two)
           end
 
-          context "when feature flag is disabled" do
-            before { FeatureFlag.deactivate(:course_sites_updated_email_notification) }
+          it "removes the unselected school from both models" do
+            expect { service_call }
+              .to change { course.schools.reload.count }.by(-1)
+              .and change { course.site_statuses.reload.count }.by(-1)
 
-            it "does not call the notification service" do
-              expect(NotificationService::CourseSitesUpdated).not_to receive(:call)
-              service_call
-            end
+            expect(course.reload.schools.pluck(:provider_school_id)).to eq([provider_school_two.id])
+            expect(course.sites).to contain_exactly(site_two)
+          end
+        end
+
+        context "when an empty selection is allowed" do
+          let(:params) { { school_uuids: [] } }
+
+          before do
+            attach_school(site_one, provider_school_one)
           end
 
-          context "when course is not published" do
-            it "sets all site_statuses to new_status" do
-              service_call
-              expect(course.reload.site_statuses.pluck(:status)).to match(%w[new_status new_status])
-            end
+          it "removes every school from both models" do
+            expect { service_call }
+              .to change { course.schools.reload.count }.from(1).to(0)
+              .and change { course.site_statuses.reload.count }.from(1).to(0)
+          end
+        end
+
+        context "when the course is published" do
+          let(:course) { create(:course, :published, provider:) }
+          let(:previous_timestamp) { 1.day.ago.change(usec: 0) }
+
+          before do
+            provider.update_columns(changed_at: 2.days.ago)
+            course.update_columns(changed_at: 2.days.ago)
+            course.enrichments.published.update_all(last_published_timestamp_utc: previous_timestamp)
           end
 
-          context "when course is published" do
-            let(:course) { create(:course, :published, provider:, site_statuses: [site_status]) }
-            let(:site_status) { build(:site_status, :running, :published, site: site_one) }
-            let(:previous_timestamp) { 1.day.ago.change(usec: 0) }
+          it "touches the provider when a school is added" do
+            expect { service_call }.to(change { provider.reload.changed_at })
+          end
+
+          it "refreshes last_published_at when a school is added" do
+            service_call
+
+            expect(course.reload.last_published_at).to be_within(5.seconds).of(Time.zone.now)
+            expect(course.last_published_at).to be > previous_timestamp
+          end
+
+          context "when a school is removed" do
+            let(:params) { { school_uuids: [] } }
 
             before do
-              course.enrichments.published.update_all(last_published_timestamp_utc: previous_timestamp)
+              attach_school(site_one, provider_school_one, status: :running, publish: :published)
+              provider.update_columns(changed_at: 2.days.ago)
+              course.update_columns(changed_at: 2.days.ago)
             end
 
-            it "sets all site_statuses to running" do
-              service_call
-              expect(course.reload.site_statuses.pluck(:status)).to match(%w[running running])
+            it "touches the provider" do
+              expect { service_call }.to(change { provider.reload.changed_at })
             end
 
             it "refreshes last_published_at" do
@@ -100,199 +152,106 @@ module Publish
           end
         end
 
-        context "when site_ids are the same as course.site_ids" do
-          let(:params) { { site_ids: course.site_ids } }
+        context "when notifications are enabled" do
+          before do
+            FeatureFlag.activate(:course_sites_updated_email_notification)
+            attach_school(site_one, provider_school_one)
+          end
 
-          it "does not call the notification service" do
-            expect(NotificationService::CourseSitesUpdated).not_to receive(:call)
+          after do
+            FeatureFlag.deactivate(:course_sites_updated_email_notification)
+          end
+
+          it "sends the new-model school names through the legacy notification interface" do
+            expect(NotificationService::CourseSitesUpdated).to receive(:call).with(
+              course:,
+              previous_site_names: [provider_school_one.location_name],
+              updated_site_names: [provider_school_two.location_name],
+            )
+
             service_call
           end
         end
 
-        # Regression coverage for the QA-reported bug: when a school is
-        # unticked, sync_schools suspends (or destroys) its site_status,
-        # then apply_publish_status_to_site_statuses runs over the remaining
-        # site_statuses. These tests pin down that:
-        #   1. Site_statuses suspended/destroyed during sync stay that way.
-        #   2. Site_statuses still attached after sync get the right
-        #      publish/status applied.
-        describe "site_status state after the apply step" do
-          let(:provider) { create(:provider, sites: [site_one, site_two]) }
-          let(:site_one) { build(:site, location_name: "Site 1") }
-          let(:site_two) { build(:site, location_name: "Site 2") }
-
-          context "when unticking a school on a published course" do
-            let(:course) do
-              create(
-                :course,
-                :published,
-                provider:,
-                site_statuses: [
-                  build(:site_status, :running, :published, site: site_one),
-                  build(:site_status, :running, :published, site: site_two),
-                ],
-              )
-            end
-            let(:params) { { site_ids: [site_two.id] } }
-
-            it "destroys the unticked site_status" do
-              described_class.new(course:, params:).call
-
-              expect(course.reload.site_statuses.where(site: site_one)).to be_empty
-            end
-
-            it "removes the unticked school from course.sites" do
-              described_class.new(course:, params:).call
-
-              expect(course.reload.sites.map(&:id)).to contain_exactly(site_two.id)
-            end
-
-            it "leaves the kept site_status as :running and :published" do
-              described_class.new(course:, params:).call
-
-              site_status = course.reload.site_statuses.find_by!(site: site_two)
-              expect(site_status).to be_status_running
-              expect(site_status).to be_published_on_ucas
-            end
-          end
-
-          context "when an existing suspended site_status is on the course" do
-            let(:course) do
-              create(
-                :course,
-                :published,
-                provider:,
-                site_statuses: [
-                  build(:site_status, :running, :published, site: site_one),
-                  build(:site_status, :suspended, :unpublished, site: site_two),
-                ],
-              )
-            end
-            let(:params) { { site_ids: [site_one.id] } }
-
-            it "does not flip the suspended site_status back to running" do
-              described_class.new(course:, params:).call
-
-              site_status = course.reload.site_statuses.find_by!(site: site_two)
-              expect(site_status).to be_status_suspended
-            end
-
-            it "does not flip the suspended site_status back to published" do
-              described_class.new(course:, params:).call
-
-              site_status = course.reload.site_statuses.find_by!(site: site_two)
-              expect(site_status).to be_unpublished_on_ucas
-            end
-          end
-
-          context "when an existing discontinued site_status is on the course" do
-            let(:course) do
-              create(
-                :course,
-                :published,
-                provider:,
-                site_statuses: [
-                  build(:site_status, :running, :published, site: site_one),
-                  build(:site_status, :discontinued, :unpublished, site: site_two),
-                ],
-              )
-            end
-            let(:params) { { site_ids: [site_one.id] } }
-
-            it "does not touch the discontinued site_status" do
-              described_class.new(course:, params:).call
-
-              site_status = course.reload.site_statuses.find_by!(site: site_two)
-              expect(site_status).to be_status_discontinued
-              expect(site_status).to be_unpublished_on_ucas
-            end
-          end
-
-          context "when adding a school to a draft (unpublished) course" do
-            let(:course) { create(:course, provider:, site_statuses: []) }
-            let(:params) { { site_ids: [site_one.id] } }
-
-            it "the newly attached site_status is :new_status :unpublished" do
-              described_class.new(course:, params:).call
-
-              site_status = course.reload.site_statuses.find_by!(site: site_one)
-              expect(site_status).to be_status_new_status
-              expect(site_status).to be_unpublished_on_ucas
-            end
-          end
-        end
-
-        context "dual-write to Course::School" do
-          let(:gias_school_one) { create(:gias_school, urn: site_one.urn) }
-          let(:gias_school_two) { create(:gias_school, urn: site_two.urn) }
-
+        context "when the Course::School write fails" do
           before do
-            # Persist sites so they have IDs / URNs present in the DB
-            provider.save!
-            create(:provider_school, provider:, gias_school: gias_school_one, site_code: "X")
-            create(:provider_school, provider:, gias_school: gias_school_two, site_code: "Y")
+            allow(UpdateCourseProviderSchoolsService).to receive(:call)
+              .and_raise(ActiveRecord::RecordInvalid)
           end
 
-          context "when a site is newly attached" do
-            let(:params) { { site_ids: [site_one.id, site_two.id] } }
+          it "rolls back the legacy write and does not notify" do
+            FeatureFlag.activate(:course_sites_updated_email_notification)
+            expect(NotificationService::CourseSitesUpdated).not_to receive(:call)
 
-            it "creates a Course::School row for the newly attached site" do
-              expect {
-                described_class.new(course:, params:).call
-              }.to change { course.schools.count }.by(1)
+            expect { service_call }.to raise_error(ActiveRecord::RecordInvalid)
 
-              added = course.schools.find_by(gias_school: gias_school_two)
-              expect(added).to be_present
-              expect(added.site_code).to eq("Y")
-            end
-          end
-
-          context "when a site is detached" do
-            let(:params) { { site_ids: [] } }
-
-            before do
-              create(:course_school, course:, gias_school: gias_school_one, site_code: "X")
-            end
-
-            it "destroys the Course::School row for the detached site" do
-              expect {
-                described_class.new(course:, params:).call
-              }.to change { course.schools.count }.by(-1)
-
-              expect(course.schools.where(gias_school: gias_school_one)).to be_empty
-            end
-          end
-
-          context "when the prerequisite provider_school is missing" do
-            let(:params) { { site_ids: [site_one.id, site_two.id] } }
-
-            before do
-              # Simulate an env where the schools backfill has not yet run
-              # for this provider's existing sites.
-              Provider::School.where(provider:, gias_school: gias_school_two).destroy_all
-            end
-
-            it "still attaches the legacy SiteStatus and does not raise" do
-              expect {
-                described_class.new(course:, params:).call
-              }.not_to raise_error
-
-              expect(course.reload.sites.map(&:id)).to include(site_two.id)
-            end
-
-            it "skips the Course::School write for the missing provider_school" do
-              described_class.new(course:, params:).call
-
-              expect(course.reload.schools.where(gias_school: gias_school_two)).to be_empty
-            end
-
-            it "logs the skip so operators can spot environments needing a backfill" do
-              expect(Rails.logger).to receive(:warn).with(/no provider_school for course=/)
-
-              described_class.new(course:, params:).call
-            end
+            expect(course.site_statuses.count).to eq(0)
+          ensure
+            FeatureFlag.deactivate(:course_sites_updated_email_notification)
           end
         end
+
+        it "raises inline when a Provider::School UUID cannot be resolved" do
+          expect { described_class.call(course:, params: { school_uuids: [SecureRandom.uuid] }) }
+            .to raise_error(described_class::UnresolvedProviderSchoolsError)
+        end
+
+        it "requires the caller to provide school_uuids" do
+          expect { described_class.call(course:, params: { schools_validated: "true" }) }
+            .to raise_error(KeyError, /school_uuids/)
+        end
+
+        context "when the course save fails after both relationship writes" do
+          before do
+            allow(course).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+          end
+
+          it "rolls back both relationship writes" do
+            expect { service_call }.to raise_error(ActiveRecord::RecordInvalid)
+
+            expect(course.reload.schools).to be_empty
+            expect(course.sites).to be_empty
+          end
+        end
+
+        context "when a Provider::School has no matching legacy Site" do
+          let(:provider_school_without_site) do
+            create(:provider_school, provider:, gias_school: create(:gias_school))
+          end
+          let(:params) { { school_uuids: [provider_school_without_site.uuid] } }
+
+          it "raises and writes neither relationship" do
+            expect { service_call }
+              .to raise_error(UpdateCourseSiteStatusesService::UnresolvedSitesError)
+
+            expect(course.reload.schools).to be_empty
+            expect(course.site_statuses).to be_empty
+          end
+        end
+
+        context "when the course belongs to a cycle after the remodel cycle" do
+          let(:recruitment_cycle) do
+            find_or_create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
+          end
+          let(:provider) { create(:provider, recruitment_cycle:, sites: [site_one, site_two]) }
+
+          it "continues to write both school models" do
+            service_call
+
+            expect(course.reload.schools.find_by(provider_school: provider_school_two)).to be_present
+            expect(course.sites).to contain_exactly(site_two)
+          end
+        end
+      end
+
+      def attach_school(site, provider_school, status: :new_status, publish: :unpublished)
+        course.site_statuses.create!(site:, status:, publish:)
+        create(
+          :course_school,
+          course:,
+          provider_school:,
+          gias_school: provider_school.gias_school,
+        )
       end
     end
   end

--- a/spec/services/publish/schools/update_course_site_statuses_service_spec.rb
+++ b/spec/services/publish/schools/update_course_site_statuses_service_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  module Schools
+    RSpec.describe UpdateCourseSiteStatusesService do
+      let(:site_one) { build(:site, location_name: "Site 1") }
+      let(:site_two) { build(:site, location_name: "Site 2") }
+      let(:provider) { create(:provider, sites: [site_one, site_two]) }
+      let(:course) { create(:course, provider:) }
+
+      subject(:service_call) { described_class.call(course:, school_uuids:) }
+
+      context "when a school is added to a draft course" do
+        let(:school_uuids) { [site_one.uuid] }
+
+        it "creates an unpublished SiteStatus" do
+          expect { service_call }.to change { course.site_statuses.count }.by(1)
+
+          site_status = course.reload.site_statuses.find_by!(site: site_one)
+          expect(site_status).to be_status_new_status
+          expect(site_status).to be_unpublished_on_ucas
+        end
+      end
+
+      context "when a school is added to a published course" do
+        let(:course) { create(:course, :published, provider:) }
+        let(:school_uuids) { [site_one.uuid, site_two.uuid] }
+
+        before do
+          course.site_statuses.create!(site: site_one, status: :running, publish: :published)
+        end
+
+        it "creates a running and published SiteStatus" do
+          service_call
+
+          site_status = course.reload.site_statuses.find_by!(site: site_two)
+          expect(site_status).to be_status_running
+          expect(site_status).to be_published_on_ucas
+        end
+      end
+
+      context "when a school is removed from a published course" do
+        let(:course) { create(:course, :published, provider:) }
+        let(:school_uuids) { [site_two.uuid] }
+
+        before do
+          course.site_statuses.create!(site: site_one, status: :running, publish: :published)
+          course.site_statuses.create!(site: site_two, status: :running, publish: :published)
+        end
+
+        it "removes the SiteStatus and leaves the selected school running" do
+          service_call
+
+          expect(course.reload.site_statuses.where(site: site_one)).to be_empty
+          kept_site_status = course.site_statuses.find_by!(site: site_two)
+          expect(kept_site_status).to be_status_running
+          expect(kept_site_status).to be_published_on_ucas
+        end
+      end
+
+      context "when old inactive SiteStatus rows exist" do
+        let(:school_uuids) { [site_one.uuid] }
+
+        before do
+          course.site_statuses.create!(site: site_one, status: :new_status, publish: :unpublished)
+          course.site_statuses.create!(site: site_two, status: :suspended, publish: :unpublished)
+          course.site_statuses.create!(site: site_two, status: :discontinued, publish: :unpublished)
+        end
+
+        it "does not reactivate them" do
+          service_call
+
+          expect(course.reload.site_statuses.where(site: site_two).pluck(:status, :publish))
+            .to contain_exactly(%w[suspended unpublished], %w[discontinued unpublished])
+        end
+      end
+
+      context "when a submitted UUID has no legacy Site" do
+        let(:school_uuids) { [site_one.uuid, site_two.uuid] }
+
+        before do
+          site_two.discard!
+        end
+
+        it "raises before changing SiteStatus rows" do
+          expect { service_call }
+            .to raise_error(described_class::UnresolvedSitesError, /school_uuids=#{site_two.uuid}/)
+
+          expect(course.reload.site_statuses).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/course_school_edit.rb
+++ b/spec/support/page_objects/publish/course_school_edit.rb
@@ -7,7 +7,7 @@ module PageObjects
     class CourseSchoolEdit < PageObjects::Base
       set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/schools"
 
-      SCHOOL_CHECKBOX = "input[name='publish_course_school_form[site_ids][]']"
+      SCHOOL_CHECKBOX = "input[name='publish_course_school_form[school_uuids][]']"
 
       sections :vacancies, Sections::Vacancy, ".govuk-checkboxes__item"
 

--- a/spec/system/publish/courses/confirm_live_changes_spec.rb
+++ b/spec/system/publish/courses/confirm_live_changes_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Confirming live changes before publishing course edits" do
     and_the_course_was_last_published_yesterday
     when_i_update_course_schools
     then_i_should_not_see_the_live_changes_interstitial
-    expect(page).to have_content("Schools updated")
+    expect(page).to have_content("School updated")
     and_the_last_updated_timestamp_is_refreshed
   end
 
@@ -66,9 +66,9 @@ private
   end
 
   def given_a_published_course_with_schools
-    site = create(:site, location_name: "Site 1", provider:)
+    site = create(:site, :with_provider_school, location_name: "Site 1", provider:)
     given_a_course_exists(:published, sites: [site])
-    create(:site, location_name: "Site 2", provider:)
+    create(:site, :with_provider_school, location_name: "Site 2", provider:)
   end
 
   def when_i_edit_what_you_will_study

--- a/spec/system/publish/courses/editing_course_schools_spec.rb
+++ b/spec/system/publish/courses/editing_course_schools_spec.rb
@@ -65,6 +65,31 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     then_i_should_see_an_error_message
   end
 
+  scenario "i see an error when a selected school no longer belongs to the provider" do
+    then_i_should_see_a_list_of_schools
+    given_provider_school_one_is_removed_after_the_page_load
+    when_i_update_the_course_schools
+    and_i_submit
+    then_i_should_see_the_school_selection_error
+    and_no_school_is_attached_to_the_course
+  end
+
+  scenario "i see an error when a selected school is removed after validation" do
+    given_the_course_school_update_fails_after_validation
+    when_i_update_the_course_schools
+    and_i_submit
+    then_i_should_see_the_school_selection_error
+    and_the_error_is_reported_to_sentry
+  end
+
+  scenario "i see an error when the legacy Site mapping is missing after validation" do
+    given_the_legacy_site_update_fails_after_validation
+    when_i_update_the_course_schools
+    and_i_submit
+    then_i_should_see_the_school_selection_error
+    and_the_error_is_reported_to_sentry
+  end
+
   def given_i_am_authenticated_as_a_provider_user
     given_i_am_authenticated(
       user: create(
@@ -118,14 +143,21 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
 
   def then_i_should_see_an_error_message
     expect(publish_course_school_edit_page).to have_content(
-      I18n.t("activemodel.errors.models.publish/course_school_form.attributes.site_ids.no_schools"),
+      I18n.t("activemodel.errors.models.publish/course_school_form.attributes.school_uuids.no_schools"),
+    )
+  end
+
+  def then_i_should_see_the_school_selection_error
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content(
+      I18n.t("activemodel.errors.models.publish/course_school_form.attributes.school_uuids.school_uuids_invalid"),
     )
   end
 
   def and_provider_schools_mirror_the_sites
     provider.sites.each do |site|
-      gias_school = create(:gias_school, urn: site.urn)
-      create(:provider_school, provider:, gias_school:, site_code: site.code)
+      gias_school = create(:gias_school, name: site.location_name, urn: site.urn)
+      create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
     end
   end
 
@@ -134,7 +166,37 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     gias_school = GiasSchool.find_by!(urn: site.urn)
     course_school = course.reload.schools.find_by(gias_school:)
     expect(course_school).to be_present
-    expect(course_school.site_code).to eq(site.code)
+    expect(course_school.provider_school.site_code).to eq(site.code)
+  end
+
+  def given_provider_school_one_is_removed_after_the_page_load
+    provider.schools.joins(:gias_school).find_by!(gias_school: { name: "Site 1" }).destroy!
+  end
+
+  def given_the_course_school_update_fails_after_validation
+    @course_school_update_error =
+      Publish::Schools::UpdateCourseSchoolsService::UnresolvedProviderSchoolsError.new("no provider_school")
+    stub_course_school_update_failure
+  end
+
+  def given_the_legacy_site_update_fails_after_validation
+    @course_school_update_error =
+      Publish::Schools::UpdateCourseSiteStatusesService::UnresolvedSitesError.new("no legacy site")
+    stub_course_school_update_failure
+  end
+
+  def and_the_error_is_reported_to_sentry
+    expect(Sentry).to have_received(:capture_exception).with(@course_school_update_error)
+  end
+
+  def stub_course_school_update_failure
+    allow(Publish::Schools::UpdateCourseSchoolsService).to receive(:call_or_enqueue).and_raise(@course_school_update_error)
+    allow(Sentry).to receive(:capture_exception)
+  end
+
+  def and_no_school_is_attached_to_the_course
+    expect(course.reload.sites).to be_empty
+    expect(course.schools).to be_empty
   end
 
   def given_the_course_already_has_both_sites
@@ -199,8 +261,8 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     provider.sites << build(:site, location_name: "Site 3")
     provider.save!
     site = provider.sites.find_by(location_name: "Site 3")
-    gias_school = create(:gias_school, urn: site.urn)
-    create(:provider_school, provider:, gias_school:, site_code: site.code)
+    gias_school = create(:gias_school, name: site.location_name, urn: site.urn)
+    create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
   end
 
   def given_the_course_is_published_with_all_three_sites_running

--- a/spec/system/publish/courses/publishing_a_course_without_schools_spec.rb
+++ b/spec/system/publish/courses/publishing_a_course_without_schools_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe "Publishing a course that is allowed to have no schools", travel:
 
   def and_provider_schools_mirror_the_sites
     provider.sites.each do |site|
-      gias_school = create(:gias_school, urn: site.urn)
-      create(:provider_school, provider:, gias_school:, site_code: site.code)
+      gias_school = create(:gias_school, name: site.location_name, urn: site.urn)
+      create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
     end
   end
 
@@ -82,6 +82,7 @@ RSpec.describe "Publishing a course that is allowed to have no schools", travel:
   end
 
   def and_the_course_has_no_schools
+    expect(course.reload.sites).to be_empty
     expect(course.reload.schools).to be_empty
   end
 

--- a/spec/system/publish/courses/schools/school_list_display_spec.rb
+++ b/spec/system/publish/courses/schools/school_list_display_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Publish - Placement schools list display", type: :system do
 
   def given_i_am_authenticated_as_a_provider_user
     @provider = create(:provider)
-    @sites = create_list(:site, 3, provider: @provider)
+    @sites = create_list(:provider_school, 3, provider: @provider)
     @user = create(:user, providers: [@provider])
     given_i_am_authenticated(user: @user)
     @provider.reload
@@ -61,8 +61,8 @@ RSpec.describe "Publish - Placement schools list display", type: :system do
 
   def given_a_course_with_attached_sites(count:)
     @course = create(:course, provider: @provider, sites: [])
-    @provider.sites.first(count).each do |site|
-      @course.site_statuses.create!(site:, status: :new_status, publish: :unpublished)
+    @provider.schools.first(count).each do |site|
+      @course.schools.create!(gias_school_id: site.gias_school_id, provider_school_id: site.id)
     end
   end
 
@@ -73,15 +73,8 @@ RSpec.describe "Publish - Placement schools list display", type: :system do
 
   def given_the_provider_has_a_named_school
     @school = create(
-      :site,
+      :provider_school,
       provider: @provider,
-      location_name: "Belvidere School",
-      address1: "Belvidere Lane",
-      address2: "",
-      address3: "",
-      town: "Shrewsbury",
-      address4: "Shropshire",
-      postcode: "SY2 5RJ",
     )
   end
 
@@ -98,12 +91,12 @@ RSpec.describe "Publish - Placement schools list display", type: :system do
   end
 
   def then_the_school_label_shows_the_name
-    expect(page).to have_css(".govuk-checkboxes__label", text: "Belvidere School")
+    expect(page).to have_css(".govuk-checkboxes__label", text: @school.location_name)
   end
 
   def and_the_hint_shows_the_address_without_the_name
-    hint = page.find(".govuk-hint", text: "Belvidere Lane")
-    expect(hint.text).to eq("Belvidere Lane, Shrewsbury, Shropshire, SY2 5RJ")
-    expect(hint.text).not_to include("Belvidere School")
+    hint = page.find(".govuk-hint", text: @school.address1)
+    expect(hint.text).to eq(@school.full_address)
+    expect(hint.text).not_to include(@school.location_name)
   end
 end

--- a/spec/system/publish/courses/schools/select_all_schools_spec.rb
+++ b/spec/system/publish/courses/schools/select_all_schools_spec.rb
@@ -75,14 +75,10 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    @provider = build(
-      :provider,
-      sites: [
-        build(:site, location_name: "Site 1"),
-        build(:site, location_name: "Site 2"),
-        build(:site, location_name: "Site 3"),
-      ],
-    )
+    @provider = create(:provider)
+    create(:site, :with_provider_school, provider: @provider, location_name: "Site 1")
+    create(:site, :with_provider_school, provider: @provider, location_name: "Site 2")
+    create(:site, :with_provider_school, provider: @provider, location_name: "Site 3")
     @user = create(
       :user,
       providers: [provider],
@@ -92,12 +88,12 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
   end
 
   def given_there_are_many_schools
-    @schools = create_list(:site, 30, provider: @provider)
+    @schools = create_list(:site, 30, :with_provider_school, provider: @provider)
   end
 
   def given_the_provider_has_25_schools
     # the provider already has 3 sites from authentication setup
-    create_list(:site, 22, provider: @provider)
+    create_list(:site, 22, :with_provider_school, provider: @provider)
     @provider.reload
   end
 
@@ -132,10 +128,14 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
   def and_all_schools_should_be_assigned_to_the_course
     expect(course.reload.sites.map(&:location_name))
       .to contain_exactly("Site 1", "Site 2", "Site 3")
+    expect(course.schools.map { |course_school| course_school.provider_school.location_name })
+      .to contain_exactly("Site 1", "Site 2", "Site 3")
   end
 
   def and_many_schools_should_be_attached_to_courses
     expect(course.reload.sites.map(&:location_name))
+      .to match_array(["Site 1", "Site 2", "Site 3", @schools.map(&:location_name)].flatten)
+    expect(course.schools.map { |course_school| course_school.provider_school.location_name })
       .to match_array(["Site 1", "Site 2", "Site 3", @schools.map(&:location_name)].flatten)
   end
 
@@ -175,6 +175,7 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
 
   def and_all_25_schools_should_be_attached
     expect(course.reload.sites.count).to eq(25)
+    expect(course.schools.count).to eq(25)
   end
 
   # "Site 3" sorts last of the 25 (the other 22 are "Main Site..."), so it renders
@@ -185,6 +186,9 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
 
   def given_the_last_school_is_already_attached_to_the_course
     course.site_statuses.create!(site: last_school, status: :new_status, publish: :unpublished)
+
+    provider_school = provider.schools.find_by!(uuid: last_school.uuid)
+    create(:course_school, course:, provider_school:, gias_school: provider_school.gias_school)
   end
 
   # A collapsed school keeps its checked state in the DOM even though its row is
@@ -201,6 +205,7 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
 
   def and_the_last_school_is_still_attached
     expect(course.reload.sites).to include(last_school)
+    expect(course.schools.map(&:provider_school)).to include(provider.schools.find_by!(uuid: last_school.uuid))
   end
 
   def given_a_course_exists(sites: [])

--- a/spec/system/publish/providers/courses/schools_rollover_validation_spec.rb
+++ b/spec/system/publish/providers/courses/schools_rollover_validation_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe "Publish - Schools validation during 2026 rollover", service: :pu
   let!(:site_one) { create(:site, provider:, location_name: "School A") }
   let!(:site_two) { create(:site, provider:, location_name: "School B") }
   let!(:course)   { create(:course, :publishable, provider:, course_code: "XYZ", sites: [site_one, site_two], accrediting_provider: accredited_provider, enrichments: [build(:course_enrichment, :rolled_over)]) }
-  let(:user)      { create(:user, providers: [provider]) }
+  let!(:provider_school_one) { create_provider_school_for(site_one) }
+  let!(:provider_school_two) { create_provider_school_for(site_two) }
+  let!(:course_school_one) { create_course_school_for(provider_school_one) }
+  let!(:course_school_two) { create_course_school_for(provider_school_two) }
+  let(:user) { create(:user, providers: [provider]) }
 
   before do
     sign_in_system_test(user:)
@@ -123,7 +127,7 @@ RSpec.describe "Publish - Schools validation during 2026 rollover", service: :pu
     error_links = all("a", text: "Review the schools for this course")
     expect(error_links).not_to be_empty
 
-    expect(error_links.first[:href]).to eq("#publish-course-school-form-site-ids-field-error")
+    expect(error_links.first[:href]).to eq("#publish-course-school-form-school-uuids-field-error")
   end
 
   def when_i_click_update_schools
@@ -133,5 +137,24 @@ RSpec.describe "Publish - Schools validation during 2026 rollover", service: :pu
   def then_course_is_published
     expect(page).to have_content("Your course has been scheduled.")
     expect(course.reload.is_published?).to be(true)
+  end
+
+  def create_provider_school_for(site)
+    create(
+      :provider_school,
+      provider:,
+      gias_school: create(:gias_school, name: site.location_name, urn: site.urn),
+      site_code: site.code,
+      uuid: site.uuid,
+    )
+  end
+
+  def create_course_school_for(provider_school)
+    create(
+      :course_school,
+      course:,
+      provider_school:,
+      gias_school: provider_school.gias_school,
+    )
   end
 end

--- a/spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb
+++ b/spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Publish - Courses: 'Newly added' tag for register import sites w
   let!(:site_one) do
     create(
       :site,
+      :with_provider_school,
       provider:,
       added_via: :register_import,
       location_name: "Register Import School",
@@ -20,6 +21,7 @@ RSpec.describe "Publish - Courses: 'Newly added' tag for register import sites w
   let!(:site_two) do
     create(
       :site,
+      :with_provider_school,
       provider:,
       added_via: :publish_interface,
       location_name: "UI Added School",


### PR DESCRIPTION
## Context

This is the course school update part of the school data remodel. It only takes care of the school adding in the basic details component of a course in publish.

The legacy `Site` and corresponding `Provider::School` are expected to share the same UUID. This allows one submitted `Provider::School` selection to be applied consistently to both models.

Inline and queued updates are both transactional. Their handling of a missing `Provider::School` differs deliberately:

- Inline requests fail and show a form error because the submitted selection is no longer valid.
- Queued requests log and exclude `Provider::School` records removed while the job was waiting.
- The resulting effective selection is then written atomically to both models.
- A valid `Provider::School` without its expected legacy `Site` is treated as data drift and raises rather than silently leaving the models inconsistent.

## Changes proposed in this pull request

- Updates the existing course schools form to display available `Provider::School` records and submit `school_uuids` instead of legacy Site IDs.
- Reads the course's current selection and attached-school count from `Course::School`.
- Uses the same `GiasSchool.available` scope for form display and validation, excluding closed schools.
- Validates that submitted UUIDs belong to an available school for the course provider.
- Reports unresolved inline selections to Sentry and displays the existing form error.
- Refactors `Publish::Schools::UpdateCourseSchoolsService` to:
  - resolve submitted `Provider::School` UUIDs once;
  - lock resolved records while the update is applied;
  - pass the same effective selection to both writers;
  - keep inline and queued dual writes within one transaction;
  - persist attributes such as `schools_validated`;
  - save the course so `provider.changed_at` is updated for downstream Apply synchronisation;
  - send school-update notifications from the resulting `Course::School` selection.
- Adds `Publish::Schools::UpdateCourseProviderSchoolsService` to synchronise `Course::School` records from already-resolved `Provider::School` records.
- Adds `Publish::Schools::UpdateCourseSiteStatusesService` to temporarily mirror the same UUID selection to legacy `SiteStatus` records.
- Makes missing legacy Site mappings explicit instead of silently skipping them.
- Updates the queued job to tolerate stale `Provider::School` UUIDs without disabling transaction protection for other failures.
- Counts unique, non-blank UUIDs consistently when deciding whether to enqueue and which success message to show.
- Adds a Site factory trait that creates a corresponding GIAS school and `Provider::School` with matching school data and UUID.
- Adds coverage for:
  - adding, removing and replacing schools in both models;
  - removing every school where this is permitted;
  - stale queued selections;
  - transaction rollback after writer or course-save failures;
  - missing legacy Site mappings;
  - inline form errors and Sentry reporting;
  - notifications;
  - provider `changed_at` updates;
  - dual writing after the remodel cycle;
  - closed schools;
  - queue boundaries, duplicate UUIDs and blank values;
  - select-all and collapsed school lists.

There are no intended visual changes beyond the form being backed by the remodelled school data.

## Guidance to review

Suggested review order:

Option 1: Check the history and review it that way

Option 2: Check by topic as stated below:

### 1. Existing course edit form and validation

- `app/forms/publish/course_school_form.rb`
- `app/controllers/publish/courses/schools_controller.rb`
- `app/views/publish/courses/schools/edit.html.erb`
- `config/locales/en.yml`
- `app/decorators/course_decorator.rb`
- `spec/forms/publish/course_school_form_spec.rb`
- `spec/decorators/course_decorator_spec.rb`
- `spec/support/page_objects/publish/course_school_edit.rb`
- `spec/system/publish/courses/editing_course_schools_spec.rb`
- `spec/system/publish/courses/schools/school_list_display_spec.rb`

Check that the form displays available `Provider::School` records, submits UUIDs, restores its selection from `Course::School`, rejects unavailable or unrelated schools, and renders a normal form error when an inline update can no longer resolve the selection.

### 2. Update orchestration and queued behaviour

- `app/services/publish/schools/update_course_schools_service.rb`
- `app/jobs/update_course_schools_job.rb`
- `spec/services/publish/schools/update_course_schools_service_spec.rb`
- `spec/jobs/update_course_schools_job_spec.rb`

Check that submitted UUIDs are resolved once and that both writers receive the same effective selection.

Pay particular attention to the queued path: stale `Provider::School` UUIDs are logged and excluded, but the remaining dual write is still transactional. Unexpected writer, validation or course-save failures therefore roll back both models.

Also check the comment around `course.save!`. The save is required to update `provider.changed_at`, which Apply uses to decide whether the provider's courses need synchronising.

### 3. New Course::School synchronisation

- `app/services/publish/schools/update_course_provider_schools_service.rb`
- `spec/services/publish/schools/update_course_provider_schools_service_spec.rb`

Check that this service has one responsibility: synchronising `Course::School` rows from an already-resolved collection of `Provider::School` records.

UUID resolution and missing-school policy deliberately remain in the orchestrator.

### 4. Legacy SiteStatus synchronisation

- `app/services/publish/schools/update_course_site_statuses_service.rb`
- `spec/services/publish/schools/update_course_site_statuses_service_spec.rb`

Check that this temporary writer applies the same effective UUID selection to legacy `SiteStatus` records.

The important invariant is that matching `Site` and `Provider::School` records share a UUID. Missing Site mappings now raise before mutation rather than being silently skipped.

Also check that published status is applied only to active SiteStatus rows and that suspended or discontinued rows are not reactivated.

### 5. Queue boundaries and user journeys

- `spec/system/publish/courses/schools/select_all_schools_spec.rb`
- `spec/system/publish/courses/publishing_a_course_without_schools_spec.rb`
- `spec/system/publish/providers/courses/schools_rollover_validation_spec.rb`
- `spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb`

Check select-all and collapsed-list behaviour, the asynchronous path above 30 unique schools, rollover validation, newly added labels, and providers that are allowed to remove every school.

### 6. Supporting test and course-creation changes

- `spec/factories/sites.rb`
- `app/services/courses/creation_service.rb`
- `spec/services/courses/creation_service_spec.rb`

Check that the Site factory trait creates matching legacy and remodelled school records with the same UUID, URN and location information. The course-creation changes in this PR are limited to keeping the existing creation behavior and comments consistent with the completed backfill.