### PR TITLE
Stop the length controller spec depending on a random length

### DIFF
--- a/spec/controllers/publish/courses/length_controller_spec.rb
+++ b/spec/controllers/publish/courses/length_controller_spec.rb
@@ -6,7 +6,21 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
   render_views
   let(:user) { create(:user, :with_provider) }
   let(:provider) { user.providers.first }
-  let(:course) { create(:course, :published, provider:) }
+  # The course starts on a length that is pinned, and deliberately not the one
+  # these examples submit. Left to the factory it is picked at random from a
+  # list that includes "TwoYears", and on the runs where it came up the course
+  # already had the length being submitted - so "did not persist the change"
+  # could not be told apart from "did".
+  let(:original_course_length) { "OneYear" }
+  let(:new_course_length) { "TwoYears" }
+  let(:course) do
+    create(
+      :course,
+      :published,
+      provider:,
+      enrichments: [build(:course_enrichment, :published, course_length: original_course_length)],
+    )
+  end
 
   before do
     allow(controller).to receive(:authenticate).and_return(true)
@@ -20,7 +34,7 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
         recruitment_cycle_year: provider.recruitment_cycle_year,
         code: course.course_code,
         publish_course_length_form: {
-          course_length: "TwoYears",
+          course_length: new_course_length,
         },
       }
     end
@@ -32,7 +46,7 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Your changes will go live immediately.")
         expect(response.body).to include("Continue and publish changes")
-        expect(course.reload.enrichments.find_or_initialize_draft.course_length).not_to eq("TwoYears")
+        expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq(original_course_length)
       end
     end
 
@@ -47,7 +61,7 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
             course.course_code,
           ),
         )
-        expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq("TwoYears")
+        expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq(new_course_length)
         expect(flash[:success_with_body]).to include(
           "body" => "These changes are now live.",
         )
@@ -55,7 +69,15 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
     end
 
     context "when the course is a draft" do
-      let(:course) { create(:course, :draft_enrichment, provider:) }
+      # Pinned for the same reason: otherwise the draft can start on the length
+      # being submitted, and the example passes without saving anything.
+      let(:course) do
+        create(
+          :course,
+          provider:,
+          enrichments: [build(:course_enrichment, :initial_draft, course: nil, course_length: original_course_length)],
+        )
+      end
 
       it "saves immediately without rendering the interstitial" do
         patch :update, params: params
@@ -68,7 +90,7 @@ RSpec.describe Publish::Courses::LengthController, type: :controller do
           ),
         )
         expect(response.body).not_to include("Your changes will go live immediately.")
-        expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq("TwoYears")
+        expect(course.reload.enrichments.find_or_initialize_draft.course_length).to eq(new_course_length)
       end
     end
   end


### PR DESCRIPTION
`spec/controllers/publish/courses/length_controller_spec.rb` failed on CI without anyone touching it. 

https://github.com/DFE-Digital/publish-teacher-training/actions/runs/31395512610/job/93477907109?pr=6276

The course enrichment factory picks `course_length` at random from a list that includes `"TwoYears"`, which is the value these examples submit. On the runs where it came up, the published course already had the length being submitted, so `expect(...course_length).not_to eq("TwoYears")` failed even though the controller had behaved correctly and persisted nothing. The other two assertions in that example, that the interstitial rendered, passed.

The starting length is now pinned to `"OneYear"` and the example asserts the draft still holds it, rather than only that it isn't the submitted value. The draft context is pinned for the same reason, where the coincidence had the opposite effect: the example asserting the change was saved would have passed without anything being saved. The factory is untouched, since the randomness is used across the suite and it is the spec that should pin what it depends on. Verified by forcing the seed to reproduce CI's failure exactly, then running the file 30 times with random seeds, zero failures.
