### PR TITLE
School remodel - Adding new relationships to recruitment_cycle

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -7,6 +7,9 @@ class RecruitmentCycle < ApplicationRecord
   # a site to a new recruitment_cycle
   has_many :courses, through: :providers
   has_many :sites, through: :providers
+  has_many :provider_schools, through: :providers, source: :schools
+  has_many :course_schools, through: :courses, source: :schools
+  has_many :gias_schools, -> { distinct }, through: :provider_schools
   has_many :study_sites, through: :providers
   validates :year, presence: true
 


### PR DESCRIPTION
## Context

Just adding new relationships to the recruitment_cycle which will allow us to query this relationships quicker.

## Changes proposed in this pull request

- Adding new has_many to all course_schools associated with the recruitment_cycle
- Adding new has_many to all provider_schools associated with the recruitment_cycle
- Adding new has_many to all gias_schools associated with the recruitment_cycle. This is distinct as it's joined though the provider_school table and can therefore return duplicated entries if not queried with distinct

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
