### PR TITLE
School experience validation fix

### DIFF
--- a/app/wizards/school_experience_wizard/repositories/school_experience_repository.rb
+++ b/app/wizards/school_experience_wizard/repositories/school_experience_repository.rb
@@ -3,6 +3,26 @@
 class SchoolExperienceWizard
   module Repositories
     class SchoolExperienceRepository < DfE::Wizard::Repository::Model
+      SCHOOL_EXPERIENCE_ATTRIBUTES = %i[
+        school_experience_required
+        school_experience_required_content
+      ].freeze
+
+      def readable_attributes
+        SCHOOL_EXPERIENCE_ATTRIBUTES
+      end
+
+      def writable_attributes
+        SCHOOL_EXPERIENCE_ATTRIBUTES
+      end
+
+      def write_data(hash)
+        # The wizard steps validate these values before the repository writes
+        # them. Do not run unrelated Course validations here.
+        record.assign_attributes(hash.slice(*writable_attributes))
+        record.save!(validate: false)
+      end
+
       def transform_for_read(step_data)
         step_data[:experience_required] = step_data[:school_experience_required]
 

--- a/spec/system/publish/courses/school_experience/editing_school_experience_spec.rb
+++ b/spec/system/publish/courses/school_experience/editing_school_experience_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe "Editing school experience requirements", travel: mid_cycle, type
     and_i_see_that_experience_is_not_required
   end
 
+  scenario "provider must enter school experience details" do
+    given_i_am_authenticated_as_a_provider_user
+    and_i_have_a_salaried_course
+
+    when_i_visit_the_course_description_tab
+    when_i_click_to_change_school_experience
+    when_i_choose_that_experience_is_required
+    and_i_click_continue
+    and_i_click_update
+
+    then_i_am_on_the_experience_details_page
+    and_i_see_the_missing_details_error
+  end
+
   scenario "provider chooses yes then cancels on the details step without leaving orphaned data" do
     given_i_am_authenticated_as_a_provider_user
     and_i_have_a_salaried_course
@@ -126,6 +140,10 @@ private
 
   def and_i_click_update
     click_on "Update school experience"
+  end
+
+  def and_i_see_the_missing_details_error
+    expect(page).to have_content("Enter the school experience you are looking for")
   end
 
   def then_i_am_back_on_the_course_description_tab

--- a/spec/wizards/school_experience_wizard/repositories/school_experience_repository_spec.rb
+++ b/spec/wizards/school_experience_wizard/repositories/school_experience_repository_spec.rb
@@ -73,5 +73,16 @@ RSpec.describe SchoolExperienceWizard::Repositories::SchoolExperienceRepository 
       expect(course.reload.school_experience_required).to be(false)
       expect(course.school_experience_required_content).to be_nil
     end
+
+    it "persists school experience when an unrelated course field is invalid" do
+      course.update_column(:start_date, Time.zone.local(Find::CycleTimetable.next_year, 9, 1))
+      expect(course.valid?(:update)).to be(false)
+      expect(course.errors[:start_date]).to be_present
+
+      repository.write(experience_details: "Spend time in a school")
+
+      expect(course.reload.school_experience_required).to be(true)
+      expect(course.school_experience_required_content).to eq("Spend time in a school")
+    end
   end
 end


### PR DESCRIPTION
## Context

Saving school experience information validated the full Course record. Unrelated validation errors, such as an invalid start date introduced during rollover, could therefore prevent school experience updates from being saved.

## Changes proposed in this pull request

- Restrict the school experience repository to reading and writing only the relevant Course attributes.
- Rely on wizard-step validation instead of running all Course validations when saving.
- Add coverage for saving against a course with an unrelated invalid start date.
- Add system coverage confirming missing school experience details still display an error.

## Guidance to review

1. Open a 2027 salaried or apprenticeship course in Publish.
2. Edit its school experience information and confirm it saves.
3. Submit required school experience without details and confirm the validation error appears.
4. Run:
   `bundle exec rspec spec/wizards/school_experience_wizard/repositories/school_experience_repository_spec.rb spec/system/publish/courses/school_experience/editing_school_experience_spec.rb`

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.