### PR TITLE
Course list keep accredited provider headings

### DIFF
--- a/app/components/publish/courses/list_component.html.erb
+++ b/app/components/publish/courses/list_component.html.erb
@@ -12,11 +12,14 @@
         <%= t("publish.courses.index.course_count", count: group.courses.size) %>
       </p>
 
-      <%= render Publish::Courses::TableComponent.new(
-            courses: group.courses,
-            provider:,
-            course_information_fields: course_list.visible_course_information_fields,
-          ) %>
+      <%# A group the filters emptied keeps its heading and count, but has no table to show. %>
+      <% if group.courses.any? %>
+        <%= render Publish::Courses::TableComponent.new(
+              courses: group.courses,
+              provider:,
+              course_information_fields: course_list.visible_course_information_fields,
+            ) %>
+      <% end %>
     </section>
   <% end %>
 <% else %>

--- a/app/services/publish/course_list.rb
+++ b/app/services/publish/course_list.rb
@@ -44,7 +44,11 @@ module Publish
       start_date: ->(course) { course.start_date.presence&.to_date&.beginning_of_month },
     }.freeze
 
-    delegate :any?, to: :groups
+    # Asks whether any course survived the filters rather than whether any group
+    # did, so a group that keeps its place with nothing in it is not a list.
+    def any?
+      groups.any? { |group| group.courses.any? }
+    end
 
     def initialize(provider:, params: {})
       @provider = provider

--- a/app/services/publish/course_list.rb
+++ b/app/services/publish/course_list.rb
@@ -2,10 +2,12 @@
 
 module Publish
   # Presentation facade over Publish::Courses::Query for the publish course list
-  # page. Chunks the pre-ordered query rows into accredited-provider groups.
+  # page. Splits the pre-ordered query rows into accredited-provider groups.
   #
-  # Filters are passed straight through to the query, so a group whose courses
-  # are all filtered out simply does not appear.
+  # The groups are those of the whole (unfiltered) list, so a group whose courses
+  # are all filtered out keeps its place and reports no courses rather than
+  # disappearing — a heading that vanishes mid-filter reads as though the
+  # accredited provider itself has gone.
   class CourseList
     include Enumerable
 
@@ -76,9 +78,9 @@ module Publish
     end
 
     def groups
-      @groups ||= courses
-        .chunk_while { |a, b| a[:group_name] == b[:group_name] }
-        .map { |chunk| Group.new(accredited_provider_name: chunk.first[:group_name], courses: chunk.map(&:decorate)) }
+      @groups ||= group_names.map do |name|
+        Group.new(accredited_provider_name: name, courses: filtered_courses_by_group.fetch(name, []).map(&:decorate))
+      end
     end
 
     def each(&)
@@ -88,6 +90,16 @@ module Publish
   private
 
     attr_reader :provider, :params
+
+    # Every group the whole list has, in the order the query already put the rows
+    # in: self-accredited first, then by accredited provider name.
+    def group_names
+      @group_names ||= unfiltered_courses.map { |course| course[:group_name] }.uniq
+    end
+
+    def filtered_courses_by_group
+      @filtered_courses_by_group ||= courses.group_by { |course| course[:group_name] }
+    end
 
     def courses
       @courses ||= Publish::Courses::Query.call(provider:, params:).to_a

--- a/spec/components/publish/courses/list_component_spec.rb
+++ b/spec/components/publish/courses/list_component_spec.rb
@@ -4,8 +4,10 @@ require "rails_helper"
 
 RSpec.describe Publish::Courses::ListComponent, type: :component do
   subject(:render_component) do
-    render_inline(described_class.new(course_list: Publish::CourseList.new(provider: provider.reload), provider:))
+    render_inline(described_class.new(course_list: Publish::CourseList.new(provider: provider.reload, params:), provider:))
   end
+
+  let(:params) { {} }
 
   context "when the provider has self-accredited and ratified courses" do
     let(:provider) { create(:provider, :accredited_provider, provider_name: "Mid Provider") }
@@ -31,6 +33,35 @@ RSpec.describe Publish::Courses::ListComponent, type: :component do
       first_section = page.all("section.app-table--courses__section").first
       expect(first_section).to have_no_css("h2")
       expect(first_section).to have_css("table.app-table--courses")
+    end
+  end
+
+  context "when the filters leave a group with no courses" do
+    let(:provider) { create(:provider, :accredited_provider, provider_name: "Mid Provider") }
+    let(:params) { { level: %w[secondary] } }
+
+    before do
+      create(:course, :published_postgraduate, :primary, provider:,
+                                                         accrediting_provider: create(:accredited_provider, provider_name: "Aardvark University"))
+      create(:course, :published_postgraduate, :secondary, provider:,
+                                                           accrediting_provider: create(:accredited_provider, provider_name: "Zoo College"))
+    end
+
+    it "keeps the heading and reports no courses, without a table" do
+      render_component
+
+      emptied = page.all("section.app-table--courses__section").first
+      expect(emptied.find("h2").text.squish).to eq("Accredited provider Aardvark University")
+      expect(emptied.find(".app-table--courses__count").text.squish).to eq("0 courses")
+      expect(emptied).to have_no_css("table.app-table--courses")
+    end
+
+    it "still renders the groups that do have courses" do
+      render_component
+
+      matched = page.all("section.app-table--courses__section").last
+      expect(matched.find(".app-table--courses__count").text.squish).to eq("1 course")
+      expect(matched).to have_css("table.app-table--courses")
     end
   end
 

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -36,13 +36,26 @@ RSpec.describe Publish::CourseList do
       expect(filtered.groups.flat_map(&:courses).map(&:name)).to eq(["Secondary course"])
     end
 
-    it "drops a group entirely when none of its courses match" do
+    # A heading that vanishes mid-filter reads as though the accredited provider
+    # has gone away, so the group stays in place and reports nothing to show.
+    it "keeps a group, in its place, when none of its courses match" do
       other = create(:accredited_provider, provider_name: "Other University")
       create(:course, :primary, provider:, accrediting_provider: other, name: "Ratified primary")
 
       filtered = described_class.new(provider: provider.reload, params: { level: %w[secondary] })
 
-      expect(filtered.groups.map(&:heading)).to eq([nil])
+      expect(filtered.groups.map(&:heading)).to eq([nil, "Other University"])
+      expect(filtered.groups.map { |group| group.courses.size }).to eq([1, 0])
+    end
+
+    it "keeps the self-accredited group when only a ratified course matches" do
+      other = create(:accredited_provider, provider_name: "Other University")
+      create(:course, :primary, provider:, accrediting_provider: other, study_mode: :part_time, name: "Ratified part time")
+
+      filtered = described_class.new(provider: provider.reload, params: { study_mode: %w[part_time] })
+
+      expect(filtered.groups.map(&:heading)).to eq([nil, "Other University"])
+      expect(filtered.groups.map { |group| group.courses.size }).to eq([0, 1])
     end
 
     it "reports whether anything matched" do

--- a/spec/system/publish/filtering_courses_spec.rb
+++ b/spec/system/publish/filtering_courses_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe "Filtering the course list" do
     and_the_course_counts_read("0 courses", "1 course")
   end
 
+  scenario "no accredited provider has courses matching my filters" do
+    given_my_courses_are_ratified_by_two_accredited_providers
+    when_i_visit_the_courses_page
+    when_i_filter_by("Further education")
+    then_i_am_told_no_courses_were_found
+    and_i_see_no_accredited_provider_headings
+  end
+
   scenario "I only see the start dates my courses use" do
     given_my_provider_has_courses_starting_in_different_months
     when_i_visit_the_courses_page
@@ -226,6 +234,10 @@ RSpec.describe "Filtering the course list" do
     end
 
     expect(headings).to eq(names)
+  end
+
+  def and_i_see_no_accredited_provider_headings
+    expect(publish_provider_courses_index_page).to have_no_courses
   end
 
   # Each chip carries a visually hidden "Remove filter" for screen readers.

--- a/spec/system/publish/filtering_courses_spec.rb
+++ b/spec/system/publish/filtering_courses_spec.rb
@@ -72,6 +72,17 @@ RSpec.describe "Filtering the course list" do
     then_i_am_told_no_courses_were_found
   end
 
+  # An accredited provider whose heading disappeared mid-filter read as though it
+  # had gone away, so the heading stays and reports no courses.
+  scenario "an accredited provider has no courses matching my filters" do
+    given_my_courses_are_ratified_by_two_accredited_providers
+    when_i_visit_the_courses_page
+    when_i_filter_by("QTS only")
+    then_i_see_only("Chichester QTS course")
+    and_i_see_the_accredited_provider_headings("University of Brighton", "University of Chichester")
+    and_the_course_counts_read("0 courses", "1 course")
+  end
+
   scenario "I only see the start dates my courses use" do
     given_my_provider_has_courses_starting_in_different_months
     when_i_visit_the_courses_page
@@ -123,6 +134,16 @@ RSpec.describe "Filtering the course list" do
     create(:course, :primary, :fee, provider:, accrediting_provider: nil, name: "Primary fee course")
     create(:course, :secondary, :fee, provider:, accrediting_provider: nil, name: "Secondary fee course")
     create(:course, :primary, :salary, provider:, accrediting_provider: nil, name: "Primary salary course")
+  end
+
+  # Brighton ratifies only QTS with PGCE courses, Chichester only QTS ones, so
+  # filtering by qualification empties one group and leaves the other.
+  def given_my_courses_are_ratified_by_two_accredited_providers
+    brighton = create(:accredited_provider, provider_name: "University of Brighton")
+    chichester = create(:accredited_provider, provider_name: "University of Chichester")
+
+    create(:course, :primary, :resulting_in_pgce_with_qts, provider:, accrediting_provider: brighton, name: "Brighton PGCE course")
+    create(:course, :secondary, :resulting_in_qts, provider:, accrediting_provider: chichester, name: "Chichester QTS course")
   end
 
   def given_my_provider_has_courses_starting_in_different_months
@@ -192,6 +213,19 @@ RSpec.describe "Filtering the course list" do
 
   def and_the_course_count_reads(text)
     expect(publish_provider_courses_index_page.course_counts.map(&:text)).to eq([text])
+  end
+
+  # One count per group, in the order the groups are listed.
+  def and_the_course_counts_read(*texts)
+    expect(publish_provider_courses_index_page.course_counts.map { |count| count.text.squish }).to eq(texts)
+  end
+
+  def and_i_see_the_accredited_provider_headings(*names)
+    headings = publish_provider_courses_index_page.courses.map do |section|
+      section.subheading.text.squish.delete_prefix("Accredited provider ")
+    end
+
+    expect(headings).to eq(names)
   end
 
   # Each chip carries a visually hidden "Remove filter" for screen readers.


### PR DESCRIPTION
# Keep accredited provider headings when filters empty a group

Trello: [1691 — add filters and count](https://trello.com/c/Aot8AB8q/1691-course-list-add-filters-and-count-for-number-of-courses-displayed) · [1756 — logic for when to display filters](https://trello.com/c/69eknLzg/1756-course-list-add-logic-for-when-to-display-filters)

## Why

`Publish::CourseList#groups` chunked the **filtered** query rows, so a group whose courses were all filtered out simply disappeared. For a provider with several accredited providers this is disorienting: the heading vanishes and the list jumps to the next AP, so the provider can't tell whether that AP has no matching courses or has stopped existing.

The group now keeps its place and reads **0 courses**.

## Try it

```
git checkout td/course-list-keep-accredited-provider-headings
bin/dev            # serves on http://localhost:3001
```

All URLs below are verified against the sanitised 2026 data in the dev database. **3F4** is the provider from the card — 100 courses across four accredited providers, listed 13 / 20 / 17 / 50 with no filters applied. Counts below follow that same order.

| # | Scenario | URL | What you should see |
| --- | --- | --- | --- |
| 1 | Baseline, no filters | `/publish/organisations/3F4/2026/courses` | Four AP groups — 13 / 20 / 17 / 50 |
| 2 | **The bug on the card** — filter by QTS only | `/publish/organisations/3F4/2026/courses?qualification[]=qts` | **0** / 15 / **0** / 29 — the first and third headings stay in place at 0 courses |
| 3 | The designer's mock, exactly | `/publish/organisations/3F4/2026/courses?status[]=rolled_over` | **0** / 20 / **0** / 3 |
| 4 | Emptied group between two populated ones | `/publish/organisations/3F4/2026/courses?status[]=withdrawn` | 3 / **0** / **0** / 1 — order unchanged |
| 5 | Two filters combined, one group left | `/publish/organisations/3F4/2026/courses?qualification[]=qts&study_mode[]=part_time` | **0** / **0** / **0** / 1 |
| 6 | Nothing matches anywhere | `/publish/organisations/3F4/2026/courses?level[]=further_education` | A single "No courses found" — no wall of zeros |
| 7 | The provider's own (headingless) group empties | `/publish/organisations/P83/2026/courses?status[]=closed` | The provider's own group holds its place at **0 courses**, its one AP group shows 32 |

Scenarios 6 and 7 are the two judgement calls worth a look:

- **6** — when *every* group is emptied we keep the existing single "No courses found" rather than listing every AP at zero.
- **7** — a provider's own courses render without a heading, and that group still holds its place at 0 so the list doesn't shift under you. Only one provider in the 2026 data is in that state, hence the separate example.
