### PR TITLE
Stop rollover duplicating provider sites

### DIFF
--- a/app/services/data_hub/rollover/provider_processor.rb
+++ b/app/services/data_hub/rollover/provider_processor.rb
@@ -67,7 +67,9 @@ module DataHub
         {
           courses_count: result[:courses],
           sites_count: result[:sites],
+          sites_already_present_count: result[:sites_already_present],
           study_sites_count: result[:study_sites],
+          study_sites_already_present_count: result[:study_sites_already_present],
           partnerships_count: result[:partnerships],
           courses_failed: result[:courses_failed] || [],
           courses_skipped: result[:courses_skipped] || [],

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -42,11 +42,18 @@ module Providers
                 :copy_partnership_to_provider_service,
                 :force
 
+    # `sites` and `study_sites` count what this run created. `*_already_present`
+    # counts what the destination provider already had, which is the normal
+    # outcome of a repeat run and not a problem. `*_skipped` is reserved for
+    # copies that were attempted and failed — rollover reporting surfaces those
+    # for support to act on, so nothing else belongs in them.
     def init_result_hash
       {
         providers: 0,
         sites: 0,
+        sites_already_present: 0,
         study_sites: 0,
+        study_sites_already_present: 0,
         courses: 0,
         partnerships: 0,
         courses_failed: [],
@@ -84,13 +91,22 @@ module Providers
     def copy_schools(provider, new_provider, result)
       school_result = copy_schools_to_provider_service.execute(provider:, new_provider:)
       result[:sites] += school_result[:copied]
+      result[:sites_already_present] += school_result.fetch(:already_present, []).size
       result[:sites_skipped].concat(school_result[:skipped])
     end
 
+    # Study sites already on the destination provider are filtered out before the
+    # orchestrator sees them: it hands out codes from a finite pool, and which
+    # branch it takes depends on the list it is given, so passing sites we are
+    # about to skip would burn codes and shift the codes it assigns to the rest.
     def copy_study_sites(provider, new_provider, result)
+      existing_sites = Sites::ExistingSiteIndex.for(provider: new_provider, site_type: :study_site)
+      sites_to_copy, already_present = provider.study_sites.partition { !existing_sites.already_copied?(it) }
+      result[:study_sites_already_present] += already_present.size
+
       assignments = DataHub::Rollover::StudySiteCodeOrchestrator.new(
         target_provider: new_provider,
-        sites_to_copy: provider.study_sites,
+        sites_to_copy:,
       ).call
 
       assignments.each do |assignment|

--- a/app/services/rollover/schools/legacy_provider_copier.rb
+++ b/app/services/rollover/schools/legacy_provider_copier.rb
@@ -8,9 +8,15 @@ module Rollover
       end
 
       def execute(provider:, new_provider:)
-        result = { copied: 0, skipped: [] }
+        result = { copied: 0, skipped: [], already_present: [] }
+        existing_sites = ::Sites::ExistingSiteIndex.for(provider: new_provider, site_type: :school)
 
         provider.sites.with_available_gias_school.each do |site|
+          if existing_sites.already_copied?(site)
+            result[:already_present] << site.code
+            next
+          end
+
           site_result = site_copier.execute(site:, new_provider:)
 
           if site_result.success?

--- a/app/services/rollover/schools/provider_copier.rb
+++ b/app/services/rollover/schools/provider_copier.rb
@@ -5,19 +5,24 @@ module Rollover
     class ProviderCopier
       def execute(provider:, new_provider:)
         existing = new_provider.schools.index_by { |school| [school.gias_school_id, school.site_code] }
-        schools = provider.schools.with_available_gias_school
+        result = { copied: 0, skipped: [], already_present: [] }
 
-        schools.each do |provider_school|
+        provider.schools.with_available_gias_school.each do |provider_school|
           key = [provider_school.gias_school_id, provider_school.site_code]
-          next if existing.key?(key)
+
+          if existing.key?(key)
+            result[:already_present] << provider_school.site_code
+            next
+          end
 
           existing[key] = new_provider.schools.create!(
             gias_school_id: provider_school.gias_school_id,
             site_code: provider_school.site_code,
           )
+          result[:copied] += 1
         end
 
-        { copied: schools.size, skipped: [] }
+        result
       end
     end
   end

--- a/app/services/sites/copy_to_course_service.rb
+++ b/app/services/sites/copy_to_course_service.rb
@@ -20,14 +20,13 @@ module Sites
     attr_reader :new_site, :new_course
 
     def copy_school
-      new_course.site_statuses.create(
-        site: new_site,
-        status: :new_status,
-      )
+      new_course.site_statuses.find_or_create_by(site: new_site) do |site_status|
+        site_status.status = :new_status
+      end
     end
 
     def copy_study_site
-      new_course.study_site_placements.create(site: new_site)
+      new_course.study_site_placements.find_or_create_by(site: new_site)
     end
   end
 end

--- a/app/services/sites/existing_site_index.rb
+++ b/app/services/sites/existing_site_index.rb
@@ -7,12 +7,16 @@ module Sites
   #
   # Identity follows those same rules:
   #
-  # * school sites are identified by URN, which Site validates as unique per
-  #   provider, falling back to the site code for the URN-less sites the URN
-  #   presence validation exempts — in practice, main sites
+  # * school sites are identified by URN and code together. URN alone is not
+  #   identity: a provider can hold one URN twice, on a main site and on an
+  #   ordinary site, since main sites are matched to GIAS by postcode. A copy
+  #   keeps its source's code, so the pair is stable across runs, and the URN-less
+  #   sites the presence validation exempts simply key on their code alone
   # * study sites are identified by location name, which Site validates as unique
   #   per provider and site type, and by URN when they have one — the two checks
-  #   Publish::StudySiteForm makes before letting anyone add a study site
+  #   Publish::StudySiteForm makes before letting anyone add a study site. Code is
+  #   deliberately absent here: StudySiteCodeOrchestrator reassigns study site
+  #   codes as it copies them, so a code is not stable across runs
   #
   # The index is a snapshot of what the target provider had before the copy
   # started, and is deliberately never updated with the sites being copied.
@@ -35,10 +39,8 @@ module Sites
           [:study_site, :location_name, normalize(site.location_name)],
           ([:study_site, :urn, normalize(site.urn)] if site.urn.present?),
         ].compact
-      elsif site.urn.present?
-        [[:school, :urn, normalize(site.urn)]]
       else
-        [[:school, :code, site.code]]
+        [[:school, normalize(site.urn), site.code]]
       end
     end
 

--- a/app/services/sites/existing_site_index.rb
+++ b/app/services/sites/existing_site_index.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Sites
+  # Answers "does the target provider already have this site?" for the rollover
+  # copiers, which save with `validate: false` and so bypass the uniqueness rules
+  # Site would otherwise enforce.
+  #
+  # Identity follows those same rules:
+  #
+  # * school sites are identified by URN, which Site validates as unique per
+  #   provider, falling back to the site code for the URN-less sites the URN
+  #   presence validation exempts — in practice, main sites
+  # * study sites are identified by location name, which Site validates as unique
+  #   per provider and site type, and by URN when they have one — the two checks
+  #   Publish::StudySiteForm makes before letting anyone add a study site
+  #
+  # The index is a snapshot of what the target provider had before the copy
+  # started, and is deliberately never updated with the sites being copied.
+  # Rollover::Schools::LegacyCourseCopier and Courses::CopyToProviderService both
+  # resolve a source site to its copy by code, so folding fresh copies in would
+  # collapse two same-named source sites onto one copy and silently drop the
+  # second one's course placement.
+  class ExistingSiteIndex
+    def self.for(provider:, site_type:)
+      sites = Site.kept
+                  .where(provider_id: provider.id, site_type:)
+                  .select(:id, :code, :urn, :location_name, :site_type)
+
+      new(sites.flat_map { keys_for(it) })
+    end
+
+    def self.keys_for(site)
+      if site.study_site?
+        [
+          [:study_site, :location_name, normalize(site.location_name)],
+          ([:study_site, :urn, normalize(site.urn)] if site.urn.present?),
+        ].compact
+      elsif site.urn.present?
+        [[:school, :urn, normalize(site.urn)]]
+      else
+        [[:school, :code, site.code]]
+      end
+    end
+
+    def self.normalize(value)
+      value.to_s.strip.downcase
+    end
+
+    def initialize(keys)
+      @keys = keys.to_set
+    end
+
+    def already_copied?(site)
+      self.class.keys_for(site).any? { keys.include?(it) }
+    end
+
+  private
+
+    attr_reader :keys
+  end
+end

--- a/spec/services/data_hub/rollover/provider_processor_spec.rb
+++ b/spec/services/data_hub/rollover/provider_processor_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe DataHub::Rollover::ProviderProcessor, type: :service do
           providers: 1,
           courses: 1,
           sites: 1,
+          sites_already_present: 2,
           study_sites: 1,
+          study_sites_already_present: 3,
           partnerships: 0,
           courses_failed: [],
           courses_skipped: [],
@@ -60,7 +62,9 @@ RSpec.describe DataHub::Rollover::ProviderProcessor, type: :service do
           "status" => "rolled_over",
           "courses_count" => 1,
           "sites_count" => 1,
+          "sites_already_present_count" => 2,
           "study_sites_count" => 1,
+          "study_sites_already_present_count" => 3,
           "duration_seconds" => 35.5,
         )
       end

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -231,7 +231,9 @@ describe Providers::CopyToRecruitmentCycleService do
       expect(output).to include(
         providers: 1,
         sites: 1,
+        sites_already_present: 0,
         study_sites: 1,
+        study_sites_already_present: 0,
         courses: 1,
         partnerships: 1,
         courses_failed: [],
@@ -285,6 +287,54 @@ describe Providers::CopyToRecruitmentCycleService do
           new_provider: new_provider,
           assigned_code: "DUP1",
         )
+      end
+    end
+
+    # The site copier is a double everywhere else in this file, which cannot
+    # write rows and so hides a repeat run entirely. This context wires up the
+    # real one.
+    context "when the provider has already been rolled over" do
+      let(:mocked_copy_site_service) { Sites::CopyToProviderService.new }
+
+      before do
+        allow(mocked_copy_site_service).to receive(:execute).and_call_original
+
+        service.execute(provider:, new_recruitment_cycle:)
+      end
+
+      it "does not copy the school sites again" do
+        expect { service.execute(provider:, new_recruitment_cycle:) }
+          .not_to change(new_provider.sites, :count).from(1)
+      end
+
+      it "does not copy the study sites again" do
+        expect { service.execute(provider:, new_recruitment_cycle:) }
+          .not_to change(new_provider.study_sites, :count).from(1)
+      end
+
+      it "reports them as already present rather than copied" do
+        result = service.execute(provider:, new_recruitment_cycle:)
+
+        expect(result).to include(
+          sites: 0,
+          sites_already_present: 1,
+          sites_skipped: [],
+          study_sites: 0,
+          study_sites_already_present: 1,
+          study_sites_skipped: [],
+        )
+      end
+
+      # Pins the filtering to *before* the orchestrator: it hands out study site
+      # codes from a finite pool, so letting it see sites we are about to skip
+      # would burn codes and change how it assigns them on every re-run.
+      it "does not ask the orchestrator to assign codes to sites it will skip" do
+        allow(DataHub::Rollover::StudySiteCodeOrchestrator).to receive(:new).and_call_original
+
+        service.execute(provider:, new_recruitment_cycle:)
+
+        expect(DataHub::Rollover::StudySiteCodeOrchestrator)
+          .to have_received(:new).with(target_provider: new_provider, sites_to_copy: [])
       end
     end
 

--- a/spec/services/rollover/schools/dual_provider_copier_spec.rb
+++ b/spec/services/rollover/schools/dual_provider_copier_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Rollover::Schools::DualProviderCopier do
   end
 
   it "returns the legacy result used by rollover reporting" do
-    expect(copy_schools).to eq(copied: 1, skipped: [])
+    expect(copy_schools).to eq(copied: 1, skipped: [], already_present: [])
   end
 
   it "copies neither the legacy Site nor the Provider::School when the GIAS record has closed" do

--- a/spec/services/rollover/schools/legacy_provider_copier_spec.rb
+++ b/spec/services/rollover/schools/legacy_provider_copier_spec.rb
@@ -43,10 +43,14 @@ RSpec.describe Rollover::Schools::LegacyProviderCopier do
       expect(result).to eq(copied: 0, skipped: [], already_present: [site.code])
     end
 
-    it "matches on URN rather than site code" do
+    # A copy always keeps its source's code, so a same-URN site under a
+    # different code is a different entry - a main site and an ordinary site
+    # can share a URN. LegacyCourseCopier resolves a source site to its copy by
+    # code, so skipping this one would leave the course with no site to link to.
+    it "copies a source site whose URN is on the new provider under another code" do
       create(:site, provider: new_provider, urn: site.urn, code: "X")
 
-      expect { copy_sites }.not_to change(new_provider.sites, :count)
+      expect { copy_sites }.to change(new_provider.sites, :count).by(1)
     end
 
     it "copies a source site whose URN is not yet on the new provider" do

--- a/spec/services/rollover/schools/legacy_provider_copier_spec.rb
+++ b/spec/services/rollover/schools/legacy_provider_copier_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Rollover::Schools::LegacyProviderCopier do
+  subject(:copy_sites) { described_class.new(site_copier: Sites::CopyToProviderService.new).execute(provider:, new_provider:) }
+
+  let(:provider) { create(:provider) }
+  let(:new_provider) { create(:provider, recruitment_cycle: create(:recruitment_cycle, :next)) }
+  let!(:site) { create(:site, :with_gias_school, provider:, code: "S") }
+
+  it "copies school sites to the new provider" do
+    expect { copy_sites }.to change(new_provider.sites, :count).from(0).to(1)
+
+    expect(new_provider.sites.pluck(:code, :urn)).to contain_exactly([site.code, site.urn])
+  end
+
+  it "returns the number of sites it created" do
+    expect(copy_sites).to eq(copied: 1, skipped: [], already_present: [])
+  end
+
+  it "does not copy a site whose GIAS record has closed" do
+    create(:site, provider:, code: "Z", urn: create(:gias_school, :closed).urn)
+
+    copy_sites
+
+    expect(new_provider.sites.pluck(:code)).to contain_exactly(site.code)
+  end
+
+  describe "idempotency" do
+    it "does not copy a site that has already been rolled over" do
+      copy_sites
+
+      expect { described_class.new(site_copier: Sites::CopyToProviderService.new).execute(provider:, new_provider:) }
+        .not_to change(new_provider.sites, :count)
+    end
+
+    it "reports the sites that were already present rather than counting them as copied" do
+      copy_sites
+
+      result = described_class.new(site_copier: Sites::CopyToProviderService.new).execute(provider:, new_provider:)
+
+      expect(result).to eq(copied: 0, skipped: [], already_present: [site.code])
+    end
+
+    it "matches on URN rather than site code" do
+      create(:site, provider: new_provider, urn: site.urn, code: "X")
+
+      expect { copy_sites }.not_to change(new_provider.sites, :count)
+    end
+
+    it "copies a source site whose URN is not yet on the new provider" do
+      create(:site, :with_gias_school, provider: new_provider, code: site.code)
+
+      expect { copy_sites }.to change(new_provider.sites, :count).by(1)
+    end
+
+    it "copies a main site only once" do
+      main_site = create(:site, :main_site, provider:)
+
+      copy_sites
+      described_class.new(site_copier: Sites::CopyToProviderService.new).execute(provider:, new_provider:)
+
+      expect(new_provider.sites.where(code: main_site.code).count).to eq(1)
+    end
+
+    it "does not skip a URN-less source site because an unrelated site holds its code" do
+      main_site = create(:site, :main_site, provider:)
+      create(:site, :with_gias_school, provider: new_provider, code: main_site.code)
+
+      copy_sites
+
+      expect(new_provider.sites.where(code: main_site.code).count).to eq(2)
+    end
+
+    it "copies a site again once the rolled over copy has been discarded" do
+      copy_sites
+      new_provider.sites.sole.discard
+
+      expect { described_class.new(site_copier: Sites::CopyToProviderService.new).execute(provider:, new_provider:) }
+        .to change(new_provider.sites, :count).from(0).to(1)
+    end
+  end
+end

--- a/spec/services/rollover_provider_service_idempotency_spec.rb
+++ b/spec/services/rollover_provider_service_idempotency_spec.rb
@@ -57,6 +57,26 @@ RSpec.describe RolloverProviderService do
     end
   end
 
+  # The guard this fix replaces matched on code alone and read school and study
+  # site codes as one namespace, so a study site sharing a school site's code was
+  # dropped and never rolled over at all. Removing that guard is what let repeat
+  # runs duplicate. Both halves have to hold at once.
+  context "when a study site shares a school site's code" do
+    let!(:study_sites) do
+      [
+        create(:site, :study_site, provider:, code: school_sites.first.code),
+        create(:site, :study_site, provider:),
+      ]
+    end
+
+    it "copies it exactly once across repeated rollovers" do
+      courses.each { roll_over(it) }
+
+      expect(new_provider.study_sites.count).to eq(2)
+      expect(new_provider.study_sites.pluck(:location_name)).to match_array(study_sites.map(&:location_name))
+    end
+  end
+
   it "reports the sites it left alone rather than counting them as copied" do
     roll_over(courses.first)
 

--- a/spec/services/rollover_provider_service_idempotency_spec.rb
+++ b/spec/services/rollover_provider_service_idempotency_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Rolling a provider over twice must not duplicate its sites. The per-course
+# rollover in Publish (Publish::Courses::DraftRolloverController) runs the whole
+# provider pipeline once per course, so a provider with three draft courses is
+# rolled over three times in a row by design.
+#
+# Deliberately unmocked, unlike spec/services/rollover_provider_service_spec.rb —
+# the collaborators have to write real rows for a repeat run to be observable.
+RSpec.describe RolloverProviderService do
+  subject(:new_provider) do
+    next_recruitment_cycle.reload.providers.find_by(provider_code: provider.provider_code)
+  end
+
+  let!(:next_recruitment_cycle) { create(:recruitment_cycle, :next) }
+  let(:provider) { create(:provider) }
+  let!(:school_sites) { create_list(:site, 2, :with_gias_school, :with_provider_school, provider:) }
+  let!(:study_sites) { create_list(:site, 2, :study_site, provider:) }
+  let!(:courses) { create_list(:course, 3, provider:) }
+
+  def roll_over(course)
+    described_class.call(provider_code: provider.provider_code, course_codes: [course.course_code], force: true)
+  end
+
+  it "copies the sites once when a single course is rolled over" do
+    roll_over(courses.first)
+
+    expect(new_provider.sites.count).to eq(2)
+    expect(new_provider.study_sites.count).to eq(2)
+  end
+
+  context "when each course is rolled over separately" do
+    before { courses.each { roll_over(it) } }
+
+    it "does not duplicate the school sites" do
+      expect(new_provider.sites.count).to eq(2)
+      expect(new_provider.sites.pluck(:urn)).to match_array(school_sites.map(&:urn))
+    end
+
+    it "does not duplicate the study sites" do
+      expect(new_provider.study_sites.count).to eq(2)
+      expect(new_provider.study_sites.pluck(:location_name)).to match_array(study_sites.map(&:location_name))
+    end
+
+    it "gives each copied study site its own code" do
+      expect(new_provider.study_sites.pluck(:code).uniq.size).to eq(2)
+    end
+
+    it "does not duplicate the provider schools" do
+      expect(new_provider.schools.count).to eq(2)
+    end
+
+    it "copies every course" do
+      expect(new_provider.courses.pluck(:course_code)).to match_array(courses.map(&:course_code))
+    end
+  end
+
+  it "reports the sites it left alone rather than counting them as copied" do
+    roll_over(courses.first)
+
+    result = roll_over(courses.second)
+
+    expect(result).to include(
+      sites: 0,
+      sites_already_present: 2,
+      sites_skipped: [],
+      study_sites: 0,
+      study_sites_already_present: 2,
+      study_sites_skipped: [],
+    )
+  end
+end

--- a/spec/services/sites/copy_to_course_service_spec.rb
+++ b/spec/services/sites/copy_to_course_service_spec.rb
@@ -31,6 +31,11 @@ describe Sites::CopyToCourseService do
 
       it { is_expected.to be_status_new_status }
     end
+
+    it "does not add the site to the course twice" do
+      expect { described_class.call(new_site: site, new_course: course) }
+        .not_to change(course.site_statuses.reload, :count)
+    end
   end
 
   context "site is a study site" do
@@ -43,6 +48,11 @@ describe Sites::CopyToCourseService do
     it "has the same code as the original site" do
       new_study_site = course.study_sites.last
       expect(new_study_site.code).to eq(site.code)
+    end
+
+    it "does not add the study site to the course twice" do
+      expect { described_class.call(new_site: site, new_course: course) }
+        .not_to change(course.study_site_placements.reload, :count)
     end
   end
 end

--- a/spec/services/sites/existing_site_index_spec.rb
+++ b/spec/services/sites/existing_site_index_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Sites::ExistingSiteIndex do
+  let(:provider) { create(:provider) }
+  let(:other_provider) { create(:provider) }
+
+  describe "school sites" do
+    subject(:index) { described_class.for(provider:, site_type: :school) }
+
+    let!(:site) { create(:site, provider:, urn: "123456", code: "A") }
+
+    it "recognises a site with the same URN" do
+      expect(index).to be_already_copied(build(:site, urn: " 123456 ", code: "Z"))
+    end
+
+    it "does not recognise a site with a different URN" do
+      expect(index).not_to be_already_copied(build(:site, urn: "654321", code: "A"))
+    end
+
+    it "does not recognise a site belonging to another provider" do
+      other_index = described_class.for(provider: other_provider, site_type: :school)
+
+      expect(other_index).not_to be_already_copied(site)
+    end
+
+    it "does not recognise a discarded site" do
+      site.discard
+
+      expect(index).not_to be_already_copied(site)
+    end
+
+    it "does not recognise a study site with the same URN" do
+      expect(index).not_to be_already_copied(build(:site, :study_site, urn: "123456"))
+    end
+
+    context "when the site has no URN" do
+      let!(:site) { create(:site, :main_site, provider:) }
+
+      it "falls back to the site code" do
+        expect(index).to be_already_copied(build(:site, :main_site))
+      end
+
+      it "does not recognise a URN-less site with a different code" do
+        expect(index).not_to be_already_copied(build(:site, urn: nil, code: "Q"))
+      end
+    end
+
+    # A school site created in the target cycle always has a URN, so it never
+    # registers a code key. Without that asymmetry a main site would be skipped
+    # whenever an unrelated site happened to hold its code.
+    it "does not let a site with a URN mask a URN-less site sharing its code" do
+      expect(index).not_to be_already_copied(build(:site, urn: nil, code: site.code))
+    end
+  end
+
+  describe "study sites" do
+    subject(:index) { described_class.for(provider:, site_type: :study_site) }
+
+    let!(:study_site) { create(:site, :study_site, provider:, location_name: "Trumpington Campus", urn: "123456") }
+
+    it "recognises a study site with the same location name" do
+      expect(index).to be_already_copied(build(:site, :study_site, location_name: " trumpington campus ", urn: nil))
+    end
+
+    it "recognises a study site with the same URN" do
+      expect(index).to be_already_copied(build(:site, :study_site, location_name: "Somewhere else", urn: "123456"))
+    end
+
+    it "does not recognise a study site with a different location name and URN" do
+      expect(index).not_to be_already_copied(build(:site, :study_site, location_name: "Somewhere else", urn: "654321"))
+    end
+
+    it "does not recognise a study site with no URN and a different location name" do
+      expect(index).not_to be_already_copied(build(:site, :study_site, location_name: "Somewhere else", urn: nil))
+    end
+
+    it "does not recognise a school site with the same location name" do
+      expect(index).not_to be_already_copied(build(:site, location_name: study_site.location_name))
+    end
+
+    it "does not recognise a discarded study site" do
+      study_site.discard
+
+      expect(index).not_to be_already_copied(study_site)
+    end
+  end
+
+  it "does not load the provider's sites association" do
+    create(:site, provider:)
+
+    described_class.for(provider:, site_type: :school)
+
+    expect(provider.sites).not_to be_loaded
+  end
+end

--- a/spec/services/sites/existing_site_index_spec.rb
+++ b/spec/services/sites/existing_site_index_spec.rb
@@ -11,12 +11,20 @@ RSpec.describe Sites::ExistingSiteIndex do
 
     let!(:site) { create(:site, provider:, urn: "123456", code: "A") }
 
-    it "recognises a site with the same URN" do
-      expect(index).to be_already_copied(build(:site, urn: " 123456 ", code: "Z"))
+    it "recognises a site with the same URN and code" do
+      expect(index).to be_already_copied(build(:site, urn: " 123456 ", code: "A"))
     end
 
     it "does not recognise a site with a different URN" do
       expect(index).not_to be_already_copied(build(:site, urn: "654321", code: "A"))
+    end
+
+    # A provider can hold one URN twice - a main site and an ordinary school
+    # site, since the backfill matches main sites to GIAS by postcode. They are
+    # separate entries, and the copiers resolve a source site to its copy by
+    # code, so conflating them would strand a course's site placement.
+    it "does not recognise a site with the same URN at a different code" do
+      expect(index).not_to be_already_copied(build(:site, urn: "123456", code: "Z"))
     end
 
     it "does not recognise a site belonging to another provider" do
@@ -38,18 +46,21 @@ RSpec.describe Sites::ExistingSiteIndex do
     context "when the site has no URN" do
       let!(:site) { create(:site, :main_site, provider:) }
 
-      it "falls back to the site code" do
+      it "matches it on its code" do
         expect(index).to be_already_copied(build(:site, :main_site))
       end
 
       it "does not recognise a URN-less site with a different code" do
         expect(index).not_to be_already_copied(build(:site, urn: nil, code: "Q"))
       end
+
+      # Main sites carry both in the real data, and Site.with_available_gias_school
+      # is the only place that tells them apart.
+      it "treats a blank URN the same as a missing one" do
+        expect(index).to be_already_copied(build(:site, :main_site, urn: " "))
+      end
     end
 
-    # A school site created in the target cycle always has a URN, so it never
-    # registers a code key. Without that asymmetry a main site would be skipped
-    # whenever an unrelated site happened to hold its code.
     it "does not let a site with a URN mask a URN-less site sharing its code" do
       expect(index).not_to be_already_copied(build(:site, urn: nil, code: site.code))
     end

--- a/spec/system/publish/courses/rolling_over_draft_courses_spec.rb
+++ b/spec/system/publish/courses/rolling_over_draft_courses_spec.rb
@@ -6,13 +6,12 @@ require "rails_helper"
 # provider with several draft courses gets rolled over once per course. The
 # reported bug was a provider whose study sites appeared three times in the new
 # cycle after its three courses were rolled over one at a time.
-RSpec.describe "Rolling over draft courses one at a time" do
-  around do |example|
-    Timecop.travel(Find::CycleTimetable.apply_deadline(2025) - 1.hour) do
-      example.run
-    end
-  end
-
+#
+# Nothing here turns on which moment of the cycle it is, only on there being a
+# cycle to roll over into. The year is pinned rather than left to the real date
+# because Find::CycleTimetable::CYCLE_DATES is a hardcoded hash that ends at
+# 2027, so an unpinned cycle eventually asks it for a year it does not hold.
+RSpec.describe "Rolling over draft courses one at a time", travel: mid_cycle(2025) do
   scenario "the provider's sites are not duplicated" do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_rollable_next_recruitment_cycle
@@ -34,7 +33,7 @@ RSpec.describe "Rolling over draft courses one at a time" do
   end
 
   def and_there_is_a_rollable_next_recruitment_cycle
-    find_or_create(:recruitment_cycle, year: RecruitmentCycle.current.year.to_i + 1)
+    find_or_create(:recruitment_cycle, :next)
     RecruitmentCycle.next.update(available_in_publish_from: 1.hour.ago)
   end
 

--- a/spec/system/publish/courses/rolling_over_draft_courses_spec.rb
+++ b/spec/system/publish/courses/rolling_over_draft_courses_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Rolling a course over runs the whole provider pipeline, sites included, so a
+# provider with several draft courses gets rolled over once per course. The
+# reported bug was a provider whose study sites appeared three times in the new
+# cycle after its three courses were rolled over one at a time.
+RSpec.describe "Rolling over draft courses one at a time" do
+  around do |example|
+    Timecop.travel(Find::CycleTimetable.apply_deadline(2025) - 1.hour) do
+      example.run
+    end
+  end
+
+  scenario "the provider's sites are not duplicated" do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_rollable_next_recruitment_cycle
+    when_i_roll_over(@courses.first)
+    and_i_roll_over(@courses.second)
+    then_each_study_site_is_listed_once
+    and_each_school_site_is_listed_once
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    @courses = build_list(:course, 2, enrichments: [build(:course_enrichment)], funding_type: "salary")
+    @provider = create(
+      :provider,
+      sites: build_list(:site, 2, :with_gias_school, :with_provider_school),
+      study_sites: build_list(:site, 2, :study_site),
+      courses: @courses,
+    )
+    given_i_am_authenticated(user: create(:user, providers: [@provider]))
+  end
+
+  def and_there_is_a_rollable_next_recruitment_cycle
+    find_or_create(:recruitment_cycle, year: RecruitmentCycle.current.year.to_i + 1)
+    RecruitmentCycle.next.update(available_in_publish_from: 1.hour.ago)
+  end
+
+  def when_i_roll_over(course)
+    rollover_form_page.load(
+      provider_code: @provider.provider_code,
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+      course_code: course.course_code,
+    )
+    rollover_form_page.rollover_course_button.click
+
+    expect(page).to have_content "Course rolled over"
+  end
+
+  alias_method :and_i_roll_over, :when_i_roll_over
+
+  def then_each_study_site_is_listed_once
+    visit "/publish/organisations/#{@provider.provider_code}/#{RecruitmentCycle.next.year}/study-sites"
+
+    @provider.study_sites.each do |study_site|
+      expect(page).to have_content(study_site.location_name, count: 1)
+    end
+    expect(next_cycle_provider.study_sites.count).to eq(2)
+  end
+
+  def and_each_school_site_is_listed_once
+    expect(next_cycle_provider.sites.count).to eq(2)
+  end
+
+  def next_cycle_provider
+    RecruitmentCycle.next.providers.find_by(provider_code: @provider.provider_code)
+  end
+
+  def rollover_form_page
+    @rollover_form_page ||= PageObjects::Publish::DraftRollover.new
+  end
+end


### PR DESCRIPTION
## Problem

Study sites (and school sites) appeared three times in the new recruitment cycle.

Rolling over a single course runs the whole provider copy pipeline, so a provider with three draft courses gets rolled over three times. The legacy `Site` copiers had no "already copied?" check, so every site was duplicated on each run. Nothing caught it: `Sites::CopyToProviderService` saves with `validate: false`, bypassing `Site`'s uniqueness validations, and `site` has no unique index. `Provider::School` was unaffected — it has one.

## Solution

New `Sites::ExistingSiteIndex` answers "does the target provider already have this site?", using `Site`'s own uniqueness rules: school sites by URN (site code for URN-less main sites), study sites by location name and URN. The legacy provider copier and the study site copy skip what it matches — study sites before `StudySiteCodeOrchestrator` sees them, so it doesn't burn codes on sites we skip. `Sites::CopyToCourseService` now uses `find_or_create_by`.

Rollover reporting gains `sites_already_present` / `study_sites_already_present`, separate from `*_skipped`, which means "failed".
