### PR TITLE
Display schools in course wizard

### DIFF
--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -120,10 +120,7 @@ module Courses
       # once add-course creation only writes Course::School.
       course.sites = selected_sites
 
-      selected_sites.each do |site|
-        provider_school = provider_school_for(site)
-        next unless provider_school
-
+      selected_schools.each do |provider_school|
         course.schools.build(gias_school: provider_school.gias_school, provider_school:)
       end
     end
@@ -133,37 +130,21 @@ module Courses
     end
 
     def selected_sites
-      resolve_sites
-      @selected_sites
+      schools_resolver.sites
+    end
+
+    def selected_schools
+      schools_resolver.schools
     end
 
     # Schools are picked by UUID. The resolver logs any that do not belong to the
     # provider; the validator is what stops the course being saved without them.
-    def resolve_sites
-      return if defined?(@selected_sites)
-
-      @selected_sites = ::Schools::UuidResolver.call(
+    def schools_resolver
+      @schools_resolver ||= ::Schools::UuidResolver.new(
         provider:,
         uuids: school_uuids,
         log_tag: "CourseSchools",
-      ).schools
-    end
-
-    def provider_school_for(site)
-      provider_school = provider_schools_by_uuid[site.uuid]
-      return provider_school if provider_school
-
-      Rails.logger.warn(
-        "[CourseSchools] skipped course_school build - no provider_school for " \
-        "provider=#{provider.id} site_uuid=#{site.uuid} urn=#{site.urn.inspect}",
       )
-      nil
-    end
-
-    def provider_schools_by_uuid
-      @provider_schools_by_uuid ||= provider.schools
-        .where(uuid: selected_sites.map(&:uuid))
-        .index_by(&:uuid)
     end
 
     def update_study_sites(course)

--- a/app/services/schools/uuid_resolver.rb
+++ b/app/services/schools/uuid_resolver.rb
@@ -1,62 +1,59 @@
 # frozen_string_literal: true
 
 module Schools
-  # Resolves school UUIDs to the provider's own school records, preserving the
-  # order they were submitted in and reporting back any UUID that does not
-  # belong to the provider.
-  #
-  # Every layer of the add-course flow needs the same lookup but reacts to an
-  # unrecognised UUID differently - the wizard step raises a form error the
-  # provider can fix, the draft degrades so the review row still renders, and
-  # course creation errors the course. Only the lookup is shared here; the
-  # reaction stays with the caller.
-  #
-  # TODO School data remodel - the scope below becomes provider.schools once the
-  # add-course flow reads the new model. Schools are keyed by UUID precisely so
-  # that swap is a one-line change here rather than one per caller.
   class UuidResolver
-    include ServicePattern
-
-    Result = Struct.new(:schools, :unrecognised_uuids, keyword_init: true) do
-      def unrecognised?
-        unrecognised_uuids.any?
-      end
-    end
-
     def initialize(provider:, uuids:, log_tag:)
       @provider = provider
       @uuids = Array(uuids).compact_blank.map(&:to_s)
       @log_tag = log_tag
     end
 
-    def call
-      return Result.new(schools: [], unrecognised_uuids: []) if uuids.empty?
+    def schools
+      @schools ||= ordered(schools_by_uuid)
+    end
 
-      log_unrecognised if unrecognised_uuids.any?
+    def sites
+      @sites ||= ordered(sites_by_uuid)
+    end
 
-      Result.new(schools:, unrecognised_uuids:)
+    def unrecognised_uuids
+      log_unrecognised
+      unrecognised
+    end
+
+    def unrecognised?
+      unrecognised_uuids.any?
     end
 
   private
 
     attr_reader :provider, :uuids, :log_tag
 
-    def schools
-      @schools ||= uuids.filter_map { |uuid| schools_by_uuid[uuid] }
+    def ordered(records_by_uuid)
+      log_unrecognised
+      uuids.filter_map { |uuid| records_by_uuid[uuid] }
     end
 
-    def unrecognised_uuids
-      @unrecognised_uuids ||= uuids - schools_by_uuid.keys
+    def unrecognised
+      @unrecognised ||= uuids - schools_by_uuid.keys
+    end
+
+    def sites_by_uuid
+      @sites_by_uuid ||= provider.sites.where(uuid: uuids).index_by { |site| site.uuid.to_s }
     end
 
     def schools_by_uuid
-      @schools_by_uuid ||= provider.sites.where(uuid: uuids).index_by { |site| site.uuid.to_s }
+      @schools_by_uuid ||= provider.schools.includes(:gias_school).where(uuid: uuids).index_by { |school| school.uuid.to_s }
     end
 
     def log_unrecognised
+      return if @logged || unrecognised.empty?
+
+      @logged = true
+
       Rails.logger.warn(
         "[#{log_tag}] unrecognised school UUIDs for provider=#{provider.id}: " \
-        "#{unrecognised_uuids.join(', ')}",
+        "#{unrecognised.join(', ')}",
       )
     end
   end

--- a/app/wizards/course_wizard/draft.rb
+++ b/app/wizards/course_wizard/draft.rb
@@ -178,7 +178,7 @@ class CourseWizard
     # A school UUID that no longer resolves is logged and left out, rather than
     # blanking the whole review row.
     def ordered_school_records(uuids)
-      ::Schools::UuidResolver.call(
+      ::Schools::UuidResolver.new(
         provider: wizard.provider,
         uuids:,
         log_tag: "CourseWizard::Draft",

--- a/app/wizards/course_wizard/steps/schools.rb
+++ b/app/wizards/course_wizard/steps/schools.rb
@@ -23,7 +23,7 @@ class CourseWizard
       end
 
       def schools
-        @schools ||= provider.sites.order(:location_name)
+        @schools ||= provider.schools.includes(:gias_school).order("gias_school.name")
       end
 
       def schools_collapse_threshold
@@ -58,7 +58,7 @@ class CourseWizard
       def school_uuids_resolve
         return if selected_school_uuids.empty?
 
-        resolution = ::Schools::UuidResolver.call(
+        resolution = ::Schools::UuidResolver.new(
           provider:,
           uuids: selected_school_uuids,
           log_tag: "CourseWizard::Schools",

--- a/spec/components/publish/check_answers/summary_component_spec.rb
+++ b/spec/components/publish/check_answers/summary_component_spec.rb
@@ -96,19 +96,19 @@ RSpec.describe Publish::CheckAnswers::SummaryComponent, type: :component do
   end
 
   it "renders school and study-site rows with selected values and change links" do
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_school = create(:provider_school, provider:)
     study_site = provider.study_sites.first || create(:site, :study_site, provider:)
 
     state_store.write(
       qualification: "undergraduate_degree_with_qts",
-      school_uuids: [placement_site.uuid],
+      school_uuids: [placement_school.uuid],
       study_sites_ids: [study_site.id.to_s],
     )
     allow(wizard).to receive(:saved?).with(:schools).and_return(true)
     allow(wizard).to receive(:saved?).with(:study_sites).and_return(true)
 
     expect(rendered_component).to have_text("Employing school")
-    expect(rendered_component).to have_text(placement_site.location_name)
+    expect(rendered_component).to have_text(placement_school.location_name)
     expect(rendered_component).to have_link("Change", href: /return_to_review=schools/)
     expect(rendered_component).to have_text("Study site")
     expect(rendered_component).to have_text(study_site.location_name)
@@ -116,12 +116,12 @@ RSpec.describe Publish::CheckAnswers::SummaryComponent, type: :component do
   end
 
   it "renders select study site CTA when none is selected but study sites exist" do
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_school = create(:provider_school, provider:)
     provider.study_sites.first || create(:site, :study_site, provider:)
 
     state_store.write(
       qualification: "undergraduate_degree_with_qts",
-      school_uuids: [placement_site.uuid],
+      school_uuids: [placement_school.uuid],
       study_sites_ids: [],
     )
     allow(wizard).to receive(:saved?).with(:schools).and_return(true)
@@ -132,12 +132,12 @@ RSpec.describe Publish::CheckAnswers::SummaryComponent, type: :component do
   end
 
   it "renders add study site CTA when provider has no study sites" do
-    placement_site = provider.sites.first || create(:site, provider:)
+    placement_school = create(:provider_school, provider:)
     provider.study_sites.destroy_all
 
     state_store.write(
       qualification: "undergraduate_degree_with_qts",
-      school_uuids: [placement_site.uuid],
+      school_uuids: [placement_school.uuid],
       study_sites_ids: [],
     )
     allow(wizard).to receive(:saved?).with(:schools).and_return(true)

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -541,7 +541,9 @@ describe Courses::CreationService do
 
     context "when there is no matching provider_school (not backfilled)" do
       # GIAS school exists (matched by URN) but the provider has not been
-      # backfilled, so no Provider::School exists for the pair.
+      # backfilled, so no Provider::School exists for the pair. Resolution is
+      # keyed on Provider::School, so the UUID comes back unrecognised even
+      # though the legacy site is sitting right there.
       let!(:site) { create(:site, :with_gias_school, provider:) }
 
       before do
@@ -550,7 +552,7 @@ describe Courses::CreationService do
       end
 
       it "writes the legacy site, skips the new-model write, and logs a warning" do
-        expect(Rails.logger).to receive(:warn).with(/course_school/)
+        expect(Rails.logger).to receive(:warn).with(/unrecognised school UUIDs for provider=#{provider.id}: #{site.uuid}/)
 
         expect(created_course.sites.map(&:id)).to eq([site.id])
         expect(created_course.schools).to be_empty
@@ -601,7 +603,7 @@ describe Courses::CreationService do
       end
 
       it "keeps both sites but builds a Course::School only for the backfilled school" do
-        expect(Rails.logger).to receive(:warn).with(/site_uuid=#{site_two.uuid}/)
+        expect(Rails.logger).to receive(:warn).with(/unrecognised school UUIDs for provider=#{provider.id}: #{site_two.uuid}/)
 
         expect(created_course.sites.map(&:id)).to eq([site.id, site_two.id])
         expect(created_course.schools.map(&:gias_school_id)).to eq([gias_school.id])

--- a/spec/services/schools/uuid_resolver_spec.rb
+++ b/spec/services/schools/uuid_resolver_spec.rb
@@ -3,38 +3,48 @@
 require "rails_helper"
 
 describe Schools::UuidResolver do
-  subject(:resolution) { described_class.call(provider:, uuids:, log_tag: "TestCaller") }
+  subject(:resolver) { described_class.new(provider:, uuids:, log_tag: "TestCaller") }
 
-  let(:provider) { create(:provider, sites: [build(:site), build(:site)]) }
-  let(:first_school) { provider.sites.first }
-  let(:second_school) { provider.sites.second }
+  let(:provider) { create(:provider) }
+
+  # Sites are created with their Provider::School half, keyed by the same uuid,
+  # which is the state the backfill leaves every provider in.
+  let!(:first_site) { create(:site, :with_provider_school, provider:) }
+  let!(:second_site) { create(:site, :with_provider_school, provider:) }
+
+  let(:first_school) { provider.schools.find_by(uuid: first_site.uuid) }
+  let(:second_school) { provider.schools.find_by(uuid: second_site.uuid) }
 
   context "when every uuid belongs to the provider" do
     let(:uuids) { [second_school.uuid, first_school.uuid] }
 
     it "returns the schools in the order they were submitted" do
-      expect(resolution.schools.map(&:id)).to eq([second_school.id, first_school.id])
-      expect(resolution.unrecognised_uuids).to be_empty
-      expect(resolution).not_to be_unrecognised
+      expect(resolver.schools.map(&:id)).to eq([second_school.id, first_school.id])
+      expect(resolver.unrecognised_uuids).to be_empty
+      expect(resolver).not_to be_unrecognised
+    end
+
+    it "returns the matching legacy sites in the order they were submitted" do
+      expect(resolver.sites.map(&:id)).to eq([second_site.id, first_site.id])
     end
 
     it "does not log" do
       expect(Rails.logger).not_to receive(:warn)
 
-      resolution
+      resolver.schools
     end
   end
 
   context "when a uuid does not belong to the provider" do
-    let(:other_providers_school) { create(:site, provider: create(:provider)) }
+    let(:other_providers_school) { create(:site, :with_provider_school, provider: create(:provider)) }
     let(:uuids) { [first_school.uuid, other_providers_school.uuid] }
 
     it "resolves the rest and reports the unrecognised uuid" do
       allow(Rails.logger).to receive(:warn)
 
-      expect(resolution.schools.map(&:id)).to eq([first_school.id])
-      expect(resolution.unrecognised_uuids).to eq([other_providers_school.uuid])
-      expect(resolution).to be_unrecognised
+      expect(resolver.schools.map(&:id)).to eq([first_school.id])
+      expect(resolver.unrecognised_uuids).to eq([other_providers_school.uuid])
+      expect(resolver).to be_unrecognised
     end
 
     it "logs the unrecognised uuid against the caller's tag" do
@@ -42,7 +52,24 @@ describe Schools::UuidResolver do
         "[TestCaller] unrecognised school UUIDs for provider=#{provider.id}: #{other_providers_school.uuid}",
       )
 
-      resolution
+      resolver.schools
+    end
+
+    # Callers read the resolution in whichever shape suits them, and some read
+    # more than one. The provider is one submission short either way, so it is
+    # one log line rather than one per reader.
+    it "logs once however many times the resolution is read" do
+      expect(Rails.logger).to receive(:warn).once
+
+      resolver.schools
+      resolver.sites
+      resolver.unrecognised_uuids
+    end
+
+    it "logs when only the unrecognised uuids are read" do
+      expect(Rails.logger).to receive(:warn).once
+
+      resolver.unrecognised?
     end
   end
 
@@ -53,33 +80,49 @@ describe Schools::UuidResolver do
     it "returns no schools and reports the uuid" do
       allow(Rails.logger).to receive(:warn)
 
-      expect(resolution.schools).to be_empty
-      expect(resolution.unrecognised_uuids).to eq([unrecognised_uuid])
+      expect(resolver.schools).to be_empty
+      expect(resolver.unrecognised_uuids).to eq([unrecognised_uuid])
     end
   end
 
-  context "when a school has been discarded" do
-    let(:uuids) { [first_school.uuid] }
-
-    before { first_school.discard }
+  # Recognition is decided by Provider::School, so a site whose half of the
+  # backfill is missing does not resolve, even though the site itself is there.
+  context "when a site has no Provider::School" do
+    let(:site_without_school) { create(:site, provider:) }
+    let(:uuids) { [site_without_school.uuid] }
 
     it "treats it as unrecognised" do
       allow(Rails.logger).to receive(:warn)
 
-      expect(resolution.schools).to be_empty
-      expect(resolution.unrecognised_uuids).to eq([first_school.uuid])
+      expect(resolver.schools).to be_empty
+      expect(resolver.unrecognised_uuids).to eq([site_without_school.uuid])
+    end
+  end
+
+  # Provider::School is hard-deleted on removal rather than discarded, so
+  # discarding the legacy site on its own leaves the school resolvable.
+  context "when the legacy site has been discarded" do
+    let(:uuids) { [first_school.uuid] }
+
+    before { first_site.discard }
+
+    it "still resolves the school but drops the discarded site" do
+      expect(resolver.schools.map(&:id)).to eq([first_school.id])
+      expect(resolver).not_to be_unrecognised
+      expect(resolver.sites).to be_empty
     end
   end
 
   context "when nothing was submitted" do
     let(:uuids) { ["", nil] }
 
-    it "returns an empty result without querying or logging" do
+    it "resolves nothing without logging" do
       expect(Rails.logger).not_to receive(:warn)
 
-      expect(resolution.schools).to be_empty
-      expect(resolution.unrecognised_uuids).to be_empty
-      expect(resolution).not_to be_unrecognised
+      expect(resolver.schools).to be_empty
+      expect(resolver.sites).to be_empty
+      expect(resolver.unrecognised_uuids).to be_empty
+      expect(resolver).not_to be_unrecognised
     end
   end
 end

--- a/spec/system/publish/courses/add_course_wizard/schools_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/schools_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Add course wizard schools step", type: :system do
     and_i_have_wizard_state_for_schools(funding_type: "salary")
     when_i_visit_the_wizard_schools_page
     and_the_title_and_description_are_displayed_for_a_salaried_school
-    and_i_choose_a_site_from_the_list
+    and_i_choose_a_school_from_the_list
     and_i_click_continue
     then_i_am_taken_to_the_study_sites_page
   end
@@ -21,7 +21,7 @@ RSpec.describe "Add course wizard schools step", type: :system do
     and_i_have_wizard_state_for_schools(funding_type: "fee")
     when_i_visit_the_wizard_schools_page
     and_the_title_and_description_are_displayed_for_a_non_salaried_school
-    and_i_choose_a_site_from_the_list
+    and_i_choose_a_school_from_the_list
     and_i_click_continue
     then_i_am_taken_to_the_study_sites_page
   end
@@ -47,7 +47,7 @@ RSpec.describe "Add course wizard schools step", type: :system do
     and_i_click_continue
     then_i_am_taken_to_the_schools_page
     and_the_title_and_description_are_displayed_for_a_salaried_school
-    and_i_choose_a_site_from_the_list
+    and_i_choose_a_school_from_the_list
     and_i_click_continue
     then_i_am_taken_to_the_study_sites_page
   end
@@ -131,8 +131,8 @@ private
     choose qualification
   end
 
-  def and_i_choose_a_site_from_the_list
-    check provider.sites.first.location_name
+  def and_i_choose_a_school_from_the_list
+    check first_school.location_name
   end
 
   def then_i_have_errors_on_the_schools_step
@@ -164,77 +164,70 @@ private
     )
   end
 
-  def given_i_am_authenticated_as_a_provider_user_with_multiple_schools
-    @user = create(
-      :user,
-      providers: [
-        create(
-          :provider,
-          :accredited_provider,
-          sites: [build(:site), build(:site), build(:site, :study_site)],
-        ),
-      ],
+  # The schools step lists Provider::School, so the checkbox label and hint come
+  # from the joined GIAS record rather than the legacy site.
+  #
+  # Names are given explicitly rather than left to the factory's
+  # Faker::University.name: Capybara's `check` matches label text on a substring,
+  # so random names can collide or prefix each other.
+  def create_school(provider, name, **gias_school_attributes)
+    create(
+      :provider_school,
+      provider:,
+      gias_school: create(:gias_school, name:, **gias_school_attributes),
     )
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_multiple_schools
+    provider = create(:provider, :accredited_provider, sites: [build(:site, :study_site)])
+    create_school(provider, "Alpha Academy")
+    create_school(provider, "Beta Academy")
+
+    @user = create(:user, providers: [provider])
 
     given_i_am_authenticated(user: @user)
   end
 
   def given_i_am_authenticated_as_a_provider_user_with_a_school
-    @user = create(
-      :user,
-      providers: [
-        create(:provider, :accredited_provider, sites: [build(:site), build(:site, :study_site)]),
-      ],
-    )
+    provider = create(:provider, :accredited_provider, sites: [build(:site, :study_site)])
+    create_school(provider, "Alpha Academy")
+
+    @user = create(:user, providers: [provider])
 
     given_i_am_authenticated(user: @user)
   end
 
-  # Deterministic, non-ambiguous names: the site factory's default is
-  # "Main Site#{rand(1_000_000)}", and Capybara's `check` matches label text on a
-  # substring, so random names can collide or prefix each other.
-  #
   # The study site keeps this provider on the same route as the other scenarios
-  # (schools -> study sites). It does not show up in the schools list, since
-  # Provider#sites is scoped to school-type sites.
+  # (schools -> study sites). It does not show up in the schools list, which
+  # reads Provider#schools.
+  #
+  # Created in reverse so row order is the opposite of name order: the step sorts
+  # on the GIAS name, and which schools fall inside the first 20 would not
+  # otherwise prove that sort is applied.
   def given_i_am_authenticated_as_a_provider_user_with_25_schools
-    @user = create(
-      :user,
-      providers: [
-        create(
-          :provider,
-          :accredited_provider,
-          sites: (1..25).map { |n| build(:site, location_name: sprintf("School %02d", n)) } + [build(:site, :study_site)],
-        ),
-      ],
-    )
+    provider = create(:provider, :accredited_provider, sites: [build(:site, :study_site)])
+    25.downto(1) { |n| create_school(provider, sprintf("School %02d", n)) }
+
+    @user = create(:user, providers: [provider])
 
     given_i_am_authenticated(user: @user)
   end
 
   def given_i_am_authenticated_as_a_provider_user_with_a_named_school
-    @user = create(
-      :user,
-      providers: [
-        create(
-          :provider,
-          :accredited_provider,
-          sites: [
-            build(
-              :site,
-              location_name: "Belvidere School",
-              address1: "Belvidere Lane",
-              address2: "",
-              address3: "",
-              town: "Shrewsbury",
-              address4: "Shropshire",
-              postcode: "SY2 5RJ",
-            ),
-            build(:site),
-          ],
-        ),
-      ],
+    provider = create(:provider, :accredited_provider)
+    create_school(
+      provider,
+      "Belvidere School",
+      address1: "Belvidere Lane",
+      address2: "",
+      address3: "",
+      town: "Shrewsbury",
+      county: "Shropshire",
+      postcode: "SY2 5RJ",
     )
+    create_school(provider, "Alpha Academy")
+
+    @user = create(:user, providers: [provider])
 
     given_i_am_authenticated(user: @user)
   end
@@ -252,8 +245,12 @@ private
     end
   end
 
+  def first_school
+    @first_school ||= provider.schools.min_by(&:location_name)
+  end
+
   def last_school
-    @last_school ||= provider.sites.max_by(&:location_name)
+    @last_school ||= provider.schools.max_by(&:location_name)
   end
 
   def then_only_the_first_20_schools_are_shown

--- a/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
@@ -65,7 +65,7 @@ private
   end
 
   def and_i_choose_a_school_from_the_list
-    check provider.sites.first.location_name
+    check provider.schools.min_by(&:location_name).location_name
   end
 
   def and_i_click_continue
@@ -129,18 +129,13 @@ private
   end
 
   def given_i_am_authenticated_as_a_school_based_provider_user_with_no_study_sites_and_multiple_accredited_partners
-    @user = create(
-      :user,
-      providers: [
-        create(
-          :provider,
-          provider_type: :lead_school,
-          sites: [build(:site), build(:site)],
-        ),
-      ],
-    )
+    school_provider = create(:provider, provider_type: :lead_school)
+    ["Alpha Academy", "Beta Academy"].each do |name|
+      create(:provider_school, provider: school_provider, gias_school: create(:gias_school, name:))
+    end
 
-    school_provider = @user.providers.first
+    @user = create(:user, providers: [school_provider])
+
     create(
       :provider_partnership,
       training_provider: school_provider,

--- a/spec/wizards/add_course_wizard/draft_spec.rb
+++ b/spec/wizards/add_course_wizard/draft_spec.rb
@@ -191,32 +191,32 @@ RSpec.describe CourseWizard::Draft, type: :wizard do
     end
 
     it "keeps every stored uuid but resolves only the provider's own schools" do
-      site_one = provider.sites.first || create(:site, provider:)
-      site_two = create(:site, provider:)
-      site_three = create(:site, provider: create(:provider))
-      state_store.write(school_uuids: [site_two.uuid, site_one.uuid, site_three.uuid])
+      school_one = create(:site, :with_provider_school, provider:)
+      school_two = create(:site, :with_provider_school, provider:)
+      other_providers_school = create(:site, :with_provider_school, provider: create(:provider))
+      state_store.write(school_uuids: [school_two.uuid, school_one.uuid, other_providers_school.uuid])
 
-      expect(draft.school_uuids).to eq([site_two.uuid, site_one.uuid, site_three.uuid])
-      expect(draft.schools.map(&:id)).to eq([site_two.id, site_one.id])
+      expect(draft.school_uuids).to eq([school_two.uuid, school_one.uuid, other_providers_school.uuid])
+      expect(draft.schools.map(&:uuid)).to eq([school_two.uuid, school_one.uuid])
     end
 
     it "returns school UUIDs and ordered school records" do
-      site_one = provider.sites.first || create(:site, provider:)
-      site_two = create(:site, provider:)
-      state_store.write(school_uuids: [site_two.uuid, site_one.uuid])
+      school_one = create(:site, :with_provider_school, provider:)
+      school_two = create(:site, :with_provider_school, provider:)
+      state_store.write(school_uuids: [school_two.uuid, school_one.uuid])
 
-      expect(draft.school_uuids).to eq([site_two.uuid, site_one.uuid])
-      expect(draft.schools.map(&:id)).to eq([site_two.id, site_one.id])
+      expect(draft.school_uuids).to eq([school_two.uuid, school_one.uuid])
+      expect(draft.schools.map(&:uuid)).to eq([school_two.uuid, school_one.uuid])
     end
 
     it "logs the unrecognised uuids rather than dropping them silently" do
-      site = provider.sites.first || create(:site, provider:)
+      school = create(:site, :with_provider_school, provider:)
       unrecognised_uuid = SecureRandom.uuid
-      state_store.write(school_uuids: [site.uuid, unrecognised_uuid])
+      state_store.write(school_uuids: [school.uuid, unrecognised_uuid])
 
       expect(Rails.logger).to receive(:warn).with(/#{unrecognised_uuid}/)
 
-      expect(draft.schools.map(&:id)).to eq([site.id])
+      expect(draft.schools.map(&:uuid)).to eq([school.uuid])
     end
 
     # The review page reads both, so they can disagree: state still holds the
@@ -230,14 +230,16 @@ RSpec.describe CourseWizard::Draft, type: :wizard do
       expect(draft.schools).to eq([])
     end
 
-    it "drops a school discarded after it was chosen" do
+    # Removing a school destroys its Provider::School rather than discarding it,
+    # so that is what the draft has to survive between choosing and reviewing.
+    it "drops a school removed after it was chosen" do
       allow(Rails.logger).to receive(:warn)
-      site = create(:site, provider:)
-      state_store.write(school_uuids: [site.uuid])
+      school = create(:site, :with_provider_school, provider:)
+      state_store.write(school_uuids: [school.uuid])
 
-      site.discard
+      provider.schools.find_by(uuid: school.uuid).destroy!
 
-      expect(draft.school_uuids).to eq([site.uuid])
+      expect(draft.school_uuids).to eq([school.uuid])
       expect(draft.schools).to eq([])
     end
 

--- a/spec/wizards/add_course_wizard/steps/schools_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/schools_spec.rb
@@ -12,14 +12,20 @@ RSpec.describe CourseWizard::Steps::Schools do
 
   let(:provider) { create(:provider, :accredited_provider, recruitment_cycle:) }
 
-  let!(:site_a) { create(:site, provider:, location_name: "B School") }
-  let!(:site_b) { create(:site, provider:, location_name: "A School") }
+  # The step lists Provider::School and sorts on the GIAS name, so the name that
+  # orders the list lives on the GIAS record rather than the legacy site.
+  let!(:school_a) { create_school("B School") }
+  let!(:school_b) { create_school("A School") }
+
+  def create_school(name)
+    create(:provider_school, provider:, gias_school: create(:gias_school, name:))
+  end
 
   describe "#valid?" do
     subject(:wizard_step) { wizard.current_step }
 
     it "is valid when at least one school UUID is selected" do
-      wizard_step.school_uuids = [site_a.uuid]
+      wizard_step.school_uuids = [school_a.uuid]
 
       expect(wizard_step).to be_valid
     end
@@ -43,7 +49,7 @@ RSpec.describe CourseWizard::Steps::Schools do
     end
 
     it "is not valid when a school UUID is not a UUID" do
-      wizard_step.school_uuids = [site_a.id.to_s]
+      wizard_step.school_uuids = [school_a.id.to_s]
 
       expect(Rails.logger).to receive(:warn).with(/unrecognised school UUIDs/)
 
@@ -53,14 +59,14 @@ RSpec.describe CourseWizard::Steps::Schools do
       )
     end
 
-    context "when provider has only one site" do
-      let!(:site_b) { nil }
+    context "when provider has only one school" do
+      let!(:school_b) { nil }
 
-      it "auto-selects the only site and is valid when no site is submitted" do
+      it "auto-selects the only school and is valid when no school is submitted" do
         wizard_step.school_uuids = nil
 
         expect(wizard_step).to be_valid
-        expect(wizard_step.school_uuids).to eq([site_a.uuid])
+        expect(wizard_step.school_uuids).to eq([school_a.uuid])
       end
     end
   end
@@ -68,11 +74,11 @@ RSpec.describe CourseWizard::Steps::Schools do
   describe "#schools" do
     subject(:wizard_step) { wizard.current_step }
 
-    it "returns provider sites sorted by location name" do
+    it "returns the provider's schools sorted by GIAS name" do
       expect(wizard_step.schools).to eq(
         [
-          site_b,
-          site_a,
+          school_b,
+          school_a,
         ],
       )
     end
@@ -86,7 +92,7 @@ RSpec.describe CourseWizard::Steps::Schools do
     end
 
     context "when the provider has more than 20 schools" do
-      before { create_list(:site, 19, provider:) }
+      before { 19.times { |n| create_school(sprintf("School %02d", n)) } }
 
       it "is true" do
         expect(wizard_step.collapse_schools?).to be(true)

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
 
       before do
         study_site = provider.study_sites.first || create(:site, :study_site, provider:)
+        school = create(:provider_school, provider:)
 
         state_store.write(
           is_send: "false",
@@ -146,7 +147,7 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
           qualification: "pgce_with_qts",
           funding_type: "fee",
           study_pattern: %w[full_time],
-          school_uuids: [provider.sites.first.uuid],
+          school_uuids: [school.uuid],
           study_sites_ids: [study_site.id.to_s],
           can_sponsor_student_visa: false,
           start_date: "July 2027",


### PR DESCRIPTION
## Context

Recent work changed the form and wizard params for identifying schools on a new course from site_id to uuid.
We can now cleanly swap out the loading of schools (using the uuid) from Site to Provider::School.

## Changes proposed in this pull request

On the add schools page of the add course wizard, we now display the records from the `Provider::School` & `GiasSchool`. 

The same records are used to populate the Check Answers page.

And finally we update how the UuidResolver works so it returns both sites and schools matching the given uuids. We use these results directly to assign SiteStatus and Course::School to the course.

The names of the school objects in the affected tests are changed from `site` to `school` also.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
