### PR TITLE
Skip validating enrichment salary_details after the 2026 cycle

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -88,8 +88,8 @@ class CourseEnrichment < ApplicationRecord
             if: -> { is_fee_based? && version == 2 }
 
   # Course length and salary
-  validates :salary_details, presence: true, on: :publish, unless: :is_fee_based?
-  validates :salary_details, words_count: { maximum: 250 }, unless: :is_fee_based?
+  validates :salary_details, presence: true, on: :publish, unless: ->(record) { record.is_fee_based? || (record.course && record.course.recruitment_cycle.after?(2026)) }
+  validates :salary_details, words_count: { maximum: 250 }, unless: ->(record) { record.is_fee_based? || (record.course && record.course.recruitment_cycle.after?(2026)) }
 
   validates :salary_fee_details, words_count: { maximum: 100 }
   # Requirements and qualifications

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -147,6 +147,21 @@ RSpec.describe CourseEnrichment do
   end
 
   #
+  # Salary details (jsonb accessor, no validation yet)
+  #
+  describe "salary_details" do
+    subject(:enrichment) { build(:course_enrichment, :with_salary_based_course, salary_details: nil) }
+
+    context "before 2027 recruitment cycle", travel: mid_cycle(2026) do
+      it { is_expected.not_to be_valid(:publish) }
+    end
+
+    context "after 2026 recruitment cycle", travel: mid_cycle(2027) do
+      it { is_expected.to be_valid(:publish) }
+    end
+  end
+
+  #
   # Existing specs we already had
   #
   describe "live edits to published enrichments" do


### PR DESCRIPTION
## Context

We have retired the `salary_details` json column / attribute on the CourseEnrichment from the 2027 cycle and beyond.
We are still validating this columns presence and word count however, so we need to disabled this validation for the later recruitment cycles.


## Changes proposed in this pull request

Skip validating `CourseEnrichment#salary_details` in the 2027 cycle and beyond

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
