### PR TITLE
Touch courses with no schools when their providers schools change

### DIFF
--- a/app/controllers/publish/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/publish/providers/schools/check_multiple_controller.rb
@@ -12,11 +12,17 @@ module Publish
         def update
           saved_schools = []
 
-          gias_schools.each do |gias_school|
-            ActiveRecord::Base.transaction do
-              saved_schools << create_provider_school_and_legacy_site(gias_school:)
+          # Each school would otherwise touch the provider and sweep its
+          # no-school courses on save. Suppress that and stamp them once.
+          TouchSuppression.suppress do
+            gias_schools.each do |gias_school|
+              ActiveRecord::Base.transaction do
+                saved_schools << create_provider_school_and_legacy_site(gias_school:)
+              end
             end
           end
+
+          ::ProviderSchools::TouchParents.call(provider:) if saved_schools.any?
 
           schools_added_message(saved_schools)
 

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -41,11 +41,17 @@ module Support
         def save
           saved_schools = []
 
-          gias_schools.each do |gias_school|
-            ActiveRecord::Base.transaction do
-              saved_schools << create_provider_school_and_legacy_site(gias_school:)
+          # Each school would otherwise touch the provider and sweep its
+          # no-school courses on save. Suppress that and stamp them once.
+          TouchSuppression.suppress do
+            gias_schools.each do |gias_school|
+              ActiveRecord::Base.transaction do
+                saved_schools << create_provider_school_and_legacy_site(gias_school:)
+              end
             end
           end
+
+          ::ProviderSchools::TouchParents.call(provider:) if saved_schools.any?
 
           schools_added_message(saved_schools)
         end

--- a/app/models/concerns/touch_no_school_courses.rb
+++ b/app/models/concerns/touch_no_school_courses.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# A course that is allowed to publish without schools is served by the API with
+# all of its provider's schools as locations, so writing a provider school
+# changes that course's payload. Bumping `changed_at` is what tells API
+# consumers to re-fetch it.
+#
+# Shaped like TouchProvider: the write itself is the trigger, so every writer
+# gets this for free. Bulk writers that would otherwise repeat the sweep once
+# per row wrap their loop in TouchSuppression.suppress and call
+# `.touch_no_school_courses_for(provider)` once at the end instead.
+#
+# after_commit rather than after_save/after_destroy: ProviderSchools::Removal
+# destroys inside `with_lock`, and sweeping there would hold that row lock for
+# the length of the sweep and take course row locks under it — the opposite
+# order to attaching a school, which takes the provider school's key-share lock
+# first and then touches the course. Running after the transaction commits
+# keeps the two paths from deadlocking, and only touches once the write is
+# durable.
+module TouchNoSchoolCourses
+  extend ActiveSupport::Concern
+
+  # The columns a fallback location is serialized from: `code` reads
+  # `site_code`, and everything else is read through `gias_school`. An update
+  # that leaves both alone cannot change what the API serves, and
+  # `after_commit on: :update` fires even for a save that issued no UPDATE at
+  # all, so gate the update case on them. Create and destroy always change the
+  # set of schools served.
+  PAYLOAD_COLUMNS = %w[gias_school_id site_code].freeze
+
+  # Two callbacks, two method names: ActiveSupport dedupes callbacks by filter,
+  # so registering the same symbol twice replaces the first registration rather
+  # than adding to it.
+  included do
+    after_commit :touch_no_school_courses, on: %i[create destroy]
+    after_commit :touch_no_school_courses_on_update, on: :update
+  end
+
+  class_methods do
+    def touch_no_school_courses_for(provider)
+      # `changed_at` is UNIQUE, so every row needs its own timestamp.
+      # update_columns skips the per-course provider touch — TouchProvider has
+      # already bumped the provider once.
+      Courses::PublishRules::SchoolPresenceExemption
+        .falling_back_to_provider_schools(provider)
+        .find_each { |course| course.update_columns(changed_at: Time.zone.now) }
+    end
+  end
+
+private
+
+  def touch_no_school_courses
+    return if TouchSuppression.suppressed?
+
+    self.class.touch_no_school_courses_for(provider)
+  end
+
+  def touch_no_school_courses_on_update
+    return unless saved_changes.keys.intersect?(PAYLOAD_COLUMNS)
+
+    touch_no_school_courses
+  end
+end

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -2,6 +2,8 @@
 
 class Provider::School < ApplicationRecord
   include TouchProvider
+  # Included after TouchProvider so the provider is touched first.
+  include TouchNoSchoolCourses
 
   self.table_name = "provider_school"
 

--- a/app/services/courses/publish_rules/school_presence_exemption.rb
+++ b/app/services/courses/publish_rules/school_presence_exemption.rb
@@ -10,9 +10,20 @@
 module Courses
   module PublishRules
     class SchoolPresenceExemption
+      EXEMPT_FUNDINGS = %w[salary apprenticeship].freeze
+
       def self.applies?(course)
         course.publish_without_schools_allowed? &&
-          (course.salary? || course.apprenticeship?)
+          EXEMPT_FUNDINGS.include?(course.funding)
+      end
+
+      # Courses whose API locations fall back to the provider's schools
+      # (LocationsController#remodelled_locations) — so a provider school
+      # write changes their payload.
+      def self.falling_back_to_provider_schools(provider)
+        provider.courses
+                .where(publish_without_schools_allowed: true, funding: EXEMPT_FUNDINGS)
+                .where.missing(:schools)
       end
     end
   end

--- a/app/services/provider_schools/touch_parents.rb
+++ b/app/services/provider_schools/touch_parents.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ProviderSchools
+  # Stamps what a single provider school write stamps through TouchProvider and
+  # TouchNoSchoolCourses. Bulk writers wrap their loop in
+  # TouchSuppression.suppress — so those callbacks don't repeat the work once
+  # per school and call this once at the end instead.
+  class TouchParents
+    def self.call(provider:)
+      provider.update_changed_at
+      Provider::School.touch_no_school_courses_for(provider)
+    end
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -305,6 +305,29 @@ FactoryBot.define do
       end
     end
 
+    trait :with_schools do
+      transient do
+        schools_count { 1 }
+      end
+
+      after(:build) do |course, evaluator|
+        evaluator.schools_count.times do
+          gias_school = build(:gias_school)
+          provider_school = build(:provider_school, provider: course.provider, gias_school:)
+
+          course.schools << build(:course_school, course:, gias_school:, provider_school:)
+        end
+      end
+    end
+
+    trait :with_2_schools do
+      with_schools
+
+      transient do
+        schools_count { 2 }
+      end
+    end
+
     trait :draft_enrichment do
       enrichments { [build(:course_enrichment, :initial_draft, course: nil)] }
     end

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -198,4 +198,61 @@ describe Provider::School do
       }.to raise_error(ActiveRecord::InvalidForeignKey)
     end
   end
+
+  # A course that publishes without schools serves its provider's schools as
+  # its API locations, so a provider school write changes its payload.
+  describe "touching courses that fall back to the provider's schools" do
+    let(:provider) { create(:provider) }
+    let!(:exempt_course) { create(:course, :with_salary, provider:, publish_without_schools_allowed: true) }
+
+    it "touches them when a school is added" do
+      expect { create(:provider_school, provider:) }.to(change { exempt_course.reload.changed_at })
+    end
+
+    it "touches them when a school is removed" do
+      provider_school = create(:provider_school, provider:)
+
+      expect { provider_school.destroy! }.to(change { exempt_course.reload.changed_at })
+    end
+
+    it "touches them when a school is updated" do
+      provider_school = create(:provider_school, provider:)
+
+      expect { provider_school.update!(site_code: "Z") }.to(change { exempt_course.reload.changed_at })
+    end
+
+    # `after_commit on: :update` fires even when Rails issued no UPDATE, and a
+    # bare touch only moves updated_at — neither changes what the API serves.
+    it "leaves them alone when a school is saved with no changes" do
+      provider_school = create(:provider_school, provider:)
+
+      expect { provider_school.save! }.not_to(change { exempt_course.reload.changed_at })
+    end
+
+    it "leaves them alone when only a school's timestamps move" do
+      provider_school = create(:provider_school, provider:)
+
+      expect { provider_school.touch }.not_to(change { exempt_course.reload.changed_at })
+    end
+
+    it "leaves courses with their own schools alone" do
+      school_course = create(:course, :with_2_schools, provider:)
+
+      expect { create(:provider_school, provider:) }.not_to(change { school_course.reload.changed_at })
+    end
+
+    it "leaves another provider's courses alone" do
+      other_course = create(:course, :with_salary, publish_without_schools_allowed: true)
+
+      expect { create(:provider_school, provider:) }.not_to(change { other_course.reload.changed_at })
+    end
+
+    # Bulk writers such as rollover suppress the per-row touch and stamp the
+    # parents once at the end instead.
+    it "does not touch them while touches are suppressed" do
+      expect {
+        TouchSuppression.suppress { create(:provider_school, provider:) }
+      }.not_to(change { exempt_course.reload.changed_at })
+    end
+  end
 end

--- a/spec/requests/publish/providers/schools/check_multiple_spec.rb
+++ b/spec/requests/publish/providers/schools/check_multiple_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Publish provider multiple schools check", service: :publish do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user, :with_provider) }
+  let(:provider) { user.providers.first }
+  let(:recruitment_cycle) { provider.recruitment_cycle }
+  let(:gias_schools) do
+    [
+      create(:gias_school, name: "St Joseph's Catholic Primary School", urn: "112992"),
+      create(:gias_school, name: "Bramble Hill Academy", urn: "112993"),
+    ]
+  end
+
+  before { login_user(user) }
+
+  def stash_urns(urns)
+    URNForm.new(provider, params: { values: urns }).stash
+  end
+
+  def add_schools(urns = gias_schools.map(&:urn))
+    stash_urns(urns)
+
+    put publish_provider_recruitment_cycle_schools_multiple_check_path(provider.provider_code, recruitment_cycle.year)
+  end
+
+  describe "PUT /publish/organisations/:provider_code/:recruitment_cycle_year/schools/multiple/check" do
+    let!(:exempt_course) { create(:course, :with_salary, provider:, publish_without_schools_allowed: true) }
+
+    it "adds the schools to the provider" do
+      expect { add_schools }.to change { provider.schools.count }.by(2)
+
+      expect(response).to redirect_to(publish_provider_recruitment_cycle_schools_path(provider.provider_code, recruitment_cycle.year))
+      expect(provider.schools.map(&:gias_school)).to match_array(gias_schools)
+    end
+
+    # The API serves every one of the provider's schools as the locations of a
+    # course that is allowed to publish without schools, so adding schools
+    # changes that course's payload. Bumping changed_at is what tells API
+    # consumers to re-fetch it.
+    it "touches courses that are publishable without schools" do
+      expect { add_schools }.to(change { exempt_course.reload.changed_at })
+    end
+
+    it "touches every course that is publishable without schools" do
+      second_exempt_course = create(:course, :with_salary, provider:, publish_without_schools_allowed: true)
+
+      expect { add_schools }.to(change { [exempt_course.reload.changed_at, second_exempt_course.reload.changed_at] })
+
+      expect(exempt_course.changed_at).to be > exempt_course.updated_at
+      expect(second_exempt_course.changed_at).to be > second_exempt_course.updated_at
+    end
+
+    it "sweeps the courses once, not once per school added" do
+      allow(Provider::School).to receive(:touch_no_school_courses_for).and_call_original
+
+      add_schools
+
+      expect(Provider::School).to have_received(:touch_no_school_courses_for).once
+    end
+
+    it "does not touch courses that have their own schools" do
+      school_course = create(:course, :with_2_schools, provider:)
+
+      expect { add_schools }.not_to(change { school_course.reload.changed_at })
+    end
+
+    it "does not touch another provider's courses" do
+      other_exempt_course = create(:course, :with_salary, publish_without_schools_allowed: true)
+
+      expect { add_schools }.not_to(change { other_exempt_course.reload.changed_at })
+    end
+
+    it "does not touch anything when no school is added" do
+      expect { add_schools(%w[999999]) }.not_to(change { exempt_course.reload.changed_at })
+
+      expect(provider.schools.count).to be_zero
+    end
+  end
+end

--- a/spec/requests/publish/providers/schools/checks_spec.rb
+++ b/spec/requests/publish/providers/schools/checks_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Publish provider schools check", service: :publish do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user, :with_provider) }
+  let(:provider) { user.providers.first }
+  let(:recruitment_cycle) { provider.recruitment_cycle }
+  let(:gias_school) { create(:gias_school, name: "St Joseph's Catholic Primary School", urn: "112992") }
+
+  before { login_user(user) }
+
+  def add_school
+    put publish_provider_recruitment_cycle_schools_check_path(provider.provider_code, recruitment_cycle.year),
+        params: { site: { school_id: gias_school.id } }
+  end
+
+  describe "PUT /publish/organisations/:provider_code/:recruitment_cycle_year/schools/check" do
+    let!(:exempt_course) { create(:course, :with_salary, provider:, publish_without_schools_allowed: true) }
+
+    it "adds the school to the provider" do
+      expect { add_school }.to change { provider.schools.count }.by(1)
+
+      expect(response).to redirect_to(publish_provider_recruitment_cycle_schools_path(provider.provider_code, recruitment_cycle.year))
+      expect(provider.schools.last.gias_school).to eq(gias_school)
+    end
+
+    # The API serves every one of the provider's schools as the locations of a
+    # course that is allowed to publish without schools, so adding a school
+    # changes that course's payload. Bumping changed_at is what tells API
+    # consumers to re-fetch it.
+    it "touches courses that are publishable without schools" do
+      expect { add_school }.to(change { exempt_course.reload.changed_at })
+    end
+
+    it "does not touch courses that have their own schools" do
+      school_course = create(:course, :with_2_schools, provider:)
+
+      expect { add_school }.not_to(change { school_course.reload.changed_at })
+    end
+
+    it "does not touch another provider's courses" do
+      other_exempt_course = create(:course, :with_salary, publish_without_schools_allowed: true)
+
+      expect { add_school }.not_to(change { other_exempt_course.reload.changed_at })
+    end
+
+    it "touches every course that is publishable without schools" do
+      second_exempt_course = create(:course, :with_salary, provider:, publish_without_schools_allowed: true)
+
+      expect { add_school }.to(change { [exempt_course.reload.changed_at, second_exempt_course.reload.changed_at] })
+
+      expect(exempt_course.changed_at).to be > exempt_course.updated_at
+      expect(second_exempt_course.changed_at).to be > second_exempt_course.updated_at
+    end
+  end
+end

--- a/spec/requests/publish/providers/schools_spec.rb
+++ b/spec/requests/publish/providers/schools_spec.rb
@@ -183,4 +183,49 @@ RSpec.describe "Publish provider school show page", service: :publish do
       expect(response.body).to include("Catholic Primary School")
     end
   end
+
+  describe "DELETE /publish/organisations/:provider_code/:recruitment_cycle_year/schools/:uuid" do
+    let(:provider) { create(:provider) }
+    let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: SecureRandom.uuid) }
+    let!(:provider_school) do
+      create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
+    end
+    let!(:exempt_course) { create(:course, :with_salary, provider:, publish_without_schools_allowed: true) }
+
+    before { login_provider_user(provider) }
+
+    def remove_school
+      delete publish_provider_recruitment_cycle_school_path(provider.provider_code, provider.recruitment_cycle.year, provider_school.uuid)
+    end
+
+    it "removes the school" do
+      expect { remove_school }.to change { provider.schools.count }.by(-1)
+
+      expect(response).to redirect_to(publish_provider_recruitment_cycle_schools_path(provider.provider_code, provider.recruitment_cycle.year))
+    end
+
+    # A course that is allowed to publish without schools is served by the API
+    # with all of its provider's schools as locations, so removing one changes
+    # that course's payload.
+    it "touches every course that is publishable without schools" do
+      second_exempt_course = create(:course, :with_salary, provider:, publish_without_schools_allowed: true)
+
+      expect { remove_school }.to(change { [exempt_course.reload.changed_at, second_exempt_course.reload.changed_at] })
+    end
+
+    it "does not touch another provider's courses" do
+      other_exempt_course = create(:course, :with_salary, publish_without_schools_allowed: true)
+
+      expect { remove_school }.not_to(change { other_exempt_course.reload.changed_at })
+    end
+
+    it "does not touch courses when the school cannot be removed" do
+      course = create(:course, provider:)
+      create(:course_school, course:, gias_school:, provider_school:)
+
+      expect { remove_school }.not_to(change { exempt_course.reload.changed_at })
+
+      expect(provider.schools.count).to eq(1)
+    end
+  end
 end

--- a/spec/requests/support/providers/schools/check_multiple_spec.rb
+++ b/spec/requests/support/providers/schools/check_multiple_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Support provider multiple school checks" do
+  include DfESignInUserHelper
+
+  let(:provider) { create(:provider) }
+  let(:recruitment_cycle) { provider.recruitment_cycle }
+  let(:gias_schools) do
+    [
+      create(:gias_school, urn: "112992"),
+      create(:gias_school, urn: "112993"),
+    ]
+  end
+  let(:admin) { create(:user, :admin) }
+
+  before do
+    host! URI(Settings.base_url).host
+    login_user(admin)
+  end
+
+  def add_schools(urns = gias_schools.map(&:urn))
+    URNForm.new(provider, params: { values: urns }).stash
+
+    put support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle.year, provider)
+  end
+
+  describe "PUT /support/:recruitment_cycle_year/providers/:provider_id/schools/multiple/check" do
+    let!(:exempt_course) { create(:course, :with_salary, provider:, publish_without_schools_allowed: true) }
+
+    it "adds the schools to the provider" do
+      expect { add_schools }.to change { provider.schools.count }.by(2)
+
+      expect(response).to redirect_to(support_recruitment_cycle_provider_schools_path(recruitment_cycle.year, provider))
+      expect(provider.schools.map(&:gias_school)).to match_array(gias_schools)
+    end
+
+    # The API serves every one of the provider's schools as the locations of a
+    # course that is allowed to publish without schools, so adding schools
+    # changes that course's payload. Bumping changed_at is what tells API
+    # consumers to re-fetch it.
+    it "touches every course that is publishable without schools" do
+      second_exempt_course = create(:course, :with_salary, provider:, publish_without_schools_allowed: true)
+
+      expect { add_schools }.to(change { [exempt_course.reload.changed_at, second_exempt_course.reload.changed_at] })
+    end
+
+    it "sweeps the courses once, not once per school added" do
+      allow(Provider::School).to receive(:touch_no_school_courses_for).and_call_original
+
+      add_schools
+
+      expect(Provider::School).to have_received(:touch_no_school_courses_for).once
+    end
+
+    it "does not touch courses that have their own schools" do
+      school_course = create(:course, :with_2_schools, provider:)
+
+      expect { add_schools }.not_to(change { school_course.reload.changed_at })
+    end
+
+    it "does not touch another provider's courses" do
+      other_exempt_course = create(:course, :with_salary, publish_without_schools_allowed: true)
+
+      expect { add_schools }.not_to(change { other_exempt_course.reload.changed_at })
+    end
+
+    it "does not touch anything when no school is added" do
+      expect { add_schools(%w[999999]) }.not_to(change { exempt_course.reload.changed_at })
+
+      expect(provider.schools.count).to be_zero
+    end
+  end
+end

--- a/spec/requests/support/providers/schools/checks_spec.rb
+++ b/spec/requests/support/providers/schools/checks_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe "Support provider school checks" do
   include DfESignInUserHelper
 
-  let(:recruitment_cycle) { create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year) }
-  let(:provider) { create(:provider, recruitment_cycle:) }
+  let(:provider) { create(:provider) }
+  let(:recruitment_cycle) { provider.recruitment_cycle }
   let(:gias_school) { create(:gias_school) }
   let(:admin) { create(:user, :admin) }
 

--- a/spec/requests/support/providers/schools/checks_spec.rb
+++ b/spec/requests/support/providers/schools/checks_spec.rb
@@ -15,6 +15,50 @@ RSpec.describe "Support provider school checks" do
     login_user(admin)
   end
 
+  def add_school
+    put support_recruitment_cycle_provider_schools_check_path(
+      recruitment_cycle.year,
+      provider,
+      school_id: gias_school.id,
+    )
+  end
+
+  describe "touching courses that are publishable without schools" do
+    let!(:exempt_course) { create(:course, :with_salary, provider:, publish_without_schools_allowed: true) }
+
+    # The API serves every one of the provider's schools as the locations of a
+    # course that is allowed to publish without schools, so adding a school
+    # changes that course's payload. Bumping changed_at is what tells API
+    # consumers to re-fetch it.
+    it "touches every course that is publishable without schools" do
+      second_exempt_course = create(:course, :with_salary, provider:, publish_without_schools_allowed: true)
+
+      expect { add_school }.to(change { [exempt_course.reload.changed_at, second_exempt_course.reload.changed_at] })
+
+      expect(provider.schools.count).to eq(1)
+    end
+
+    it "does not touch courses that have their own schools" do
+      school_course = create(:course, :with_2_schools, provider:)
+
+      expect { add_school }.not_to(change { school_course.reload.changed_at })
+    end
+
+    it "does not touch another provider's courses" do
+      other_exempt_course = create(:course, :with_salary, publish_without_schools_allowed: true)
+
+      expect { add_school }.not_to(change { other_exempt_course.reload.changed_at })
+    end
+
+    it "does not touch courses when the school is not added" do
+      allow(ProviderSchools::Creator).to receive(:call).and_raise(StandardError, "provider school failed")
+
+      expect {
+        expect { add_school }.to raise_error(StandardError, "provider school failed")
+      }.not_to(change { exempt_course.reload.changed_at })
+    end
+  end
+
   it "rolls back the legacy Site when Provider::School creation fails" do
     allow(ProviderSchools::Creator).to receive(:call).and_raise(StandardError, "provider school failed")
 

--- a/spec/requests/support/providers/schools_spec.rb
+++ b/spec/requests/support/providers/schools_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Support provider schools" do
+  include DfESignInUserHelper
+
+  let(:provider) { create(:provider) }
+  let(:recruitment_cycle) { provider.recruitment_cycle }
+  let(:gias_school) { create(:gias_school) }
+  let(:admin) { create(:user, :admin) }
+
+  before do
+    host! URI(Settings.base_url).host
+    login_user(admin)
+  end
+
+  describe "DELETE /support/:recruitment_cycle_year/providers/:provider_id/schools/:uuid" do
+    let!(:site) { create(:site, provider:, urn: gias_school.urn, code: "A", uuid: SecureRandom.uuid) }
+    let!(:provider_school) do
+      create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)
+    end
+    let!(:exempt_course) { create(:course, :with_salary, provider:, publish_without_schools_allowed: true) }
+
+    def remove_school
+      delete support_recruitment_cycle_provider_school_path(recruitment_cycle.year, provider, provider_school.uuid)
+    end
+
+    it "removes the school" do
+      expect { remove_school }.to change { provider.schools.count }.by(-1)
+
+      expect(response).to redirect_to(support_recruitment_cycle_provider_schools_path(recruitment_cycle.year, provider))
+    end
+
+    # A course that is allowed to publish without schools is served by the API
+    # with all of its provider's schools as locations, so removing one changes
+    # that course's payload.
+    it "touches every course that is publishable without schools" do
+      second_exempt_course = create(:course, :with_salary, provider:, publish_without_schools_allowed: true)
+
+      expect { remove_school }.to(change { [exempt_course.reload.changed_at, second_exempt_course.reload.changed_at] })
+    end
+
+    it "does not touch another provider's courses" do
+      other_exempt_course = create(:course, :with_salary, publish_without_schools_allowed: true)
+
+      expect { remove_school }.not_to(change { other_exempt_course.reload.changed_at })
+    end
+
+    it "does not touch courses when the school cannot be removed" do
+      course = create(:course, provider:)
+      create(:course_school, course:, gias_school:, provider_school:)
+
+      expect { remove_school }.not_to(change { exempt_course.reload.changed_at })
+
+      expect(provider.schools.count).to eq(1)
+    end
+  end
+end

--- a/spec/services/courses/publish_rules/school_presence_exemption_spec.rb
+++ b/spec/services/courses/publish_rules/school_presence_exemption_spec.rb
@@ -28,4 +28,39 @@ describe Courses::PublishRules::SchoolPresenceExemption do
       expect(described_class.applies?(course_with(funding: :apprenticeship, allowed: false))).to be(false)
     end
   end
+
+  describe ".falling_back_to_provider_schools" do
+    let(:provider) { create(:provider) }
+
+    it "returns exempt courses with no schools of their own" do
+      salaried = create(:course, :with_salary, provider:, publish_without_schools_allowed: true)
+      apprenticeship = create(:course, :with_apprenticeship, provider:, publish_without_schools_allowed: true)
+
+      expect(described_class.falling_back_to_provider_schools(provider)).to contain_exactly(salaried, apprenticeship)
+    end
+
+    it "excludes an exempt course that has its own schools" do
+      create(:course, :with_salary, :with_2_schools, provider:, publish_without_schools_allowed: true)
+
+      expect(described_class.falling_back_to_provider_schools(provider)).to be_empty
+    end
+
+    it "excludes a course support has not allowed to publish without schools" do
+      create(:course, :with_salary, provider:, publish_without_schools_allowed: false)
+
+      expect(described_class.falling_back_to_provider_schools(provider)).to be_empty
+    end
+
+    it "excludes a fee-paying course, even when allowed" do
+      create(:course, :fee, provider:, publish_without_schools_allowed: true)
+
+      expect(described_class.falling_back_to_provider_schools(provider)).to be_empty
+    end
+
+    it "excludes another provider's courses" do
+      create(:course, :with_salary, publish_without_schools_allowed: true)
+
+      expect(described_class.falling_back_to_provider_schools(provider)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Context

Since we have allowed some courses to be published without attaching schools, we have decided to inject all the providers schools into the API response for those schools locations.

This creates a dependency between those courses and the providers schools.

When the providers schools change we need to touch the no-schools courses becuase their API payload changes in tandem.

## Changes proposed in this pull request

We need to touch the no-schools courses when a providers schools change. So that means when one or more is added, or when one is deleted.

When one or more is added, we suppress the model callback which would fire N times, for multiple school additions. We then fire the touch once when the schools are added.

### Avoiding over reach

If  Provider::School is saved without any real changes (call `#save`, the updated_at is changed) then we want to avoid the cascade of touches. So scope the `update` callback to only cases where some properties of value have changed.




## Guidance to review

- Add `TouchNoSchoolCourses` to add callbacks on `Provider::School`
- ADd `TouchParents` to touch the provider and all the providers no-school courses in one go

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
