### PR TITLE
Remove findable scope in API for new data model

### DIFF
--- a/app/services/course_search_service_schools.rb
+++ b/app/services/course_search_service_schools.rb
@@ -25,7 +25,6 @@ class CourseSearchServiceSchools
     scope = scope.with_salary if funding_filter_salary?
     scope = scope.with_qualifications(qualifications) if qualifications.any?
     scope = scope.application_status_open if applications_open?
-    scope = scope.findable if findable?
     scope = scope.with_study_modes(study_types) if study_types.any?
     scope = scope.with_subjects(subject_codes) if subject_codes.any?
     scope = scope.with_provider_name(provider_name) if provider_name.present?
@@ -204,10 +203,6 @@ private
 
   def applications_open?
     filter[:applications_open].to_s.downcase == "true"
-  end
-
-  def findable?
-    filter[:findable].to_s.downcase == "true"
   end
 
   def study_types

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -253,6 +253,28 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
           expect(ids).to include(near_course.id.to_s)
           expect(ids).not_to include(far_course.id.to_s)
         end
+
+        context "when the findable filter is requested for 2027" do
+          before do
+            get :index, params: {
+              recruitment_cycle_year: provider.recruitment_cycle.year,
+              provider_code: provider.provider_code,
+              filter: {
+                findable: true,
+                latitude: 51.5074,
+                longitude: -0.1278,
+                radius: 10,
+              },
+            }
+          end
+
+          it "returns courses using schools from the new data model" do
+            ids = json_response["data"].map { |course| course["id"] }
+
+            expect(ids).to include(near_course.id.to_s)
+            expect(ids).not_to include(far_course.id.to_s)
+          end
+        end
       end
     end
 

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -254,7 +254,9 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
           expect(ids).not_to include(far_course.id.to_s)
         end
 
-        context "when the findable filter is requested for 2027" do
+        context "when the findable filter is requested for after the remodel cutover year" do
+          let(:provider) { create(:provider, recruitment_cycle: find_or_create(:recruitment_cycle, year: Settings.schools_remodel_cycle_year + 1)) }
+
           before do
             get :index, params: {
               recruitment_cycle_year: provider.recruitment_cycle.year,

--- a/spec/services/course_search_service_schools_spec.rb
+++ b/spec/services/course_search_service_schools_spec.rb
@@ -349,11 +349,10 @@ RSpec.describe CourseSearchServiceSchools do
     describe "filter[findable]" do
       context "when true" do
         let(:filter) { { findable: true } }
-        let(:expected_scope) { double }
 
-        it "adds the findable scope" do
-          expect(scope).to receive(:findable).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
+        it "does not apply the legacy site status scope" do
+          expect(scope).not_to receive(:findable)
+          expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end


### PR DESCRIPTION
## Context

The 2027 school data model uses `Course::School` rather than legacy `site_status` records.

`CourseSearchServiceSchools` still applied the legacy `findable` scope when requested by API consumers. This could exclude valid 2027 courses from location-based API results because the scope depends on `site_status`.

## Changes proposed in this pull request

- Remove the legacy `findable` scope from `CourseSearchServiceSchools`.
- Remove the now-unused `findable?` helper.
- Confirm `findable: true` no longer applies the legacy scope.
- Add API coverage confirming 2027 location searches return courses using the new school data model.

There are no UI changes.

## Guidance to review

Run:

```shell
bundle exec rspec spec/services/course_search_service_schools_spec.rb spec/controllers/api/public/v1/providers/courses_controller_spec.rb
```

Review that:
- The legacy search service remains unchanged.
- The 2027 API still accepts `findable: true`.
- Location filtering uses attached `Course::School` records.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.