### PR TITLE
School Data - Mop up missing school data model switch in publish

### DIFF
--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -63,6 +63,6 @@ private
   end
 
   def school_present?
-    provider.sites.any?
+    provider.schools.any?
   end
 end

--- a/app/controllers/publish/course_wizards_controller.rb
+++ b/app/controllers/publish/course_wizards_controller.rb
@@ -16,7 +16,7 @@ module Publish
     end
 
     def new
-      return render_schools_messages unless provider.sites.any?
+      return render_schools_messages unless provider.schools.any?
 
       redirect_to publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: params[:provider_code],

--- a/spec/components/add_course_button_spec.rb
+++ b/spec/components/add_course_button_spec.rb
@@ -13,7 +13,7 @@ describe AddCourseButton do
   end
 
   context "when the wizard add course flow is active" do
-    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], sites: [build(:site)], recruitment_cycle:) }
+    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], schools: [build(:provider_school)], recruitment_cycle:) }
 
     it "renders a course wizard link" do
       component = described_class.new(provider:)
@@ -33,7 +33,7 @@ describe AddCourseButton do
   end
 
   context "when the wizard add course flow is not active" do
-    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], sites: [build(:site)], recruitment_cycle:) }
+    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], schools: [build(:provider_school)], recruitment_cycle:) }
 
     it "renders a course link" do
       component = described_class.new(provider:)
@@ -129,7 +129,7 @@ describe AddCourseButton do
   end
 
   context "when the provider has only added a site" do
-    let(:provider) { build(:provider, sites: [create(:site)], recruitment_cycle:) }
+    let(:provider) { build(:provider, schools: [create(:provider_school)], recruitment_cycle:) }
 
     it "renders an accredited provider link" do
       expect(rendered_content).to have_link(
@@ -153,7 +153,7 @@ describe AddCourseButton do
   end
 
   context "when the provider has added a site and a study site" do
-    let(:provider) { build(:provider, study_sites: [build(:site, :study_site)], sites: [build(:site)], recruitment_cycle:) }
+    let(:provider) { build(:provider, study_sites: [build(:site, :study_site)], schools: [build(:provider_school)], recruitment_cycle:) }
 
     it "renders a study sites link" do
       expect(rendered_content).to have_no_link(
@@ -187,7 +187,7 @@ describe AddCourseButton do
   end
 
   context "when the provider has added all required organisation details" do
-    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], sites: [build(:site)], recruitment_cycle:) }
+    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], schools: [build(:provider_school)], recruitment_cycle:) }
 
     it "renders a study sites link" do
       expect(rendered_content).to have_no_link(

--- a/spec/system/publish/add_course_button_spec.rb
+++ b/spec/system/publish/add_course_button_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Add course button" do
       user: create(
         :user,
         providers: [
-          create(:provider, :accredited_provider, sites: [build(:site)], courses: [build(:course)]),
+          create(:provider, :accredited_provider, schools: [build(:provider_school)], courses: [build(:course)]),
         ],
       ),
     )
@@ -43,7 +43,7 @@ RSpec.describe "Add course button" do
       user: create(
         :user,
         providers: [
-          create(:provider, :accredited_provider, sites: [build(:site)], study_sites: [build(:site, :study_site)], courses: [build(:course)]),
+          create(:provider, :accredited_provider, schools: [build(:provider_school)], study_sites: [build(:site, :study_site)], courses: [build(:course)]),
         ],
       ),
     )

--- a/spec/system/publish/courses/add_course_wizard/age_range_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/age_range_spec.rb
@@ -88,7 +88,7 @@ private
     @user = create(
       :user,
       providers: [
-        create(:provider, :accredited_provider, sites: [build(:site)]),
+        create(:provider, :accredited_provider, schools: [build(:provider_school)]),
       ],
     )
 

--- a/spec/system/publish/courses/add_course_wizard/level_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/level_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Add course wizard level step", type: :system do
   end
 
   scenario "provider after the school remodel cycle cannot start with a site school" do
-    given_i_am_authenticated_as_a_provider_user_without_a_site_school
+    given_i_am_authenticated_as_a_provider_user_without_a_provider_school
     when_i_visit_the_wizard_level_page
     then_i_see_the_no_school_error
   end
@@ -42,17 +42,17 @@ private
     @user = create(
       :user,
       providers: [
-        create(:provider, :accredited_provider, sites: [build(:site)]),
+        create(:provider, :accredited_provider, schools: [build(:provider_school)]),
       ],
     )
 
     given_i_am_authenticated(user: @user)
   end
 
-  def given_i_am_authenticated_as_a_provider_user_without_a_site_school
+  def given_i_am_authenticated_as_a_provider_user_without_a_provider_school
     recruitment_cycle = find_or_create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)
     provider = create(:provider, :accredited_provider, recruitment_cycle:)
-    create(:provider_school, provider:)
+    create(:site, provider:)
 
     @user = create(:user, providers: [provider])
 

--- a/spec/system/publish/courses/add_course_wizard/subjects_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/subjects_spec.rb
@@ -136,7 +136,7 @@ private
     @user = create(
       :user,
       providers: [
-        create(:provider, :accredited_provider, sites: [build(:site)]),
+        create(:provider, :accredited_provider, schools: [build(:provider_school)]),
       ],
     )
 


### PR DESCRIPTION
## Context

Some things were missed during the school data work i publish, this is to mop things up 

## Changes proposed in this pull request

- Checked where the old data model is still used in publish, this is to mop up parts that were already worked on and sites are still the used dat amodel

## Guidance to review

- Check ze code! Ain't much there anyways
 
## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
