### PR TITLE
Content fix: School experience (salaried courses bug party)

### DIFF
--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -49,7 +49,7 @@ en:
           or_equivalent_qualification: or equivalent qualification
           equivalency_tests: Equivalency tests
           school_experience: School experience
-          yes_school_experience: Yes, school experience is required or strongly recommended
+          yes_school_experience: Previous school experience is required or strongly recommended
           degree_subject_requirements: Degree subject requirements
           degree_requirements: Degree requirements
           a_levels: A levels

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -504,7 +504,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
       it "renders the school experience row" do
         expect(result.text).to include("School experience")
-        expect(result.text).to include("Yes, school experience is required or strongly recommended")
+        expect(result.text).to include("Previous school experience is required or strongly recommended")
         expect(result.text).to include("You must complete two weeks in a school.")
       end
     end

--- a/spec/system/find/course/viewing_school_experience_spec.rb
+++ b/spec/system/find/course/viewing_school_experience_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe "Viewing school experience on a course", service: :find do
 
   def then_i_see_the_school_experience_row
     expect(page).to have_content("School experience")
-    expect(page).to have_content("Yes, school experience is required or strongly recommended")
+    expect(page).to have_content("Previous school experience is required or strongly recommended")
   end
 
   def then_i_do_not_see_the_school_experience_row
-    expect(page).to have_no_content("Yes, school experience is required or strongly recommended")
+    expect(page).to have_no_content("Previous school experience is required or strongly recommended")
   end
 
   def then_i_see(content)


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/0488kl2d

During testing we found candidates were confused as to whether we meant they need past school experience, or whether they will get school experience with the course. The wording needs udating. 

## Changes proposed in this pull request

Updated wording on details component:

Previous comtent: Yes, school experience is required or strongly recommended
New content: **Previous school experience is required or strongly recommended**

<img width="673" height="275" alt="Screenshot 2026-08-04 at 14 31 47" src="https://github.com/user-attachments/assets/de58fcdd-b8ae-4a62-a9c2-64396aab9aa6" />


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
