### PR TITLE
pin rails_semantic_logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem "sidekiq", "~> 6.5"
 gem "sidekiq-cron"
 
 # Semantic Logger makes logs pretty
-gem "rails_semantic_logger"
+gem "rails_semantic_logger", "~> 4.20.0"
 
 # Render nice markdown
 gem "redcarpet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,10 +578,10 @@ GEM
     rails-html-sanitizer (1.7.1)
       loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails_semantic_logger (5.1.0)
+    rails_semantic_logger (4.20.0)
       rack
-      railties (>= 7.2)
-      semantic_logger (>= 5.1)
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     railties (8.1.3.1)
       actionpack (= 8.1.3.1)
       activesupport (= 8.1.3.1)
@@ -717,7 +717,7 @@ GEM
     schema_to_scaffold (0.8.0)
       activesupport (>= 3.2.1)
     securerandom (0.4.1)
-    semantic_logger (5.1.0)
+    semantic_logger (4.18.0)
       concurrent-ruby (~> 1.0)
     sentry-rails (6.7.0)
       railties (>= 5.2.0)
@@ -883,7 +883,7 @@ DEPENDENCIES
   rack-cors
   rails (= 8.1.3.1)
   rails-erd
-  rails_semantic_logger
+  rails_semantic_logger (~> 4.20.0)
   rb-readline
   redcarpet
   request_store


### PR DESCRIPTION
## Context

`rails_semantic_logger` 5.1.0 references `Sidekiq::Config`, which is unavailable in the application’s pinned Sidekiq 6.5 version.


Pinned `rails_semantic_logger` to `~> 4.20.0` and downgraded:

- `rails_semantic_logger`: 5.1.0 → 4.20.0
- `semantic_logger`: 5.1.0 → 4.18.0

Sidekiq now boots successfully with 6.5.12.

This caused the Sidekiq worker to fail during startup. Because `bin/dev` stops all processes when one exits, the entire local development environment shut down.

## Changes proposed in this pull request

- Pin `rails_semantic_logger` to `~> 4.20.0`.
- Downgrade `semantic_logger` to the compatible 4.18.0 version.
- Update `Gemfile.lock`.

There are no UI changes.

## Guidance to review

Run:

```shell
bundle install
bin/dev
```

Confirm Sidekiq boots without the `uninitialized constant Sidekiq::Config` error and the development services remain running.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.