### PR TITLE
Fix sites invalid rolled over cycle

### DIFF
--- a/app/components/publish/check_answers/formatters.rb
+++ b/app/components/publish/check_answers/formatters.rb
@@ -93,7 +93,7 @@ module Publish
       class StudySites
         def call(value, draft, view)
           return value.join(", ") if value.present?
-          return if draft.wizard.provider.study_sites.any?
+          return view.helpers.value_none if draft.wizard.provider.study_sites.any?
 
           view.add_a_study_site_link
         end

--- a/app/components/publish/check_answers/formatters.rb
+++ b/app/components/publish/check_answers/formatters.rb
@@ -86,11 +86,16 @@ module Publish
         end
       end
 
+      # Blank is a legitimate answer, so it renders as an empty row. The one
+      # prompt kept is for a provider with no study sites on their
+      # organisation at all, who has to add one there before they could pick it
+      # here.
       class StudySites
-        def call(value, _draft, view)
+        def call(value, draft, view)
           return value.join(", ") if value.present?
+          return if draft.wizard.provider.study_sites.any?
 
-          view.study_sites_call_to_action_link
+          view.add_a_study_site_link
         end
       end
 

--- a/app/components/publish/check_answers/summary_component.rb
+++ b/app/components/publish/check_answers/summary_component.rb
@@ -74,21 +74,14 @@ module Publish
 
     public
 
-      def study_sites_call_to_action_link
-        if wizard.provider.study_sites.any?
-          govuk_link_to(
-            t("course_wizard.steps.check_answers.answers.select_study_site"),
-            change_path_for(:study_sites),
-          )
-        else
-          govuk_link_to(
-            t("course_wizard.steps.check_answers.answers.add_a_study_site"),
-            helpers.publish_provider_recruitment_cycle_study_sites_path(
-              wizard.provider_code,
-              wizard.recruitment_cycle_year,
-            ),
-          )
-        end
+      def add_a_study_site_link
+        govuk_link_to(
+          t("course_wizard.steps.check_answers.answers.add_a_study_site"),
+          helpers.publish_provider_recruitment_cycle_study_sites_path(
+            wizard.provider_code,
+            wizard.recruitment_cycle_year,
+          ),
+        )
       end
 
     private

--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -6,7 +6,7 @@ module Publish
       include CourseBasicDetailConcern
 
       def continue
-        params[:course][:study_sites_ids].compact_blank!
+        params[:course][:study_sites_ids]&.compact_blank!
         super
       end
 
@@ -43,19 +43,8 @@ module Publish
 
     private
 
-      def update_course_study_sites
-        study_site_ids = params[:course][:study_sites]
-        @study_sites ||= provider.study_sites.find(study_site_ids.compact_blank!)
-
-        course.study_sites = @study_sites.select { |site| study_site_ids.include?(site.id.to_s) }
-      end
-
       def current_step
         :study_site
-      end
-
-      def error_keys
-        [:study_sites]
       end
 
       def study_site_params

--- a/app/helpers/publish/value_helper.rb
+++ b/app/helpers/publish/value_helper.rb
@@ -5,5 +5,12 @@ module Publish
     def value_provided?(value)
       value.presence || tag.span(t("value_not_entered"), class: "govuk-hint").html_safe
     end
+
+    # For a field where having nothing is an answer rather than an omission.
+    # Reads the same as a course with no placement schools - see
+    # Publish::Schools::AttachedSchoolsSummaryComponent.
+    def value_none
+      tag.span("None", class: "app-!-colour-muted")
+    end
   end
 end

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -72,8 +72,14 @@ module Courses
       @permitted_new_course_attributes ||= CoursePolicy.new(nil, new_course).permitted_new_course_attributes
     end
 
+    # `find` raises on an empty array, and ticking nothing is a legitimate
+    # answer now that a study site is optional. It is kept for the ids that are
+    # there so one belonging to another provider is still refused.
     def study_sites
-      @study_sites ||= provider.study_sites.find(study_site_ids.compact_blank)
+      @study_sites ||= begin
+        ids = study_site_ids.compact_blank
+        ids.any? ? provider.study_sites.find(ids) : []
+      end
     end
 
     def subject_ids
@@ -147,12 +153,13 @@ module Courses
       )
     end
 
+    # A study site is optional. Nothing validates it at publish time and the
+    # edit form lets a provider clear every one off a live course, so adding a
+    # course must not be the one place that insists on it.
     def update_study_sites(course)
       return if study_site_ids.nil?
 
-      course.study_sites = study_sites if study_site_ids.any?
-
-      course.errors.add(:study_sites, message: "Select at least one study site") if study_site_ids.empty?
+      course.study_sites = study_sites
     end
 
     def assign_accrediting_provider_by_single_partner?(course)

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -137,7 +137,9 @@
          end
        end
 
-       if @provider.study_sites.any?
+       if course.is_withdrawn?
+         row.with_action
+       elsif @provider.study_sites.any?
          row.with_action(href: study_sites_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                          visually_hidden_text: "study sites")
        else

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -120,30 +120,30 @@
        end
      end
 
+     # A study site is optional, so an empty row gets the neutral treatment any
+     # other optional field gets. app-inset-text--important is reserved on this
+     # page for what stops a course publishing, and the row keeps an ordinary
+     # action so it can still be filled in.
      summary_list.with_row(html_attributes: { data: { qa: "course__study_sites" } }) do |row|
-       row.with_key { "Study site" }
+       row.with_key { "Study site (optional)" }
 
-       if course.study_sites.any?
-         row.with_value do
+       row.with_value do
+         if course.study_sites.any?
            content_tag(:ul, class: "govuk-list") do
              course.alphabetically_sorted_study_sites.map { |study_site| content_tag(:li, study_site.location_name) }.join.html_safe
            end
-         end
-       elsif @provider.study_sites.any?
-         row.with_value do
-           "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Select a study site', study_sites_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code))}</div>".html_safe
-         end
-       else
-         row.with_value do
-           "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Add a study site', publish_provider_recruitment_cycle_study_sites_path(@course.provider_code, @course.recruitment_cycle_year))}</div>".html_safe
+         else
+           value_provided?(nil)
          end
        end
 
-       if course.study_sites.any?
+       if @provider.study_sites.any?
          row.with_action(href: study_sites_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                          visually_hidden_text: "study sites")
        else
-         row.with_action
+         row.with_action(text: "Add",
+                         href: publish_provider_recruitment_cycle_study_sites_path(@course.provider_code, @course.recruitment_cycle_year),
+                         visually_hidden_text: "study sites")
        end
      end
 

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -133,7 +133,7 @@
              course.alphabetically_sorted_study_sites.map { |study_site| content_tag(:li, study_site.location_name) }.join.html_safe
            end
          else
-           value_none
+           value_provided?(nil)
          end
        end
 

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -133,7 +133,7 @@
              course.alphabetically_sorted_study_sites.map { |study_site| content_tag(:li, study_site.location_name) }.join.html_safe
            end
          else
-           value_provided?(nil)
+           value_none
          end
        end
 

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -125,7 +125,7 @@
                 <% end %>
               </ul>
             <% else %>
-              <%= value_provided?(nil) %>
+              <%= value_none %>
             <% end %>
           <% end %>
           <% if @provider.study_sites.any? %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -124,19 +124,21 @@
                   <li><%= site.location_name %></li>
                 <% end %>
               </ul>
-            <% elsif @provider.study_sites.any? %>
-              <%= "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to(t('.select_study_site'), new_publish_provider_recruitment_cycle_courses_study_sites_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)))}</div>".html_safe %>
             <% else %>
-              <%= "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to(t('.add_a_study_site'), publish_provider_recruitment_cycle_study_sites_path(@course.provider_code, @course.recruitment_cycle_year))}</div>".html_safe %>
+              <%= value_provided?(nil) %>
             <% end %>
           <% end %>
-          <% if course.study_sites.any? %>
+          <% if @provider.study_sites.any? %>
             <% row.with_action(
               href: new_publish_provider_recruitment_cycle_courses_study_sites_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
               visually_hidden_text: t(".study_sites"),
             ) %>
           <% else %>
-            <% row.with_action %>
+            <% row.with_action(
+              text: t(".add_study_site"),
+              href: publish_provider_recruitment_cycle_study_sites_path(@course.provider_code, @course.recruitment_cycle_year),
+              visually_hidden_text: t(".study_sites"),
+            ) %>
           <% end %>
         <% end %>
 

--- a/app/views/publish/courses/study_sites/edit.html.erb
+++ b/app/views/publish/courses/study_sites/edit.html.erb
@@ -1,10 +1,8 @@
-<% content_for :page_title, title_with_error_prefix("Study sites – #{course.name_and_code}", @course_study_site_form.errors.present?) %>
+<% content_for :page_title, "Study sites – #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
-
-<%= render "publish/shared/errors" %>
 
 <%= form_with(
   model: @course_study_site_form,
@@ -16,8 +14,6 @@
   method: :put,
   local: true,
 ) do |f| %>
-
-  <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/courses/study_sites/new.html.erb
+++ b/app/views/publish/courses/study_sites/new.html.erb
@@ -1,16 +1,14 @@
-<% content_for :page_title, title_with_error_prefix("Study sites", @errors && @errors.any?) %>
+<% content_for :page_title, "Study sites" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
-<%= render "publish/shared/errors" %>
-
 <%= form_for course,
   url: continue_publish_provider_recruitment_cycle_courses_study_sites_path(@provider.provider_code, course.recruitment_cycle.year, course.course_code),
   method: :get do |form| %>
   <%= render "publish/courses/new_fields_holder", form:, except_keys: [:study_sites_ids] do |fields| %>
-    <%= render "publish/shared/error_wrapper", error_keys: [:study_sites], data_qa: "course__sites" do %>
+    <div class="govuk-form-group" data-qa="course__sites">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading" data-qa="page-heading">
@@ -18,7 +16,6 @@
             Study sites
           </h1>
         </legend>
-        <%= render "publish/shared/error_messages", error_keys: [:study_sites] %>
 
         <div class="govuk-form-group govuk-!-margin-top-2">
           <div class="govuk-hint">Select all that apply</div>
@@ -35,7 +32,7 @@
 
         </div>
       </fieldset>
-    <% end %>
+    </div>
   <% end %>
 <% end %>
 

--- a/app/wizards/course_wizard/steps/study_sites.rb
+++ b/app/wizards/course_wizard/steps/study_sites.rb
@@ -8,6 +8,11 @@ class CourseWizard
 
       attribute :study_sites_ids
 
+      # A study site is optional, so picking none leaves an ordinary empty row
+      # with a Change link rather than a call to action demanding an answer.
+      # The exception is a provider with no study sites at all: the step is
+      # skipped for them, so there is nowhere for Change to go and the prompt
+      # to set one up on the organisation is the useful thing to show.
       review do |r|
         r.row(
           label: :study_site,
@@ -15,7 +20,7 @@ class CourseWizard
           value: ->(draft) { draft.study_sites.map(&:location_name) },
           format: Publish::CheckAnswers::Formatters::StudySites.new,
           show_when_blank: true,
-          changeable: ->(draft) { draft.selected_study_site_ids.any? },
+          changeable: ->(draft) { draft.wizard.provider.study_sites.any? },
         )
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -782,8 +782,6 @@ en:
               check_schools: "Review the schools for this course"
             schools:
               blank: "Select at least one school"
-            study_sites:
-              blank: "Add at least one study site"
             age_range_in_years:
               blank: "^Select an age range"
             program_type:
@@ -1234,10 +1232,6 @@ en:
               enter_schools: "Enter schools for this course"
               check_schools: "Review the schools for this course"
               school_uuids_invalid: "The schools you submitted couldn’t be validated. Please try again. If the problem persists, please contact support."
-        publish/course_study_site_form:
-          attributes:
-            study_site_ids:
-              blank: "Add at least one study site"
         publish/course_study_mode_form:
           attributes:
             study_mode:

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -259,7 +259,6 @@ en:
           cannot_sponsor: "No - cannot sponsor"
           salary_apprenticeship: "Salary (apprenticeship)"
           full_time_or_part_time: "Full time or part time"
-          select_study_site: "Select a study site"
           add_a_study_site: "Add a study site"
         labels:
           level: Subject level
@@ -279,8 +278,8 @@ en:
             salaried: Employing
             unsalaried: Placement
           study_site:
-            one: Study site
-            other: Study sites
+            one: Study site (optional)
+            other: Study sites (optional)
           accredited_provider: Accredited provider
           student_visas: Student visas
           skilled_worker_visas: Skilled Worker visas

--- a/config/locales/en/publish/courses/confirmation.yml
+++ b/config/locales/en/publish/courses/confirmation.yml
@@ -9,11 +9,10 @@ en:
           one: Subject
           other: Subjects
         study_site:
-          one: Study site
-          other: Study sites
+          one: Study site (optional)
+          other: Study sites (optional)
         study_sites: Study sites
-        select_study_site: Select a study site
-        add_a_study_site: Add a study site
+        add_study_site: Add
         student_visas: Student visas
         can_sponsor: Yes - can sponsor
         cannot_sponsor: No - cannot sponsor

--- a/spec/components/publish/check_answers/summary_component_spec.rb
+++ b/spec/components/publish/check_answers/summary_component_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe Publish::CheckAnswers::SummaryComponent, type: :component do
     allow(wizard).to receive(:saved?).with(:schools).and_return(true)
 
     expect(rendered_component).to have_text("Study sites (optional)")
+    expect(rendered_component).to have_text("None")
     expect(rendered_component).to have_no_link("Select a study site")
     expect(rendered_component).to have_selector("a[href*='return_to_review=study_sites']", text: "Change")
   end

--- a/spec/components/publish/check_answers/summary_component_spec.rb
+++ b/spec/components/publish/check_answers/summary_component_spec.rb
@@ -115,7 +115,9 @@ RSpec.describe Publish::CheckAnswers::SummaryComponent, type: :component do
     expect(rendered_component).to have_link("Change", href: /return_to_review=study_sites/)
   end
 
-  it "renders select study site CTA when none is selected but study sites exist" do
+  # Picking no study site is a valid answer, so the row stays empty and keeps an
+  # ordinary Change link rather than demanding one.
+  it "renders an empty study site row with a change link when none is selected" do
     placement_school = create(:provider_school, provider:)
     provider.study_sites.first || create(:site, :study_site, provider:)
 
@@ -126,9 +128,9 @@ RSpec.describe Publish::CheckAnswers::SummaryComponent, type: :component do
     )
     allow(wizard).to receive(:saved?).with(:schools).and_return(true)
 
-    expect(rendered_component).to have_text("Study sites")
-    expect(rendered_component).to have_link("Select a study site", href: /return_to_review=study_sites/)
-    expect(rendered_component).to have_no_selector("a[href*='return_to_review=study_sites']", text: "Change")
+    expect(rendered_component).to have_text("Study sites (optional)")
+    expect(rendered_component).to have_no_link("Select a study site")
+    expect(rendered_component).to have_selector("a[href*='return_to_review=study_sites']", text: "Change")
   end
 
   it "renders add study site CTA when provider has no study sites" do

--- a/spec/helpers/publish/value_helper_spec.rb
+++ b/spec/helpers/publish/value_helper_spec.rb
@@ -13,5 +13,11 @@ module Publish
         expect(value_provided?("")).to eq('<span class="govuk-hint">Not entered</span>')
       end
     end
+
+    describe "#value_none" do
+      it "reads the same as a course with no placement schools" do
+        expect(value_none).to eq('<span class="app-!-colour-muted">None</span>')
+      end
+    end
   end
 end

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -685,4 +685,68 @@ describe Courses::CreationService do
       end
     end
   end
+
+  # A study site is optional. Nothing validates it at publish time, and the edit
+  # form lets a provider clear every one off a live course, so adding a course
+  # must not be the one place that insists on it.
+  describe "writing selected study sites during course creation" do
+    subject(:created_course) do
+      described_class.call(course_params: valid_course_params, provider:, next_available_course_code: true)
+    end
+
+    let(:primary_subject) { find_or_create(:primary_subject, :primary) }
+
+    let(:valid_course_params) do
+      {
+        "age_range_in_years" => "3_to_7",
+        "applications_open_from" => recruitment_cycle.application_start_date,
+        "funding" => "fee",
+        "is_send" => "1",
+        "level" => "primary",
+        "qualification" => "qts",
+        "start_date" => "September #{recruitment_cycle.year}",
+        "study_mode" => %w[full_time],
+        "school_uuids" => [site.uuid],
+        "study_sites_ids" => [study_site.id],
+        "master_subject_id" => primary_subject.id,
+        "subjects_ids" => [primary_subject.id],
+      }
+    end
+
+    it "assigns the selected study sites" do
+      expect(created_course.study_sites.map(&:id)).to eq([study_site.id])
+      expect(created_course.errors).to be_empty
+    end
+
+    context "when nothing is ticked" do
+      let(:valid_course_params) { super().merge("study_sites_ids" => []) }
+
+      it "creates the course with no study sites and no error" do
+        expect(created_course.errors).to be_empty
+        expect(created_course.study_sites).to be_empty
+        expect(created_course.save).to be(true)
+      end
+    end
+
+    # A checkbox group posts a hidden blank value when nothing is ticked, so
+    # this is the shape the form actually submits.
+    context "when the checkboxes are submitted with nothing ticked" do
+      let(:valid_course_params) { super().merge("study_sites_ids" => [""]) }
+
+      it "creates the course with no study sites and no error" do
+        expect(created_course.errors).to be_empty
+        expect(created_course.study_sites).to be_empty
+        expect(created_course.save).to be(true)
+      end
+    end
+
+    context "when no study site selection is submitted at all" do
+      let(:valid_course_params) { super().except("study_sites_ids") }
+
+      it "leaves the study sites alone and adds no error" do
+        expect(created_course.errors).to be_empty
+        expect(created_course.study_sites).to be_empty
+      end
+    end
+  end
 end

--- a/spec/system/publish/courses/editing_study_sites_spec.rb
+++ b/spec/system/publish/courses/editing_study_sites_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe "updating study sites on a course" do
     expect(page).to have_link("Add a study site")
   end
 
-  def then_i_see_the_error_message_add_one_study_site
-    expect(page).to have_link("Add at least one study site")
-  end
-
   def and_i_am_authenticated_as_a_provider_user
     given_i_am_authenticated(
       user: create(
@@ -107,22 +103,6 @@ RSpec.describe "updating study sites on a course" do
 
   def and_the_study_site_checkbox_is_not_checked
     expect(page).to have_no_field(checked: true)
-  end
-
-  def given_i_click_cancel
-    click_link_or_button "Cancel"
-  end
-
-  def given_i_publish_the_course
-    click_link_or_button "Publish course"
-  end
-
-  def when_i_click_add_at_lease_one_study_site
-    click_link_or_button "Add at least one study site"
-  end
-
-  def then_i_should_be_on_the_study_sites_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/study-sites")
   end
 
   alias_method :and_there_is_a_course_i_want_to_edit, :given_a_course_exists

--- a/spec/system/publish/courses/editing_study_sites_spec.rb
+++ b/spec/system/publish/courses/editing_study_sites_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "updating study sites on a course" do
   def then_the_study_site_row_reads_as_optional_and_unanswered
     row = page.find(".govuk-summary-list__row", text: "Study site (optional)")
 
-    expect(row).to have_text("None")
+    expect(row).to have_text("Not entered")
     expect(row).to have_no_css(".app-inset-text--important")
   end
 

--- a/spec/system/publish/courses/editing_study_sites_spec.rb
+++ b/spec/system/publish/courses/editing_study_sites_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "updating study sites on a course" do
     and_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_details_page
-    then_i_see_the_add_a_study_site_link
+    then_the_study_site_row_reads_as_optional_and_unanswered
+    and_i_see_the_add_study_site_action
   end
 
   scenario "user can add and remove study sites from a course" do
@@ -28,8 +29,17 @@ RSpec.describe "updating study sites on a course" do
     expect(page).to have_text("Study sites updated")
   end
 
-  def then_i_see_the_add_a_study_site_link
-    expect(page).to have_link("Add a study site")
+  # A study site is optional, so an empty row says so plainly rather than
+  # nudging with the styling reserved for what blocks publishing.
+  def then_the_study_site_row_reads_as_optional_and_unanswered
+    row = page.find(".govuk-summary-list__row", text: "Study site (optional)")
+
+    expect(row).to have_text("Not entered")
+    expect(row).to have_no_css(".app-inset-text--important")
+  end
+
+  def and_i_see_the_add_study_site_action
+    expect(page).to have_link("Add study sites")
   end
 
   def and_i_am_authenticated_as_a_provider_user
@@ -76,7 +86,7 @@ RSpec.describe "updating study sites on a course" do
   end
 
   def and_i_click_add_study_site
-    click_link_or_button "Select a study site"
+    click_link_or_button "Change study sites"
   end
 
   def and_i_check_the_first_study_site_and_submit

--- a/spec/system/publish/courses/editing_study_sites_spec.rb
+++ b/spec/system/publish/courses/editing_study_sites_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "updating study sites on a course" do
   def then_the_study_site_row_reads_as_optional_and_unanswered
     row = page.find(".govuk-summary-list__row", text: "Study site (optional)")
 
-    expect(row).to have_text("Not entered")
+    expect(row).to have_text("None")
     expect(row).to have_no_css(".app-inset-text--important")
   end
 

--- a/spec/system/publish/viewing_a_course_details_spec.rb
+++ b/spec/system/publish/viewing_a_course_details_spec.rb
@@ -82,8 +82,9 @@ RSpec.describe "Course show" do
 
 private
 
+  # Optional fields with nothing entered yet offer "Add" rather than "Change".
   def and_there_are_change_links
-    expect(page.find_all(".govuk-summary-list__actions a").all? { |actions| actions.text.include?("Change ") }).to be(true)
+    expect(page.find_all(".govuk-summary-list__actions a").all? { |action| action.text.match?(/\A(Change|Add) /) }).to be(true)
   end
 
   def and_there_is_no_change_links
@@ -228,7 +229,7 @@ private
   end
 
   def then_i_see_the_correct_change_links
-    expect(publish_provider_courses_details_page.change_link_texts).to contain_exactly("subjects", "age range", "outcome", "if full or part time", "schools", "can sponsor skilled_worker visa")
+    expect(publish_provider_courses_details_page.change_link_texts).to contain_exactly("subjects", "age range", "outcome", "if full or part time", "schools", "study sites", "can sponsor skilled_worker visa")
   end
 
   def and_i_see_review_schools_link
@@ -243,6 +244,7 @@ private
                                                                                        "can sponsor skilled_worker visa",
                                                                                        "funding type",
                                                                                        "accredited provider",
+                                                                                       "study sites",
                                                                                        "date course starts")
   end
 
@@ -255,6 +257,7 @@ private
       "outcome",
       "if full or part time",
       "can sponsor skilled_worker visa",
+      "study sites",
       "date course starts",
     )
   end
@@ -270,6 +273,7 @@ private
       "can sponsor skilled_worker visa",
       "date course starts",
       "schools",
+      "study sites",
     )
   end
 


### PR DESCRIPTION
## Make study site optional when adding a course

Adding a course forced providers to pick a study site. It's optional everywhere else — no publish validation, and the edit form lets you clear every one off a live course.

- Drops the "Select at least one study site" guard in `Courses::CreationService` (covers both add-course flows)
- Removes the plumbing that only existed to report it: the legacy step's `error_keys`, error wrappers on both study-site views, two dead locale messages, and an orphan method with no callers
- Details page, legacy confirmation page and wizard check-answers now present it like any other optional field: labelled "(optional)", "Not entered" when empty, ordinary Change/Add action instead of the `app-inset-text--important` call to action reserved for things that block publishing

Two deliberate exceptions: a provider with no study sites on their organisation still gets an "Add a study site" prompt (the step is skipped for them, so Change has nowhere to go), and the row stays read-only on a withdrawn course.

