### PR TITLE
School remodel: Sync uuid after rollover automagically

### DIFF
--- a/app/services/provider_schools/sync_legacy_site_uuids.rb
+++ b/app/services/provider_schools/sync_legacy_site_uuids.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module ProviderSchools
+  # Keeps Provider::School UUIDs aligned with their copied legacy Site rows during
+  # rollover, while course school updates still dual-write to SiteStatus.
+  # TODO School data remodel removal - delete when Provider::School UUIDs no longer map to legacy Sites.
+  class SyncLegacySiteUuids
+    include ServicePattern
+
+    class LegacySiteMismatchError < StandardError; end
+
+    def initialize(provider:)
+      @provider = provider
+    end
+
+    def call
+      provider_schools.find_each do |provider_school|
+        legacy_site_uuid = legacy_site_uuid_for(provider_school)
+        next if provider_school.uuid == legacy_site_uuid
+
+        provider_school.update!(uuid: legacy_site_uuid)
+      end
+    end
+
+  private
+
+    attr_reader :provider
+
+    def provider_schools
+      Provider::School.where(provider:).includes(:gias_school)
+    end
+
+    def legacy_site_uuid_for(provider_school)
+      legacy_site_uuids = legacy_site_uuids_by_identity.fetch(identity_for(provider_school), [])
+      return legacy_site_uuids.first if legacy_site_uuids.one?
+
+      raise LegacySiteMismatchError, mismatch_message(provider_school, legacy_site_uuids)
+    end
+
+    def legacy_site_uuids_by_identity
+      @legacy_site_uuids_by_identity ||= Site.school.kept.where(provider:)
+        .pluck(:urn, :code, :uuid)
+        .each_with_object({}) do |(urn, code, uuid), index|
+          (index[[urn, code]] ||= []) << uuid
+        end
+    end
+
+    def identity_for(provider_school)
+      [provider_school.gias_school.urn, provider_school.site_code]
+    end
+
+    def mismatch_message(provider_school, legacy_site_uuids)
+      count = legacy_site_uuids.size
+      "expected one legacy site for provider=#{provider.id} " \
+        "provider_school=#{provider_school.id} " \
+        "site_code=#{provider_school.site_code} " \
+        "urn=#{provider_school.gias_school.urn.inspect}, found #{count}"
+    end
+  end
+end

--- a/app/services/provider_schools/sync_legacy_site_uuids.rb
+++ b/app/services/provider_schools/sync_legacy_site_uuids.rb
@@ -18,7 +18,7 @@ module ProviderSchools
         legacy_site_uuid = legacy_site_uuid_for(provider_school)
         next if provider_school.uuid == legacy_site_uuid
 
-        provider_school.update!(uuid: legacy_site_uuid)
+        provider_school.update_columns(uuid: legacy_site_uuid)
       end
     end
 

--- a/app/services/rollover/schools/dual_provider_copier.rb
+++ b/app/services/rollover/schools/dual_provider_copier.rb
@@ -3,21 +3,23 @@
 module Rollover
   module Schools
     class DualProviderCopier
-      def initialize(legacy_copier:, new_copier:)
+      def initialize(legacy_copier:, new_copier:, uuid_syncer: ProviderSchools::SyncLegacySiteUuids)
         @legacy_copier = legacy_copier
         @new_copier = new_copier
+        @uuid_syncer = uuid_syncer
       end
 
       def execute(provider:, new_provider:)
         legacy_result = legacy_copier.execute(provider:, new_provider:)
         new_copier.execute(provider:, new_provider:)
+        uuid_syncer.call(provider: new_provider)
 
         legacy_result
       end
 
     private
 
-      attr_reader :legacy_copier, :new_copier
+      attr_reader :legacy_copier, :new_copier, :uuid_syncer
     end
   end
 end

--- a/spec/services/provider_schools/sync_legacy_site_uuids_spec.rb
+++ b/spec/services/provider_schools/sync_legacy_site_uuids_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProviderSchools::SyncLegacySiteUuids do
+  subject(:sync_uuids) { described_class.call(provider:) }
+
+  let(:provider) { create(:provider) }
+  let(:gias_school) { create(:gias_school, :open, urn: "123456") }
+  let!(:legacy_site) { create(:site, provider:, code: "A", urn: gias_school.urn) }
+  let!(:provider_school) do
+    create(
+      :provider_school,
+      provider:,
+      gias_school:,
+      site_code: legacy_site.code,
+      uuid: SecureRandom.uuid,
+    )
+  end
+
+  it "rewrites the provider school UUID to match the legacy site UUID" do
+    expect { sync_uuids }
+      .to change { provider_school.reload.uuid }
+      .to(legacy_site.uuid)
+  end
+
+  it "does not rewrite an already aligned provider school UUID" do
+    provider_school.update!(uuid: legacy_site.uuid)
+
+    expect { sync_uuids }
+      .not_to(change { provider_school.reload.updated_at })
+  end
+
+  it "matches by provider, site code and GIAS URN" do
+    other_provider = create(:provider)
+    create(:site, provider: other_provider, code: legacy_site.code, urn: gias_school.urn)
+
+    sync_uuids
+
+    expect(provider_school.reload.uuid).to eq(legacy_site.uuid)
+  end
+
+  context "when no matching legacy site exists" do
+    before { legacy_site.destroy! }
+
+    it "raises a mismatch error" do
+      expect { sync_uuids }
+        .to raise_error(
+          described_class::LegacySiteMismatchError,
+          /expected one legacy site for provider=#{provider.id}/,
+        )
+    end
+  end
+end

--- a/spec/services/rollover/schools/dual_provider_copier_spec.rb
+++ b/spec/services/rollover/schools/dual_provider_copier_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe Rollover::Schools::DualProviderCopier do
 
   let(:provider) { create(:provider) }
   let(:new_provider) { create(:provider, recruitment_cycle: create(:recruitment_cycle, :next)) }
-  let!(:legacy_site) { create(:site, :with_gias_school, provider:, code: "S") }
-  let!(:provider_school) { create(:provider_school, provider:, site_code: "B") }
+  let(:gias_school) { create(:gias_school, :open) }
+  let!(:legacy_site) { create(:site, provider:, code: "S", urn: gias_school.urn) }
+  let!(:provider_school) { create(:provider_school, provider:, gias_school:, site_code: legacy_site.code) }
 
   it "copies both legacy Site and new Provider::School records" do
     expect { copy_schools }
@@ -24,6 +25,15 @@ RSpec.describe Rollover::Schools::DualProviderCopier do
     expect(new_provider.schools.pluck(:gias_school_id, :site_code)).to contain_exactly(
       [provider_school.gias_school_id, provider_school.site_code],
     )
+  end
+
+  it "syncs the copied Provider::School UUID to the copied legacy Site UUID" do
+    copy_schools
+
+    copied_site = new_provider.sites.find_by!(code: legacy_site.code)
+    copied_provider_school = new_provider.schools.find_by!(gias_school:, site_code: legacy_site.code)
+
+    expect(copied_provider_school.uuid).to eq(copied_site.uuid)
   end
 
   it "returns the legacy result used by rollover reporting" do


### PR DESCRIPTION
## Context

We have to run the backfill after every rollover at the moment and manual rollover is also broken due to the divergence of the uuid field in both models. This will fix it by updating the new provider_schools and changing the uuid

## Changes proposed in this pull request

- Create a service that updated the uuid of the provider_school to match the site table
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
