### PR TITLE
Start date filter options

### DIFF
--- a/app/forms/publish/courses/filter_form.rb
+++ b/app/forms/publish/courses/filter_form.rb
@@ -9,6 +9,10 @@ module Publish
     # Every group is a multi-select list of checkboxes, and each reader allows only
     # the values that group offers. That single choke point means an unrecognised
     # value in the query string reaches neither the SQL nor an active filter chip.
+    #
+    # Every group but start date offers a fixed list of options. Start date offers
+    # the months the provider's courses start in, so narrowing that list narrows
+    # the checkboxes, the allowed values and the chip labels together.
     class FilterForm < ApplicationForm
       Option = Data.define(:value, :label)
 
@@ -87,8 +91,10 @@ module Publish
         end
       end
 
+      # Only the months the provider's courses actually start in, so the panel
+      # never offers a month that would narrow the list to nothing.
       def start_date_options
-        @start_date_options ||= ::Courses::CycleStartMonths.for(provider.recruitment_cycle_year).map do |month|
+        @start_date_options ||= ::Publish::Courses::AvailableStartMonths.for(provider).map do |month|
           Option.new(value: month.to_fs(:year_and_month), label: I18n.l(month, format: :short))
         end
       end

--- a/app/services/courses/cycle_start_months.rb
+++ b/app/services/courses/cycle_start_months.rb
@@ -4,9 +4,10 @@ module Courses
   # The months a course in a given recruitment cycle can start in: the whole
   # cycle year plus January to July of the next.
   #
-  # Shared by the course wizard and the edit options (which offer the months
-  # when setting a start date) and by the publish course list filter (which
-  # offers them as checkboxes), so the three cannot drift apart.
+  # Shared by the course wizard and the edit options, which both offer these
+  # months when setting a start date, so the two cannot drift apart. The publish
+  # course list filter offers the months its courses actually start in instead —
+  # see Publish::Courses::AvailableStartMonths.
   module CycleStartMonths
     MONTHS_INTO_FOLLOWING_YEAR = 7
 

--- a/app/services/publish/courses/available_start_months.rb
+++ b/app/services/publish/courses/available_start_months.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    # The months a provider's courses actually start in, for the start date
+    # filter on the publish course list. Offering the whole cycle window instead
+    # would fill the panel with months that narrow the list to nothing.
+    #
+    # Read from +Provider#courses+, the same base scope +Publish::Courses::Query+
+    # builds the list from, so an offered month always matches at least one
+    # course and a listed course's month is always offered.
+    module AvailableStartMonths
+      # The month is resolved in the application's zone, never in UTC: a course
+      # starting 2026-09-01 00:30 is stored as 2026-08-31 23:30 UTC, but the list
+      # displays it under September and Query matches it under September, so a
+      # UTC month would offer an August option that finds nothing.
+      #
+      # Dates rather than times, because the checkbox label comes from
+      # I18n.l(month, format: :short), which formats the two quite differently.
+      def self.for(provider)
+        provider.courses.distinct.pluck(:start_date).compact.map { |start_date|
+          start_date.in_time_zone.to_date.beginning_of_month
+        }.uniq.sort
+      end
+    end
+  end
+end

--- a/spec/components/publish/courses/filter_panel_component_spec.rb
+++ b/spec/components/publish/courses/filter_panel_component_spec.rb
@@ -6,9 +6,17 @@ RSpec.describe Publish::Courses::FilterPanelComponent, type: :component do
   subject(:rendered) { render_inline(described_class.new(filter_form:, provider:, **options)) }
 
   let(:provider) { create(:provider) }
+  let(:cycle_year) { provider.recruitment_cycle_year.to_i }
   let(:attributes) { {} }
   let(:options) { {} }
   let(:filter_form) { Publish::Courses::FilterForm.new(provider:, **attributes) }
+
+  # The start date group offers the months the provider's courses start in, so
+  # the panel needs courses before it has any start date checkboxes to render.
+  before do
+    create(:course, provider:, start_date: Time.zone.local(cycle_year, 9, 1))
+    create(:course, provider:, start_date: Time.zone.local(cycle_year + 1, 1, 1))
+  end
 
   def group_headings
     rendered.css(".app-c-filter-section__summary-heading").map { |heading| heading.text.strip }
@@ -59,8 +67,12 @@ RSpec.describe Publish::Courses::FilterPanelComponent, type: :component do
       expect(labels).to eq(["Open", "Closed", "Draft", "Rolled over", "Scheduled", "Withdrawn"])
     end
 
-    it "offers every month in the cycle window as a start date" do
-      expect(rendered.css("input[name='start_date[]']").size).to eq(19)
+    it "offers only the months the provider's courses start in" do
+      inputs = rendered.css("input[name='start_date[]']")
+
+      expect(inputs.map { |input| input[:value] }).to eq(["#{cycle_year}-09", "#{cycle_year + 1}-01"])
+      expect(inputs.map { |input| rendered.css("label[for='#{input[:id]}']").text.strip })
+        .to eq(["September #{cycle_year}", "January #{cycle_year + 1}"])
     end
 
     context "when only some groups are visible" do

--- a/spec/forms/publish/courses/filter_form_spec.rb
+++ b/spec/forms/publish/courses/filter_form_spec.rb
@@ -48,11 +48,23 @@ RSpec.describe Publish::Courses::FilterForm do
       end
     end
 
-    context "when a start date month is not in the cycle window" do
-      let(:attributes) { { start_date: ["#{cycle_year + 5}-09", "#{cycle_year}-09"] } }
+    context "when no course starts in that month" do
+      let(:attributes) { { start_date: ["#{cycle_year}-10", "#{cycle_year}-09"] } }
 
-      it "drops it" do
+      before { create(:course, provider:, start_date: Time.zone.local(cycle_year, 9, 1)) }
+
+      it "drops it, even though the cycle allows it" do
         expect(form.start_date).to eq(["#{cycle_year}-09"])
+      end
+    end
+
+    context "when a course starts in a month outside the cycle window" do
+      let(:attributes) { { start_date: ["#{cycle_year + 5}-03"] } }
+
+      before { create(:course, :without_validation, provider:, start_date: Time.zone.local(cycle_year + 5, 3, 1)) }
+
+      it "keeps it, so a start date on the list can always be filtered on" do
+        expect(form.start_date).to eq(["#{cycle_year + 5}-03"])
       end
     end
   end
@@ -138,19 +150,35 @@ RSpec.describe Publish::Courses::FilterForm do
   describe "start date options" do
     subject(:options) { form.options_for(:start_date) }
 
-    it "covers the whole cycle window" do
-      expect(options.size).to eq(19)
+    it "is empty when the provider has no courses" do
+      expect(options).to be_empty
     end
 
-    it "starts in January of the cycle year" do
-      expect(options.first).to have_attributes(value: "#{cycle_year}-01", label: "January #{cycle_year}")
+    context "with courses starting in September and the following January" do
+      before do
+        create(:course, provider:, start_date: Time.zone.local(cycle_year + 1, 1, 1))
+        create(:course, provider:, start_date: Time.zone.local(cycle_year, 9, 1))
+      end
+
+      it "offers only the months its courses start in" do
+        expect(options.map(&:value)).to eq(["#{cycle_year}-09", "#{cycle_year + 1}-01"])
+      end
+
+      it "labels each month as the provider reads it on the list" do
+        expect(options.first).to have_attributes(value: "#{cycle_year}-09", label: "September #{cycle_year}")
+      end
     end
 
-    it "ends in July of the following year" do
-      expect(options.last).to have_attributes(value: "#{cycle_year + 1}-07", label: "July #{cycle_year + 1}")
+    it "ignores courses with no start date" do
+      create(:course, :without_validation, provider:, start_date: nil)
+      create(:course, provider:, start_date: Time.zone.local(cycle_year, 9, 1))
+
+      expect(options.map(&:value)).to eq(["#{cycle_year}-09"])
     end
 
     it "does not drop months that have already passed" do
+      create(:course, provider:, start_date: Time.zone.local(cycle_year, 1, 1))
+
       travel_to(Time.zone.local(cycle_year, 6, 15)) do
         expect(described_class.new(provider:).options_for(:start_date).first.label).to eq("January #{cycle_year}")
       end
@@ -182,6 +210,8 @@ RSpec.describe Publish::Courses::FilterForm do
 
     context "with a start date selected" do
       let(:attributes) { { start_date: ["#{cycle_year}-09"] } }
+
+      before { create(:course, provider:, start_date: Time.zone.local(cycle_year, 9, 1)) }
 
       it "labels the chip with the month" do
         expect(form.active_filters.map(&:formatted_value)).to eq(["September #{cycle_year}"])

--- a/spec/requests/publish/courses_spec.rb
+++ b/spec/requests/publish/courses_spec.rb
@@ -90,6 +90,38 @@ describe "Publish::CoursesController#index" do
     end
   end
 
+  describe "filtering by start month" do
+    let(:cycle_year) { provider.recruitment_cycle_year.to_i }
+
+    before do
+      create(:course, provider:, accrediting_provider: nil, name: "September course", start_date: Time.zone.local(cycle_year, 9, 1))
+      create(:course, provider:, accrediting_provider: nil, name: "January course", start_date: Time.zone.local(cycle_year + 1, 1, 1))
+    end
+
+    it "offers only the months the courses start in" do
+      get_courses
+
+      expect(response.parsed_body.css("input[name='start_date[]']").map { |input| input[:value] })
+        .to eq(["#{cycle_year}-09", "#{cycle_year + 1}-01"])
+    end
+
+    it "narrows the list by start month" do
+      get_courses(start_date: ["#{cycle_year}-09"])
+
+      expect(course_names).to include("September course")
+      expect(course_names).not_to include("January course")
+    end
+
+    # No course starts then, so the month is not an option and the value is
+    # dropped like any other unrecognised one, rather than emptying the list.
+    it "ignores a start month no course starts in" do
+      get_courses(start_date: ["#{cycle_year}-12"])
+
+      expect(course_names).to include("September course", "January course")
+      expect(response.parsed_body.css(".app-active-filters")).to be_empty
+    end
+  end
+
   describe "filtering" do
     before do
       create(:course, :primary, :fee, provider:, name: "Primary course")

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Publish::CourseList do
     # start date at all, so it is worth showing.
     context "when some courses have no start date and the rest share a month" do
       before do
-        create_course(start_date: Time.zone.local(2026, 9, 1))
+        create_course
         create_course(start_date: nil)
       end
 

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -196,6 +196,20 @@ RSpec.describe Publish::CourseList do
       end
     end
 
+    # The filter offers only the months courses start in, so this group shows a
+    # single checkbox — which still narrows the list to the courses that have a
+    # start date at all, so it is worth showing.
+    context "when some courses have no start date and the rest share a month" do
+      before do
+        create_course(start_date: Time.zone.local(2026, 9, 1))
+        create_course(start_date: nil)
+      end
+
+      it "shows the start date filter" do
+        expect(course_list.visible_filter_groups).to eq([:start_date])
+      end
+    end
+
     context "when courses start on different days of the same month" do
       before do
         create_course(start_date: Time.zone.local(2026, 9, 1))

--- a/spec/services/publish/courses/available_start_months_spec.rb
+++ b/spec/services/publish/courses/available_start_months_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Publish::Courses::AvailableStartMonths do
+  subject(:months) { described_class.for(provider) }
+
+  let(:provider) { create(:provider) }
+
+  it "is empty when the provider has no courses" do
+    expect(months).to be_empty
+  end
+
+  it "offers the month each course starts in" do
+    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+
+    expect(months).to eq([Date.new(2026, 9, 1)])
+  end
+
+  it "orders them earliest first" do
+    create(:course, provider:, start_date: Time.zone.local(2027, 1, 1))
+    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+
+    expect(months).to eq([Date.new(2026, 9, 1), Date.new(2027, 1, 1)])
+  end
+
+  it "offers a month once, however many courses start in it" do
+    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+    create(:course, provider:, start_date: Time.zone.local(2026, 9, 20))
+
+    expect(months).to eq([Date.new(2026, 9, 1)])
+  end
+
+  it "offers a month outside the cycle window when a course starts then" do
+    create(:course, :without_validation, provider:, start_date: Time.zone.local(2030, 3, 1))
+
+    expect(months).to eq([Date.new(2030, 3, 1)])
+  end
+
+  it "ignores courses with no start date" do
+    create(:course, :without_validation, provider:, start_date: nil)
+    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+
+    expect(months).to eq([Date.new(2026, 9, 1)])
+  end
+
+  it "ignores another provider's courses" do
+    create(:course, start_date: Time.zone.local(2027, 1, 1))
+
+    expect(months).to be_empty
+  end
+
+  it "ignores deleted courses" do
+    create(:course, :deleted, provider:, start_date: Time.zone.local(2026, 9, 1))
+
+    expect(months).to be_empty
+  end
+
+  # Stored as 2026-08-31 23:30 UTC, but the list displays it — and the provider
+  # thinks of it — as September, which is also the month Query matches it under.
+  it "offers the month a course displays under, not the UTC one" do
+    course = create(:course, provider:, start_date: Time.zone.local(2026, 9, 1, 0, 30))
+
+    expect(course.start_date.utc.day).to eq(31)
+    expect(months).to eq([Date.new(2026, 9, 1)])
+  end
+
+  # The checkbox label comes from I18n.l(month, format: :short), which resolves
+  # "%B %Y" for a Date and a quite different default for a Time.
+  it "returns dates" do
+    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+
+    expect(months).to all(be_an_instance_of(Date))
+  end
+end

--- a/spec/services/publish/courses/available_start_months_spec.rb
+++ b/spec/services/publish/courses/available_start_months_spec.rb
@@ -6,69 +6,75 @@ RSpec.describe Publish::Courses::AvailableStartMonths do
   subject(:months) { described_class.for(provider) }
 
   let(:provider) { create(:provider) }
+  let(:cycle_year) { provider.recruitment_cycle_year.to_i }
+  let(:september) { Date.new(cycle_year, 9, 1) }
+  let(:january) { Date.new(cycle_year + 1, 1, 1) }
 
   it "is empty when the provider has no courses" do
     expect(months).to be_empty
   end
 
   it "offers the month each course starts in" do
-    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+    create(:course, provider:, start_date: september.in_time_zone)
 
-    expect(months).to eq([Date.new(2026, 9, 1)])
+    expect(months).to eq([september])
   end
 
   it "orders them earliest first" do
-    create(:course, provider:, start_date: Time.zone.local(2027, 1, 1))
-    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+    create(:course, provider:, start_date: january.in_time_zone)
+    create(:course, provider:, start_date: september.in_time_zone)
 
-    expect(months).to eq([Date.new(2026, 9, 1), Date.new(2027, 1, 1)])
+    expect(months).to eq([september, january])
   end
 
   it "offers a month once, however many courses start in it" do
-    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
-    create(:course, provider:, start_date: Time.zone.local(2026, 9, 20))
+    create(:course, provider:, start_date: september.in_time_zone)
+    create(:course, provider:, start_date: Time.zone.local(cycle_year, 9, 20))
 
-    expect(months).to eq([Date.new(2026, 9, 1)])
+    expect(months).to eq([september])
   end
 
+  # The window runs to July of the following year, so this is well outside it.
   it "offers a month outside the cycle window when a course starts then" do
-    create(:course, :without_validation, provider:, start_date: Time.zone.local(2030, 3, 1))
+    out_of_window = Date.new(cycle_year + 5, 3, 1)
+    create(:course, :without_validation, provider:, start_date: out_of_window.in_time_zone)
 
-    expect(months).to eq([Date.new(2030, 3, 1)])
+    expect(months).to eq([out_of_window])
   end
 
   it "ignores courses with no start date" do
     create(:course, :without_validation, provider:, start_date: nil)
-    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+    create(:course, provider:, start_date: september.in_time_zone)
 
-    expect(months).to eq([Date.new(2026, 9, 1)])
+    expect(months).to eq([september])
   end
 
   it "ignores another provider's courses" do
-    create(:course, start_date: Time.zone.local(2027, 1, 1))
+    create(:course, start_date: january.in_time_zone)
 
     expect(months).to be_empty
   end
 
   it "ignores deleted courses" do
-    create(:course, :deleted, provider:, start_date: Time.zone.local(2026, 9, 1))
+    create(:course, :deleted, provider:, start_date: september.in_time_zone)
 
     expect(months).to be_empty
   end
 
-  # Stored as 2026-08-31 23:30 UTC, but the list displays it — and the provider
-  # thinks of it — as September, which is also the month Query matches it under.
+  # Stored as 31 August 23:30 UTC, because the 1st of September falls in British
+  # Summer Time. The list displays it — and the provider thinks of it — as
+  # September, which is also the month Query matches it under.
   it "offers the month a course displays under, not the UTC one" do
-    course = create(:course, provider:, start_date: Time.zone.local(2026, 9, 1, 0, 30))
+    course = create(:course, provider:, start_date: Time.zone.local(cycle_year, 9, 1, 0, 30))
 
     expect(course.start_date.utc.day).to eq(31)
-    expect(months).to eq([Date.new(2026, 9, 1)])
+    expect(months).to eq([september])
   end
 
   # The checkbox label comes from I18n.l(month, format: :short), which resolves
   # "%B %Y" for a Date and a quite different default for a Time.
   it "returns dates" do
-    create(:course, provider:, start_date: Time.zone.local(2026, 9, 1))
+    create(:course, provider:, start_date: september.in_time_zone)
 
     expect(months).to all(be_an_instance_of(Date))
   end

--- a/spec/support/page_objects/publish/provider_courses_index.rb
+++ b/spec/support/page_objects/publish/provider_courses_index.rb
@@ -32,6 +32,12 @@ module PageObjects
       sections :filter_groups, "details.app-c-filter-section" do
         element :heading, ".app-c-filter-section__summary-heading"
         element :selected_count, ".app-c-filter-section__count"
+
+        # The options this group offers, in order. A collapsed group hides its
+        # labels, so ask for the hidden text too.
+        def option_labels
+          all("label", visible: :all).map { |label| label.text(:all).strip }
+        end
       end
 
       section :active_filters, ".app-active-filters" do

--- a/spec/system/publish/filtering_courses_spec.rb
+++ b/spec/system/publish/filtering_courses_spec.rb
@@ -6,6 +6,7 @@ require "rails_helper"
 # the "Apply filters" button submits a GET and the server renders the result.
 RSpec.describe "Filtering the course list" do
   let(:provider) { create(:provider, :accredited_provider) }
+  let(:cycle_year) { provider.recruitment_cycle_year.to_i }
 
   before do
     given_i_am_authenticated(user: create(:user, providers: [provider]))
@@ -71,10 +72,25 @@ RSpec.describe "Filtering the course list" do
     then_i_am_told_no_courses_were_found
   end
 
-  scenario "I can filter by any month the cycle allows" do
+  scenario "I only see the start dates my courses use" do
     given_my_provider_has_courses_starting_in_different_months
     when_i_visit_the_courses_page
-    then_i_can_choose_a_start_month
+    then_the_start_date_group_offers("September #{cycle_year}", "January #{cycle_year + 1}")
+  end
+
+  scenario "I narrow the list to one start month" do
+    given_my_provider_has_courses_starting_in_different_months
+    when_i_visit_the_courses_page
+    when_i_filter_by("September #{cycle_year}")
+    then_i_see_only("September course")
+    and_the_course_count_reads("1 course")
+  end
+
+  scenario "a bookmarked start month no course starts in is ignored" do
+    given_my_provider_has_courses_starting_in_different_months
+    when_i_visit_the_courses_page_with(start_date: ["#{cycle_year}-12"])
+    then_i_see_only("September course", "January course")
+    and_i_see_no_active_filters
   end
 
   scenario "an unrecognised filter in the address bar is ignored" do
@@ -110,8 +126,8 @@ RSpec.describe "Filtering the course list" do
   end
 
   def given_my_provider_has_courses_starting_in_different_months
-    create(:course, provider:, accrediting_provider: nil, name: "September course", start_date: Time.zone.local(provider.recruitment_cycle_year.to_i, 9, 1))
-    create(:course, provider:, accrediting_provider: nil, name: "January course", start_date: Time.zone.local(provider.recruitment_cycle_year.to_i + 1, 1, 1))
+    create(:course, provider:, accrediting_provider: nil, name: "September course", start_date: Time.zone.local(cycle_year, 9, 1))
+    create(:course, provider:, accrediting_provider: nil, name: "January course", start_date: Time.zone.local(cycle_year + 1, 1, 1))
   end
 
   def given_all_my_courses_are_identical
@@ -149,11 +165,8 @@ RSpec.describe "Filtering the course list" do
     check(label)
   end
 
-  # A collapsed group's labels read as empty text, so ask for the hidden text too.
   def group_offering(label)
-    publish_provider_courses_index_page.filter_groups.map(&:root_element).find do |group|
-      group.all("label", visible: :all).any? { |option| option.text(:all).strip == label }
-    end
+    publish_provider_courses_index_page.filter_groups.find { |group| group.option_labels.include?(label) }&.root_element
   end
 
   def when_i_remove_the_active_filter(label)
@@ -222,11 +235,8 @@ RSpec.describe "Filtering the course list" do
     expect(publish_provider_courses_index_page.empty_message.text).to eq("No courses found")
   end
 
-  def then_i_can_choose_a_start_month
-    month = "September #{provider.recruitment_cycle_year}"
-    group_offering(month).find("summary").click
-
-    expect(page).to have_field(month, type: "checkbox")
+  def then_the_start_date_group_offers(*labels)
+    expect(filter_group("Start date").option_labels).to eq(labels)
   end
 
   # Course links read "Primary fee course (X123)"; the code is noise here.


### PR DESCRIPTION
## Context

Trello: [Course list — add logic for when to display start date filter options](https://trello.com/c/69eknLzg/1756-course-list-add-logic-for-when-to-display-filters)

The start date filter offers all nineteen months of the recruitment cycle window, most of which narrow a provider's list to nothing. It should offer the months their courses actually start in — so a provider whose courses run in August and September 2026 sees two checkboxes, not nineteen, and adding a course with a new start date adds its month.

No feature flag, no waiting for rollover.

Two decisions worth knowing about:

- **Start date only.** The other groups keep their fixed option lists.
- **Purely data-derived**, so a start date outside the cycle window is still offered. Otherwise a date visible in the course information column would be unfilterable.

## Changes proposed in this pull request

New `Publish::Courses::AvailableStartMonths` reads the months from `Provider#courses` — the same base scope `Publish::Courses::Query` builds the list from, so an offered month always matches at least one course.

`FilterForm` is the choke point: every group reader intersects with its own options, so pointing `options_for(:start_date)` at those months narrows the checkboxes, the allowed values and the active filter chips together. Nothing else in the app changes — `CourseList#visible_filter_groups` stays correct by construction, since more than one distinct month now means more than one option.

Months are resolved in the application's zone, not UTC: a course starting `2026-09-01 00:30` is stored as `2026-08-31 23:30 UTC`, but the list displays it under September and `Query` matches it under September.

**Behaviour change:** a bookmarked `?start_date[]=2026-12` where no course starts in December is now dropped — full list, no chip — instead of kept and showing "No courses found". Same as `?level[]=bogus` already behaves.

## Guidance to review

Five commits, each green on its own; commit 2 is the only one that changes behaviour.

Sign in as a provider with courses in two different months, open the course list and expand **Start date** — only those two months. Change one course's start date and the new month appears.

```
bundle exec rspec spec/services/publish/courses/available_start_months_spec.rb \
  spec/forms/publish/courses/filter_form_spec.rb \
  spec/components/publish/courses/filter_panel_component_spec.rb \
  spec/services/publish/course_list_spec.rb \
  spec/requests/publish/courses_spec.rb \
  spec/system/publish/filtering_courses_spec.rb
```

The course list now has 25 system scenarios, up from 23.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
