### PR TITLE
Increasing Dependabot max PR limit to 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
     labels:
       - deploy
       - dependencies
@@ -25,11 +25,11 @@ updates:
     directory: "/docs"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
     labels:
       - github_actions


### PR DESCRIPTION
## Context

It is easy to reach the current limit of 10 open pull requests, particularly with additional PRs coming from UCD for prototypes and design updates. As the team is expected to grow soon, this limit may be reached more frequently.

Dependabot does not create new pull requests when there are 10 or more active PRs. This change increases the limit to 15 so that Dependabot can continue opening updates.

## Changes Proposed in This Pull Request

- Increase the maximum number of open Dependabot pull requests from 10 to 15 in the Dependabot YAML configuration.
 