### PR TITLE
Fix invalid applications open date created during course rollover

### DIFF
--- a/app/forms/support/recruitment_cycle_form.rb
+++ b/app/forms/support/recruitment_cycle_form.rb
@@ -52,7 +52,11 @@ module Support
       if expected_application_start_date.blank?
         errors.add(:application_start_date, :missing_cycle_timetable)
       elsif application_start_date != expected_application_start_date
-        errors.add(:application_start_date, :does_not_match_cycle_timetable)
+        errors.add(
+          :application_start_date,
+          :does_not_match_cycle_timetable,
+          date: expected_application_start_date.to_fs(:govuk_date),
+        )
       end
     end
 

--- a/app/forms/support/recruitment_cycle_form.rb
+++ b/app/forms/support/recruitment_cycle_form.rb
@@ -15,6 +15,7 @@ module Support
               :available_in_publish_from,
               multiple_parameters_date: true
     validate :application_end_date_must_be_after_start_date
+    validate :application_start_date_must_match_cycle_timetable
     validate :available_for_support_users_from_must_be_before_available_in_publish_from
     validate :year_must_be_unique, if: -> { validation_context != :update }
 
@@ -39,6 +40,20 @@ module Support
       return if year.blank?
 
       errors.add(:year, :taken) if RecruitmentCycle.exists?(year:)
+    end
+
+    def application_start_date_must_match_cycle_timetable
+      return if year.blank? || application_start_date.blank?
+      return unless year.to_s.match?(/\A\d+\z/)
+      return if errors[:application_start_date].present?
+
+      expected_application_start_date = Find::CycleTimetable.real_schedule_for(year.to_i)&.fetch(:apply_opens, nil)&.to_date
+
+      if expected_application_start_date.blank?
+        errors.add(:application_start_date, :missing_cycle_timetable)
+      elsif application_start_date != expected_application_start_date
+        errors.add(:application_start_date, :does_not_match_cycle_timetable)
+      end
     end
 
     def available_for_support_users_from_must_be_before_available_in_publish_from

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -26,7 +26,7 @@ module Courses
         new_course.application_status                       = "closed"
         new_course.provider                                 = new_provider
         year_differential                                   = new_course.recruitment_cycle.year.to_i - course.recruitment_cycle.year.to_i
-        new_course.applications_open_from                   = adjusted_applications_open_from_date(course, year_differential)
+        new_course.applications_open_from                   = adjusted_applications_open_from_date(course:, new_provider:, year_differential:)
         new_course.start_date                               = course.start_date + year_differential.year
         course.course_subjects.each do |cs|
           new_course.course_subjects.build(subject_id: cs.subject_id, position: cs.position)
@@ -66,24 +66,26 @@ module Courses
       @enrichments_copy_to_course.execute(enrichment: latest_enrichment, new_course:)
     end
 
-    def adjusted_applications_open_from_date(course, year_differential)
-      return current_cycle.application_start_date if course.applications_open_from.blank? && next_cycle.blank?
+    def adjusted_applications_open_from_date(course:, new_provider:, year_differential:)
+      source_recruitment_cycle = course.recruitment_cycle
+      target_recruitment_cycle = new_provider.recruitment_cycle
 
-      return course.applications_open_from if next_cycle.blank?
+      return target_recruitment_cycle.application_start_date if course.applications_open_from.blank?
 
-      if course_start_is_same_as_current_cycle_start?(course)
-        Find::CycleTimetable.apply_reopens.to_date
-      else
-        [course.applications_open_from + year_differential.year, next_cycle.application_start_date].max
-      end
+      source_date_range = source_recruitment_cycle.application_start_date..source_recruitment_cycle.application_end_date
+      return target_recruitment_cycle.application_start_date unless source_date_range.cover?(course.applications_open_from)
+
+      adjusted_date = if course.applications_open_from == source_recruitment_cycle.application_start_date
+                        target_recruitment_cycle.application_start_date
+                      else
+                        course.applications_open_from + year_differential.year
+                      end
+
+      adjusted_date.clamp(target_recruitment_cycle.application_start_date, target_recruitment_cycle.application_end_date)
     end
 
     def copy_schools(course:, new_provider:, new_course:)
       schools_copy_to_course.call(course:, new_provider:, new_course:)
-    end
-
-    def course_start_is_same_as_current_cycle_start?(course)
-      course.applications_open_from == current_cycle.application_start_date
     end
 
     def copy_study_sites(course:, new_provider:, new_course:)
@@ -101,14 +103,6 @@ module Courses
     def new_provider_study_sites(new_provider)
       @new_provider_study_sites ||= {}
       @new_provider_study_sites[new_provider.id] ||= new_provider.study_sites.index_by(&:code)
-    end
-
-    def next_cycle
-      @next_cycle ||= RecruitmentCycle.next_recruitment_cycle
-    end
-
-    def current_cycle
-      @current_cycle ||= RecruitmentCycle.current_recruitment_cycle
     end
   end
 end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -33,7 +33,9 @@ en:
             application_start_date:
               blank: Enter the date that candidates will be able to start applying for courses
               application_end_date_after_start_date: Start date must be before the application end date
+              does_not_match_cycle_timetable: Application start date must match the Find cycle timetable. Update the timetable first if this date has changed.
               invalid_date: Enter a valid date
+              missing_cycle_timetable: Add the recruitment cycle to the Find cycle timetable before setting the application start date
             application_end_date:
               blank: Enter the date that applications close
               application_end_date_after_start_date: End date must be after the application start date

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -33,7 +33,7 @@ en:
             application_start_date:
               blank: Enter the date that candidates will be able to start applying for courses
               application_end_date_after_start_date: Start date must be before the application end date
-              does_not_match_cycle_timetable: Application start date must match the Find cycle timetable. Update the timetable first if this date has changed.
+              does_not_match_cycle_timetable: Application start date must be %{date}, which is the date in the Find cycle timetable. Update the timetable first if this date has changed.
               invalid_date: Enter a valid date
               missing_cycle_timetable: Add the recruitment cycle to the Find cycle timetable before setting the application start date
             application_end_date:

--- a/spec/forms/support/recruitment_cycle_form_spec.rb
+++ b/spec/forms/support/recruitment_cycle_form_spec.rb
@@ -75,6 +75,57 @@ RSpec.describe Support::RecruitmentCycleForm do
     context "when dates are valid" do
       let(:params) do
         {
+          "year" => "2027",
+          "application_start_date(1i)" => "2026",
+          "application_start_date(2i)" => "10",
+          "application_start_date(3i)" => "06",
+          "application_end_date(1i)" => "2027",
+          "application_end_date(2i)" => "03",
+          "application_end_date(3i)" => "10",
+          "available_in_publish_from(1i)" => "2026",
+          "available_in_publish_from(2i)" => "09",
+          "available_in_publish_from(3i)" => "01",
+          "available_for_support_users_from(1i)" => "2026",
+          "available_for_support_users_from(2i)" => "08",
+          "available_for_support_users_from(3i)" => "01",
+        }
+      end
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when application start date does not match the Find cycle timetable" do
+      let(:params) do
+        {
+          "year" => "2027",
+          "application_start_date(1i)" => "2026",
+          "application_start_date(2i)" => "10",
+          "application_start_date(3i)" => "07",
+          "application_end_date(1i)" => "2027",
+          "application_end_date(2i)" => "03",
+          "application_end_date(3i)" => "10",
+          "available_in_publish_from(1i)" => "2026",
+          "available_in_publish_from(2i)" => "09",
+          "available_in_publish_from(3i)" => "01",
+          "available_for_support_users_from(1i)" => "2026",
+          "available_for_support_users_from(2i)" => "08",
+          "available_for_support_users_from(3i)" => "01",
+        }
+      end
+
+      it "is invalid" do
+        expect(form).not_to be_valid
+        expect(form.errors[:application_start_date]).to include(
+          "Application start date must match the Find cycle timetable. Update the timetable first if this date has changed.",
+        )
+      end
+    end
+
+    context "when the year is not in the Find cycle timetable" do
+      let(:params) do
+        {
           "year" => "2051",
           "application_start_date(1i)" => "2050",
           "application_start_date(2i)" => "10",
@@ -91,8 +142,11 @@ RSpec.describe Support::RecruitmentCycleForm do
         }
       end
 
-      it "is valid" do
-        expect(form).to be_valid
+      it "is invalid" do
+        expect(form).not_to be_valid
+        expect(form.errors[:application_start_date]).to include(
+          "Add the recruitment cycle to the Find cycle timetable before setting the application start date",
+        )
       end
     end
 

--- a/spec/forms/support/recruitment_cycle_form_spec.rb
+++ b/spec/forms/support/recruitment_cycle_form_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Support::RecruitmentCycleForm do
       it "is invalid" do
         expect(form).not_to be_valid
         expect(form.errors[:application_start_date]).to include(
-          "Application start date must match the Find cycle timetable. Update the timetable first if this date has changed.",
+          "Application start date must be 6 October 2026, which is the date in the Find cycle timetable. Update the timetable first if this date has changed.",
         )
       end
     end

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Courses::CopyToProviderService do
       expect(new_course.applications_open_from).to eq course.applications_open_from + 1.year
     end
 
-    context "when the original course's date is before the next cycle's start date" do
+    context "when the original course's date is before the target cycle's start date" do
       before do
         course.applications_open_from = Date.new(provider.recruitment_cycle.year.to_i - 1, 10, 1)
       end
@@ -127,12 +127,12 @@ RSpec.describe Courses::CopyToProviderService do
       it "sets the new course's applications open from date correctly", travel: mid_cycle do
         service.execute(course:, new_provider:)
 
-        expect(new_course.applications_open_from).to eq(Find::CycleTimetable.apply_reopens.to_date)
+        expect(new_course.applications_open_from).to eq(new_recruitment_cycle.application_start_date)
       end
     end
 
     context "when the original course's date is at the beginning of the cycle" do
-      let(:new_recruitment_cycle) { create(:recruitment_cycle, :next, application_start_date: "2023-09-01") }
+      let(:new_recruitment_cycle) { create(:recruitment_cycle, :next, application_start_date: Date.new(Find::CycleTimetable.next_year - 1, 10, 7)) }
 
       before do
         course.applications_open_from = provider.recruitment_cycle.application_start_date
@@ -141,7 +141,61 @@ RSpec.describe Courses::CopyToProviderService do
       it "sets the new course's applications open from date correctly" do
         service.execute(course:, new_provider:)
 
-        expect(new_course.applications_open_from).to eq(Find::CycleTimetable.apply_reopens.to_date)
+        expect(new_course.applications_open_from).to eq(new_recruitment_cycle.application_start_date)
+      end
+    end
+
+    context "when the adjusted date is after the target cycle's application end date" do
+      let(:new_recruitment_cycle) do
+        create(:recruitment_cycle,
+               :next,
+               application_end_date: Date.new(Find::CycleTimetable.next_year, 9, 1))
+      end
+
+      before do
+        course.applications_open_from = recruitment_cycle.application_end_date
+      end
+
+      it "sets the new course's applications open from date to the target cycle's application end date" do
+        service.execute(course:, new_provider:)
+
+        expect(new_course.applications_open_from).to eq(new_recruitment_cycle.application_end_date)
+      end
+    end
+
+    context "when the source course's applications open from date is outside its recruitment cycle" do
+      before do
+        course.applications_open_from = provider.recruitment_cycle.application_end_date + 1.week
+      end
+
+      it "sets the new course's applications open from date to the target cycle's application start date" do
+        service.execute(course:, new_provider:)
+
+        expect(new_course.applications_open_from).to eq(new_recruitment_cycle.application_start_date)
+      end
+    end
+
+    context "when rollover is run before providers can access the target cycle" do
+      let(:new_recruitment_cycle) do
+        create(:recruitment_cycle,
+               :next,
+               application_start_date: Date.new(2026, 10, 7),
+               application_end_date: Date.new(2027, 9, 23),
+               available_for_support_users_from: Date.new(2026, 8, 3),
+               available_in_publish_from: Date.new(2026, 8, 4))
+      end
+
+      before do
+        course.applications_open_from = recruitment_cycle.application_start_date
+      end
+
+      it "uses the target recruitment cycle's application start date" do
+        Timecop.travel(Time.zone.local(2026, 8, 3, 12)) do
+          service.execute(course:, new_provider:)
+        end
+
+        expect(new_course.applications_open_from).to eq(Date.new(2026, 10, 7))
+        expect(new_recruitment_cycle.application_start_date..new_recruitment_cycle.application_end_date).to cover(new_course.applications_open_from)
       end
     end
   end

--- a/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish, travel: mid_
 
   def when_i_fill_in_valid_recruitment_cycle_details
     fill_in "Recruitment cycle year", with: "2026"
-    fill_in "support_recruitment_cycle_form[application_start_date(3i)]", with: "04"
+    fill_in "support_recruitment_cycle_form[application_start_date(3i)]", with: "07"
     fill_in "support_recruitment_cycle_form[application_start_date(2i)]", with: "10"
     fill_in "support_recruitment_cycle_form[application_start_date(1i)]", with: "2025"
     fill_in "support_recruitment_cycle_form[application_end_date(3i)]", with: "04"
@@ -80,7 +80,7 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish, travel: mid_
     recruitment_cycle = RecruitmentCycle.find_by(year: "2026")
     expect(recruitment_cycle).to be_present
 
-    expect(recruitment_cycle.application_start_date).to eq(Date.new(2025, 10, 4))
+    expect(recruitment_cycle.application_start_date).to eq(Date.new(2025, 10, 7))
     expect(recruitment_cycle.application_end_date).to eq(Date.new(2026, 10, 4))
     expect(recruitment_cycle.available_in_publish_from).to eq(Date.new(2025, 9, 4))
     expect(recruitment_cycle.available_for_support_users_from).to eq(Date.new(2025, 9, 1))

--- a/spec/system/support/settings/recruitment_cycles/edit_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/edit_recruitment_cycle_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe "Editing a recruitment cycle", service: :publish, travel: mid_cyc
     then_i_can_edit_the_cycle
 
     when_i_click_change
-    and_i_change_the_application_start_date
     and_i_change_the_application_end_date
     and_i_change_the_available_in_publish_from_date
     and_i_click_continue
@@ -78,13 +77,6 @@ RSpec.describe "Editing a recruitment cycle", service: :publish, travel: mid_cyc
     click_link_or_button "Change", match: :first
   end
 
-  def and_i_change_the_application_start_date
-    within_fieldset "Application start date" do
-      fill_in "Day", with: "27"
-      fill_in "Month", with: "09"
-    end
-  end
-
   def and_i_change_the_application_end_date
     within_fieldset "Application end date" do
       fill_in "Day", with: "05"
@@ -107,8 +99,7 @@ RSpec.describe "Editing a recruitment cycle", service: :publish, travel: mid_cyc
     expect(page).to have_content("Recruitment cycle updated")
 
     @upcoming_cycle.reload
-    expect(@upcoming_cycle.application_start_date.day).to eq(27)
-    expect(@upcoming_cycle.application_start_date.month).to eq(9)
+    expect(@upcoming_cycle.application_start_date).to eq(Find::CycleTimetable.apply_opens(@upcoming_cycle.year).to_date)
     expect(@upcoming_cycle.application_end_date.day).to eq(5)
     expect(@upcoming_cycle.application_end_date.month).to eq(10)
     expect(@upcoming_cycle.available_in_publish_from.day).to eq(RecruitmentCycle.current.available_for_support_users_from.succ.day)


### PR DESCRIPTION
Context

We ran the rollover a few times in review apps. During that some rolled-over courses had an invalid applications_open_from date in September 2027. This was due to the wrong application start date set during the rollover task.

The recruitment cycle application window is from 7 October 2026 to 23 September 2027. The generated date falls outside the permitted range, causing course validation to fail when the course is updated.

An affected example is course F220 for provider 1CP.

Changes proposed in this pull request

* Correct the rollover logic so rolled-over courses receive a valid applications_open_from date for the new recruitment cycle
* Add test coverage for the date assigned during course rollover
* Prevent rolled-over courses from failing validation because of an automatically generated application start date

## Guidance to review

Check the code. I'll start the roll over, you guys can do QA as well.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
