### PR TITLE
Only copy placement schools the target provider has

### DIFF
--- a/app/controllers/support/providers/copy_courses_controller.rb
+++ b/app/controllers/support/providers/copy_courses_controller.rb
@@ -15,8 +15,6 @@ module Support
         @copy_courses_form = CopyCoursesForm.new(@target_provider, recruitment_cycle.providers.find_by(provider_code: params[:course][:autocompleted_provider_code]))
 
         if @copy_courses_form.valid?
-          copy_provider_schools_to_target if copy_schools?
-
           copier = ::Courses::CopyToProviderService.new(
             schools_copy_to_course: schools_copy_to_course_service,
             sites_copy_to_course: Sites::CopyToCourseService,
@@ -44,23 +42,15 @@ module Support
     private
 
       def copy_schools?
-        params[:schools].present?
+        params.dig(CopyCoursesForm.model_name.param_key, :schools).present?
       end
 
-      def copy_provider_schools_to_target
-        Rollover::Schools::ProviderCopier.new.execute(
-          provider: @copy_courses_form.provider,
-          new_provider: @copy_courses_form.target_provider,
-        )
-      end
-
+      # Placement schools are only linked where the target provider already has
+      # the school; this flow never creates schools for the target provider.
       def schools_copy_to_course_service
         return ->(**) {} unless copy_schools?
 
-        Rollover::Schools::DualCourseCopier.new(
-          legacy_copier: Rollover::Schools::LegacyCourseCopier.new(site_copier: Sites::CopyToCourseService),
-          new_copier: Rollover::Schools::CourseCopier.new,
-        )
+        CourseSchools::CopyToCourse.new
       end
     end
   end

--- a/app/services/course_schools/copy_to_course.rb
+++ b/app/services/course_schools/copy_to_course.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Copies a course's placement schools onto a copy of that course under another
+# provider.
+#
+# Only copy course schools to the new provider if the new provider has the
+# provider schools
+module CourseSchools
+  class CopyToCourse
+    def call(course:, new_provider:, new_course:)
+      schools = schools_to_copy(course, new_provider)
+      sites = paired_sites(schools, new_provider)
+
+      schools.each do |provider_school|
+        new_course.schools.create!(
+          provider_school:,
+          gias_school_id: provider_school.gias_school_id,
+        )
+
+        # TODO: School data remodel removal - delete when courses no longer dual-write to SiteStatus.
+        Sites::CopyToCourseService.call(new_site: sites.fetch(provider_school.uuid), new_course:)
+      end
+    end
+
+  private
+
+    def schools_to_copy(course, new_provider)
+      new_provider.schools.where(gias_school_id: course.schools.select(:gias_school_id)).to_a
+    end
+
+    def paired_sites(schools, new_provider)
+      new_provider.sites.where(uuid: schools.map(&:uuid)).index_by(&:uuid)
+    end
+  end
+end

--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -6,8 +6,13 @@ RSpec.describe "Support::CopyCourses" do
   include DfESignInUserHelper
   let(:user) { create(:user, :admin) }
   let(:source_provider) { create(:provider, courses: create_list(:course, 3, :with_full_time_sites)) }
-  let!(:target_provider) { create(:provider, sites: source_provider.courses.flat_map(&:sites)) }
+  let!(:target_provider) { create(:provider) }
   let!(:year) { find_or_create(:recruitment_cycle).year }
+
+  def link_school(provider, gias_school, site_code)
+    site = create(:site, provider:, urn: gias_school.urn, code: site_code)
+    create(:provider_school, provider:, gias_school:, site_code:, uuid: site.uuid)
+  end
 
   before { host! URI(Settings.base_url).host }
 
@@ -31,46 +36,49 @@ RSpec.describe "Support::CopyCourses" do
     end
 
     context "with schools" do
-      # The copier only carries over sites backed by an available GIAS school,
-      # and the course factory's sites use a urn sequence that matches none.
+      let(:source_course) { source_provider.courses.first }
+      let(:shared_gias_school) { create(:gias_school, :open) }
+      let(:unlinked_gias_school) { create(:gias_school, :open) }
+      # The target provider keeps its own site code for the shared school.
+      let!(:target_school) { link_school(target_provider, shared_gias_school, "Z") }
+
       before do
-        source_provider.courses.flat_map(&:sites).each { |site| create(:gias_school, :open, urn: site.urn) }
+        [shared_gias_school, unlinked_gias_school].each_with_index do |gias_school, index|
+          provider_school = link_school(source_provider, gias_school, ("A".."Z").to_a[index])
+          create(:course_school, course: source_course, provider_school:, gias_school:)
+        end
       end
 
-      it "copies the courses with schools" do
+      it "copies the placement schools the target provider already has" do
         login_user(user)
-        post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { "course[autocompleted_provider_code]" => source_provider.provider_code, schools: "1" }
+        post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { "course[autocompleted_provider_code]" => source_provider.provider_code, "support_copy_courses_form" => { "schools" => "true" } }
+
         expect(target_provider.reload.courses.length).to eq(3)
-        courses = target_provider.reload.courses
-        expect(courses.flat_map(&:sites).length).to eq(3)
+
+        copied_course = target_provider.courses.find_by!(course_code: source_course.course_code)
+        expect(copied_course.schools.pluck(:provider_school_id)).to eq([target_school.id])
+        expect(copied_course.sites.pluck(:uuid)).to eq([target_school.uuid])
+
         expect(response).to redirect_to(support_recruitment_cycle_provider_courses_path(year, target_provider.id))
         follow_redirect!
         expect(response.parsed_body.css(".govuk-notification-banner--success").text).to match(sprintf("Courses copied: %s", source_provider.courses.map(&:course_code).sort.to_sentence))
       end
 
-      it "copies course-school relationships when the source course uses the new model" do
-        source_course = source_provider.courses.first
-        provider_school = create(:provider_school, provider: source_provider, site_code: "S")
-        create(
-          :course_school,
-          course: source_course,
-          provider_school:,
-          gias_school: provider_school.gias_school,
-          site_code: provider_school.site_code,
-        )
-
+      it "does not copy placement schools the target provider does not have" do
         login_user(user)
-        post "/support/#{year}/providers/#{target_provider.id}/copy_courses",
-             params: { "course[autocompleted_provider_code]" => source_provider.provider_code, schools: "1" }
+        post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { "course[autocompleted_provider_code]" => source_provider.provider_code, "support_copy_courses_form" => { "schools" => "true" } }
+
+        expect(target_provider.reload.schools.pluck(:gias_school_id)).to eq([shared_gias_school.id])
+        expect(target_provider.sites.pluck(:uuid)).to eq([target_school.uuid])
+      end
+
+      it "copies no placement schools when the box is left unticked" do
+        login_user(user)
+        post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { "course[autocompleted_provider_code]" => source_provider.provider_code }
 
         copied_course = target_provider.reload.courses.find_by!(course_code: source_course.course_code)
-        expect(copied_course.schools.first).to have_attributes(
-          provider_school_id: target_provider.schools.find_by!(
-            gias_school_id: provider_school.gias_school_id,
-            site_code: provider_school.site_code,
-          ).id,
-          gias_school_id: provider_school.gias_school_id,
-        )
+        expect(copied_course.schools).to be_empty
+        expect(copied_course.sites).to be_empty
       end
     end
 

--- a/spec/services/course_schools/copy_to_course_spec.rb
+++ b/spec/services/course_schools/copy_to_course_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseSchools::CopyToCourse do
+  subject(:copy_schools) { described_class.new.call(course:, new_provider:, new_course:) }
+
+  # A provider school and the legacy site it was dual-written with, joined by
+  # the uuid the two share.
+  def link_school(provider, gias_school, site_code: "B")
+    site = create(:site, provider:, urn: gias_school.urn, code: site_code)
+    create(:provider_school, provider:, gias_school:, site_code:, uuid: site.uuid)
+  end
+
+  let(:provider) { create(:provider) }
+  let(:course) { create(:course, provider:) }
+  let(:gias_school) { create(:gias_school, :open) }
+  let!(:provider_school) { link_school(provider, gias_school) }
+  let!(:course_school) { create(:course_school, course:, provider_school:, gias_school:) }
+
+  let(:new_provider) { create(:provider) }
+  let(:new_course) { create(:course, provider: new_provider, course_code: course.course_code) }
+
+  context "when the target provider already has the school" do
+    # The target keeps its own site code for the same school.
+    let!(:new_provider_school) { link_school(new_provider, gias_school, site_code: "K") }
+
+    it "copies the course school onto the copied course" do
+      copy_schools
+
+      expect(new_course.schools.reload.map { |school| [school.provider_school_id, school.gias_school_id] })
+        .to contain_exactly([new_provider_school.id, gias_school.id])
+    end
+
+    it "attaches the target provider's paired legacy site to the copied course" do
+      copy_schools
+
+      expect(new_course.site_statuses.reload.map(&:site))
+        .to contain_exactly(new_provider.sites.find_by!(uuid: new_provider_school.uuid))
+    end
+
+    it "does not add any schools to the target provider" do
+      expect { copy_schools }.to not_change(new_provider.schools, :count).and not_change(new_provider.sites, :count)
+    end
+
+    it "copies the school once when the source course reaches it through two of its own schools" do
+      duplicate = create(:provider_school, provider:, gias_school:, site_code: "C")
+      create(:course_school, course:, provider_school: duplicate, gias_school:)
+
+      copy_schools
+
+      expect(new_course.schools.reload.pluck(:provider_school_id)).to eq([new_provider_school.id])
+    end
+  end
+
+  context "when the target provider does not have the school" do
+    it "copies nothing" do
+      copy_schools
+
+      expect(new_course.schools.reload).to be_empty
+      expect(new_course.site_statuses.reload).to be_empty
+    end
+
+    it "does not create the school for the target provider" do
+      expect { copy_schools }.to not_change(new_provider.schools, :count).and not_change(new_provider.sites, :count)
+    end
+
+    it "still copies the schools the target provider does have" do
+      other_gias_school = create(:gias_school, :open)
+      other_provider_school = link_school(provider, other_gias_school, site_code: "C")
+      create(:course_school, course:, provider_school: other_provider_school, gias_school: other_gias_school)
+      new_provider_school = link_school(new_provider, other_gias_school, site_code: "D")
+
+      copy_schools
+
+      expect(new_course.schools.reload.pluck(:provider_school_id)).to eq([new_provider_school.id])
+    end
+  end
+
+  context "when the source course school's GIAS record has closed" do
+    let(:gias_school) { create(:gias_school, :closed) }
+    let!(:new_provider_school) { link_school(new_provider, gias_school, site_code: "K") }
+
+    it "copies it, because the target provider still has the school" do
+      copy_schools
+
+      expect(new_course.schools.reload.pluck(:provider_school_id)).to eq([new_provider_school.id])
+    end
+  end
+end

--- a/spec/system/support/providers/copy_courses_to_provider_spec.rb
+++ b/spec/system/support/providers/copy_courses_to_provider_spec.rb
@@ -15,9 +15,23 @@ RSpec.describe "Support copies courses between providers", service: :publish do
   let!(:source_provider) { create(:provider, provider_name: "Source Provider", courses:) }
   let!(:target_provider) { create(:provider, provider_name: "Target Provider") }
   let(:user) { create(:user, :admin) }
+  let(:shared_school) { create(:gias_school, :open, name: "Shared Placement School") }
+
+  # A provider school and the legacy site it was dual-written with, joined by
+  # the uuid the two share.
+  def link_school(provider, gias_school, site_code)
+    site = create(:site, provider:, urn: gias_school.urn, code: site_code)
+    create(:provider_school, provider:, gias_school:, site_code:, uuid: site.uuid)
+  end
 
   before do
     sign_in_system_test(user:)
+
+    # The first course has a placement at a school the target provider already
+    # has, so ticking the checkbox should carry that placement across.
+    source_school = link_school(source_provider, shared_school, "A")
+    link_school(target_provider, shared_school, "Z")
+    create(:course_school, course: courses.first, provider_school: source_school, gias_school: shared_school)
   end
 
   it "copies courses from one provider to another using the autocomplete", :js do
@@ -37,5 +51,9 @@ RSpec.describe "Support copies courses between providers", service: :publish do
     courses.map(&:name).each do |course_name|
       expect(page).to have_content(course_name)
     end
+
+    click_on courses.first.name_and_code
+    click_on "Basic details"
+    expect(page).to have_content("Shared Placement School")
   end
 end


### PR DESCRIPTION
## Context

Ticking "Copy placement schools?" in the support copy-courses flow has
done nothing since e47dbfba9 (Dec 2024). That commit bound the form to
`CopyCoursesForm`, which namespaced every builder field under
support_copy_courses_form. It moved the provider code field back to the
top level but missed the checkbox, so `params[:schools]` has been nil ever
since and the copy was always skipped.

Read the checkbox under the form's param key so it works again.

That on its own would have been unsafe. The copying behind the dead gate
was rewritten in 33f1713b2, months after it had stopped running, to
create any placement school the target provider was missing, which
contradicts the form's own hint that unlinked schools are not copied.
Restoring the gate alone would have made that live on the first ticked
copy.

CourseSchools::CopyToCourse replaces it, narrowing a course's placements
to schools the target provider already has and pairing each with the
target's own legacy Site by their shared uuid. An unlinked school is
dropped and nothing is created for the target.

The request specs cannot catch the param mismatch, since they choose the
params themselves. The system spec now ticks the real checkbox and
follows a copied course to its Basic details tab to assert the shared
school is listed.



## Changes proposed in this pull request

1. Fix the form param so it's read in the controller
2. Change the class that copies the course so it doesn't create provider_schools

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
