### PR TITLE
Update SchoolPresenceExemption to allow fee paying courses

### DIFF
--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -102,11 +102,8 @@ module Support
       ActiveModel::Type::Boolean.new.cast(is_send)
     end
 
-    # Only salaried and apprenticeship courses can be exempted from needing
-    # schools attached at publish time, so refuse to set the flag on any other
-    # funding type even if a value is submitted.
     def publish_without_schools_allowed?
-      course.decorate.salaried? && ActiveModel::Type::Boolean.new.cast(publish_without_schools_allowed)
+      ActiveModel::Type::Boolean.new.cast(publish_without_schools_allowed)
     end
 
     def validate_start_date_format

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -953,10 +953,10 @@ class Course < ApplicationRecord
     !no_visa_sponsorship?
   end
 
-  # A salaried/apprenticeship course that support has approved to publish without
-  # an employing school (candidates already have a placement arranged) and which
-  # has no school attached. Find presents these differently so it does not prompt
-  # candidates to look for an employing school that will never be listed.
+  # Any course that support has approved to publish without an employing school
+  # (candidates already have a placement arranged) and which has no school
+  # attached. Find presents these differently so it does not prompt candidates
+  # to look for an employing school that will never be listed.
   def without_employing_school?
     Courses::PublishRules::SchoolPresenceExemption.applies?(self) &&
       schools.none?

--- a/app/services/courses/publish_rules/school_presence_exemption.rb
+++ b/app/services/courses/publish_rules/school_presence_exemption.rb
@@ -10,11 +10,8 @@
 module Courses
   module PublishRules
     class SchoolPresenceExemption
-      EXEMPT_FUNDINGS = %w[salary apprenticeship].freeze
-
       def self.applies?(course)
-        course.publish_without_schools_allowed? &&
-          EXEMPT_FUNDINGS.include?(course.funding)
+        course.publish_without_schools_allowed?
       end
 
       # Courses whose API locations fall back to the provider's schools
@@ -22,7 +19,7 @@ module Courses
       # write changes their payload.
       def self.falling_back_to_provider_schools(provider)
         provider.courses
-                .where(publish_without_schools_allowed: true, funding: EXEMPT_FUNDINGS)
+                .where(publish_without_schools_allowed: true)
                 .where.missing(:schools)
       end
     end

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -52,13 +52,11 @@
 
       <% end %>
 
-      <% if @course.decorate.salaried? %>
-        <%= f.govuk_check_boxes_fieldset :publish_without_schools_allowed,
-              legend: { text: "Publishing this course without schools" },
-              hint: { text: "Only tick this box if you have confirmed that this provider is allowed to publish courses without schools attached." },
-              multiple: false do %>
-          <% f.govuk_check_box :publish_without_schools_allowed, "true", "false", label: { text: "Allow this course to be published without schools attached" }, multiple: false %>
-        <% end %>
+      <%= f.govuk_check_boxes_fieldset :publish_without_schools_allowed,
+            legend: { text: "Publishing this course without schools" },
+            hint: { text: "Only tick this box if you have confirmed that this provider is allowed to publish courses without schools attached." },
+            multiple: false do %>
+        <% f.govuk_check_box :publish_without_schools_allowed, "true", "false", label: { text: "Allow this course to be published without schools attached" }, multiple: false %>
       <% end %>
 
       <%= f.govuk_submit t("support.update_record") %>

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     context "when funding is 'fee'" do
       let(:funding) { :fee }
 
-      it "does not show 'No employing schools listed' (fee courses are never exempt)" do
-        expect(summary_card_content).not_to include("No employing schools listed")
+      it "shows 'No employing schools listed' as the value" do
+        expect(summary_card_content).to include("No employing schools listed")
       end
     end
 

--- a/spec/components/saved_courses/summary_card_component_spec.rb
+++ b/spec/components/saved_courses/summary_card_component_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe SavedCourses::SummaryCardComponent, type: :component do
     context "when funding is 'fee'" do
       let(:funding) { :fee }
 
-      it "does not show 'No employing schools listed' (fee courses are never exempt)" do
-        expect(summary_card_content).not_to include("No employing schools listed")
+      it "shows 'No employing schools listed' as the value" do
+        expect(summary_card_content).to include("No employing schools listed")
       end
     end
 

--- a/spec/controllers/api/public/v1/providers/courses/locations_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses/locations_controller_spec.rb
@@ -149,7 +149,30 @@ RSpec.describe API::Public::V1::Providers::Courses::LocationsController do
       end
     end
 
-    context "when a fee-paying course has no schools and is not exempt" do
+    context "when a fee-paying course has one course school and is exempt from needing them" do
+      let(:course) { create(:course, :fee, provider:, publish_without_schools_allowed: true) }
+
+      before do
+        create(:course_school, course:)
+        create_list(:provider_school, 2, provider:)
+
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+          course_code: course.course_code,
+        }
+      end
+
+      it "returns the course schools" do
+        expect(json_response["data"].size).to be(1)
+      end
+
+      it "flags in the meta that the locations are the course's own schools" do
+        expect(json_response["meta"]).to eq("has_course_schools" => true)
+      end
+    end
+
+    context "when a fee-paying course has no schools and is exempt from needing them" do
       let(:course) { create(:course, :fee, provider:, publish_without_schools_allowed: true) }
 
       before do
@@ -162,8 +185,12 @@ RSpec.describe API::Public::V1::Providers::Courses::LocationsController do
         }
       end
 
-      it "does not fall back to the provider's schools" do
-        expect(json_response["data"]).to eql([])
+      it "returns the provider fallback" do
+        expect(json_response["data"].size).to be(2)
+      end
+
+      it "flags in the meta says that the locations are the providers schools" do
+        expect(json_response["meta"]).to eq("has_course_schools" => false)
       end
     end
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -5,7 +5,9 @@ FactoryBot.define do
     provider_name { "ACME SCITT#{rand(1_000_000)}" }
 
     sequence(:provider_code) do |n|
-      ProviderCodeGenerator.new(n).call
+      # Avoid generating "I30" code by chance This code has specific
+      # and unique GCSE grade requirements that can cause flaky tests
+      ProviderCodeGenerator.new(n).call(avoid: %w[I30])
     end
 
     trait :with_anonymised_data do
@@ -81,6 +83,10 @@ FactoryBot.define do
 
     trait :previous_recruitment_cycle do
       recruitment_cycle { find_or_create :recruitment_cycle, :previous }
+    end
+
+    trait :gcse_grade_5 do
+      provider_code { "I30" }
     end
 
     trait :published_scitt do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2905,6 +2905,12 @@ describe Course do
       expect(course.without_employing_school?).to be(true)
     end
 
+    it "is true for an exempt fee course with no school attached" do
+      course = create(:course, :fee, publish_without_schools_allowed: true)
+
+      expect(course.without_employing_school?).to be(true)
+    end
+
     it "is false when a school is attached" do
       course = create(:course, :with_salary, publish_without_schools_allowed: true)
       create(:course_school, course:)
@@ -2914,12 +2920,6 @@ describe Course do
 
     it "is false when publish_without_schools_allowed is false" do
       course = create(:course, :with_salary, publish_without_schools_allowed: false)
-
-      expect(course.without_employing_school?).to be(false)
-    end
-
-    it "is false for fee courses" do
-      course = create(:course, :fee, publish_without_schools_allowed: true)
 
       expect(course.without_employing_school?).to be(false)
     end

--- a/spec/requests/support/courses_spec.rb
+++ b/spec/requests/support/courses_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe "Support::Courses publish_without_schools_allowed", travel: mid_c
       expect(course.reload.publish_without_schools_allowed).to be(true)
     end
 
-    it "ignores the flag for a fee course" do
-      course = create(:course, funding: "fee", provider:)
+    it "allows a fee course to be published without schools" do
+      course = create(:course, :fee, provider:)
       login_user(admin)
 
       update_course(course)
 
-      expect(course.reload.publish_without_schools_allowed).to be(false)
+      expect(course.reload.publish_without_schools_allowed).to be(true)
     end
   end
 

--- a/spec/services/courses/publish_rules/school_presence_exemption_spec.rb
+++ b/spec/services/courses/publish_rules/school_presence_exemption_spec.rb
@@ -16,8 +16,8 @@ describe Courses::PublishRules::SchoolPresenceExemption do
       expect(described_class.applies?(course_with(funding: :apprenticeship, allowed: true))).to be(true)
     end
 
-    it "does not apply to a fee-paying course, even when allowed" do
-      expect(described_class.applies?(course_with(funding: :fee, allowed: true))).to be(false)
+    it "applies to a fee-paying course support has allowed to publish without schools" do
+      expect(described_class.applies?(course_with(funding: :fee, allowed: true))).to be(true)
     end
 
     it "does not apply to a salaried course support has not allowed" do
@@ -33,32 +33,27 @@ describe Courses::PublishRules::SchoolPresenceExemption do
     let(:provider) { create(:provider) }
 
     it "returns exempt courses with no schools of their own" do
-      salaried = create(:course, :with_salary, provider:, publish_without_schools_allowed: true)
+      salaried = create(:course, provider:, publish_without_schools_allowed: true)
       apprenticeship = create(:course, :with_apprenticeship, provider:, publish_without_schools_allowed: true)
+      fee = create(:course, :fee, provider:, publish_without_schools_allowed: true)
 
-      expect(described_class.falling_back_to_provider_schools(provider)).to contain_exactly(salaried, apprenticeship)
+      expect(described_class.falling_back_to_provider_schools(provider)).to contain_exactly(salaried, apprenticeship, fee)
     end
 
     it "excludes an exempt course that has its own schools" do
-      create(:course, :with_salary, :with_2_schools, provider:, publish_without_schools_allowed: true)
+      create(:course, :with_2_schools, provider:, publish_without_schools_allowed: true)
 
       expect(described_class.falling_back_to_provider_schools(provider)).to be_empty
     end
 
     it "excludes a course support has not allowed to publish without schools" do
-      create(:course, :with_salary, provider:, publish_without_schools_allowed: false)
-
-      expect(described_class.falling_back_to_provider_schools(provider)).to be_empty
-    end
-
-    it "excludes a fee-paying course, even when allowed" do
-      create(:course, :fee, provider:, publish_without_schools_allowed: true)
+      create(:course, provider:, publish_without_schools_allowed: false)
 
       expect(described_class.falling_back_to_provider_schools(provider)).to be_empty
     end
 
     it "excludes another provider's courses" do
-      create(:course, :with_salary, publish_without_schools_allowed: true)
+      create(:course, publish_without_schools_allowed: true)
 
       expect(described_class.falling_back_to_provider_schools(provider)).to be_empty
     end

--- a/spec/support/provider_code_generator.rb
+++ b/spec/support/provider_code_generator.rb
@@ -4,16 +4,18 @@ class ProviderCodeGenerator
   def initialize(sequence_number)
     @sequence_number = sequence_number
     @existing_codes = Provider.pluck(:provider_code).to_set
+    @unwanted_codes = @existing_codes
   end
 
-  def call
+  def call(avoid: [])
     attempt_count = 0
     possible_code = nil
+    @unwanted_codes += avoid
 
-    until possible_code && @existing_codes.exclude?(possible_code)
+    until possible_code && @unwanted_codes.exclude?(possible_code)
       possible_code = sprintf("#{('A'..'Z').to_a.sample}%02d", @sequence_number % 100)
 
-      if @existing_codes.include?(possible_code)
+      if @unwanted_codes.include?(possible_code)
         attempt_count += 1
         Rails.logger.warn("ProviderCodeGenerator: Collision detected for #{possible_code}, retrying (attempt ##{attempt_count})")
       end

--- a/spec/system/publish/courses/gcse_equivalency_spec.rb
+++ b/spec/system/publish/courses/gcse_equivalency_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "GCSE equivalency requirements" do
   scenario "a provider views course pages with course 2 GCSE requirements" do
     given_i_am_authenticated(user: user_with_courses)
     when_i_visit_the_course_page(course: course2)
+
     then_i_see_course_2_gcse_requirements
   end
 
@@ -35,7 +36,14 @@ RSpec.describe "GCSE equivalency requirements" do
     given_i_am_authenticated(user: user_with_courses)
     when_i_visit_the_course_page(course: course3)
 
-    then_i_see_course_3_gcse_requirements
+    then_i_see_course_3_gcse_requirements(grade: 4)
+  end
+
+  scenario "a provider with Grade 5 GCSE requirements" do
+    given_i_am_authenticated(user: user_with_courses(:gcse_grade_5))
+    when_i_visit_the_course_page(course: course3)
+
+    then_i_see_course_3_gcse_requirements(grade: 5)
   end
 
   scenario "a provider has completed the pending GCSE & equivalency requirements and sees their answer pre-populated on the gcse requirements page" do
@@ -48,63 +56,38 @@ RSpec.describe "GCSE equivalency requirements" do
   scenario "a provider copies gcse data from another course with all fields" do
     given_i_am_authenticated(user: user_with_courses)
     when_i_visit_the_course_publish_courses_gcse_requirements_page(course:)
-    publish_courses_gcse_requirements_page.copy_content.copy(course3)
+    and_i_copy_the_content_from(course3)
 
-    [
-      "Your changes are not yet saved",
-      "Accept pending GCSE",
-      "Accept GCSE equivalency",
-      "Accept English GCSE equivalency",
-      "Accept Maths GCSE equivalency",
-      "Additional GCSE equivalencies",
-    ].each do |name|
-      expect(publish_courses_gcse_requirements_page.copy_content_warning).to have_content(name)
-    end
-
-    expect(publish_courses_gcse_requirements_page.pending_gcse_yes_radio).to be_checked
-    expect(publish_courses_gcse_requirements_page.gcse_equivalency_yes_radio).to be_checked
-    expect(publish_courses_gcse_requirements_page.english_equivalency).to be_checked
-    expect(publish_courses_gcse_requirements_page.maths_equivalency).to be_checked
-    expect(publish_courses_gcse_requirements_page.additional_requirements.value).to eq course3.additional_gcse_equivalencies
+    then_i_see_the_copied_fields_warning
+    and_i_see_the_form_pre_populated
   end
 
   scenario "a provider copies gcse data from another course with missing fields" do
     given_i_am_authenticated(user: user_with_courses)
     when_i_visit_the_course_publish_courses_gcse_requirements_page(course:)
-    publish_courses_gcse_requirements_page.copy_content.copy(course2)
+    and_i_copy_the_content_from(course2)
 
-    expect(publish_courses_gcse_requirements_page).not_to have_copy_content_warning
-    expect(publish_courses_gcse_requirements_page.pending_gcse_no_radio).to be_checked
-    expect(publish_courses_gcse_requirements_page.gcse_equivalency_no_radio).to be_checked
-    expect(publish_courses_gcse_requirements_page.english_equivalency).not_to be_checked
-    expect(publish_courses_gcse_requirements_page.maths_equivalency).not_to be_checked
-    expect(publish_courses_gcse_requirements_page.additional_requirements.text).to eq("")
+    then_i_do_not_see_the_copied_fields_warning
+    and_i_see_the_form_is_empty
   end
 
 private
 
-  def user_with_courses
-    course = build(:course, :secondary, course_code: "XXX1", additional_gcse_equivalencies: "")
-    course2 = build(:course, :primary, course_code: "XXX2", accept_pending_gcse: false, accept_gcse_equivalency: false, additional_gcse_equivalencies: nil)
-    course3 = build(:course, :secondary,
-                    course_code: "XXX3", accept_pending_gcse: true, accept_gcse_equivalency: true,
-                    accept_english_gcse_equivalency: true, accept_maths_gcse_equivalency: true, accept_science_gcse_equivalency: nil,
-                    additional_gcse_equivalencies: "Cycling Proficiency")
+  def user_with_courses(*provider_traits)
+    provider = build(:provider, *provider_traits, courses: gcse_courses)
 
-    provider = build(
-      :provider, courses: [course, course2, course3]
-    )
-
-    create(
-      :user,
-      providers: [provider],
-    )
+    create(:user, providers: [provider])
   end
 
-  def when_i_visit_the_course_publish_courses_gcse_requirements_page(course:)
-    publish_courses_gcse_requirements_page.load(
-      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
-    )
+  def gcse_courses
+    [
+      build(:course, :secondary, course_code: "XXX1", additional_gcse_equivalencies: ""),
+      build(:course, :primary, course_code: "XXX2", accept_pending_gcse: false, accept_gcse_equivalency: false, additional_gcse_equivalencies: nil),
+      build(:course, :secondary,
+            course_code: "XXX3", accept_pending_gcse: true, accept_gcse_equivalency: true,
+            accept_english_gcse_equivalency: true, accept_maths_gcse_equivalency: true, accept_science_gcse_equivalency: nil,
+            additional_gcse_equivalencies: "Cycling Proficiency"),
+    ]
   end
 
   def provider
@@ -123,17 +106,20 @@ private
     @course3 ||= provider.courses.find_by(course_code: "XXX3")
   end
 
-  def when_i_visit_the_course_page(course:)
-    publish_provider_courses_show_page.load(
+  def gcse_requirements_page
+    publish_courses_gcse_requirements_page
+  end
+
+  def when_i_visit_the_course_publish_courses_gcse_requirements_page(course:)
+    gcse_requirements_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
     )
   end
 
-  def then_i_see_course_3_gcse_requirements
-    expect(page).to have_content("Grade 4 (C) or above in English and maths")
-    expect(page).to have_content("Candidates with pending GCSEs will be considered")
-    expect(page).to have_content("Equivalency tests will be accepted in English or maths")
-    expect(page).to have_content("Cycling Proficiency")
+  def when_i_visit_the_course_page(course:)
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
   end
 
   def then_i_see_course_2_gcse_requirements
@@ -142,16 +128,51 @@ private
     expect(page).to have_content("Equivalency tests will not be accepted")
   end
 
+  def then_i_see_course_3_gcse_requirements(grade:)
+    expect(page).to have_content("Grade #{grade} (C) or above in English and maths")
+    expect(page).to have_content("Candidates with pending GCSEs will be considered")
+    expect(page).to have_content("Equivalency tests will be accepted in English or maths")
+    expect(page).to have_content("Cycling Proficiency")
+  end
+
   def then_i_see_the_form_pre_populated
-    expect(publish_courses_gcse_requirements_page.pending_gcse_yes_radio).to be_checked
-    expect(publish_courses_gcse_requirements_page.gcse_equivalency_yes_radio).to be_checked
-    expect(publish_courses_gcse_requirements_page.english_equivalency).to be_checked
-    expect(publish_courses_gcse_requirements_page.maths_equivalency).to be_checked
-    expect(publish_courses_gcse_requirements_page.additional_requirements).to have_content("Cycling Proficiency")
+    expect(gcse_requirements_page.pending_gcse_yes_radio).to be_checked
+    expect(gcse_requirements_page.gcse_equivalency_yes_radio).to be_checked
+    expect(gcse_requirements_page.english_equivalency).to be_checked
+    expect(gcse_requirements_page.maths_equivalency).to be_checked
+    expect(gcse_requirements_page.additional_requirements.value).to eq("Cycling Proficiency")
+  end
+  alias_method :and_i_see_the_form_pre_populated, :then_i_see_the_form_pre_populated
+
+  def and_i_see_the_form_is_empty
+    expect(gcse_requirements_page.pending_gcse_no_radio).to be_checked
+    expect(gcse_requirements_page.gcse_equivalency_no_radio).to be_checked
+    expect(gcse_requirements_page.english_equivalency).not_to be_checked
+    expect(gcse_requirements_page.maths_equivalency).not_to be_checked
+    expect(gcse_requirements_page.additional_requirements.value).to eq("")
+  end
+
+  def and_i_copy_the_content_from(course)
+    gcse_requirements_page.copy_content.copy(course)
+  end
+
+  def then_i_see_the_copied_fields_warning
+    warning = gcse_requirements_page.copy_content_warning
+
+    expect(warning).to have_content("Your changes are not yet saved")
+    expect(warning).to have_content("Accept pending GCSE")
+    expect(warning).to have_content("Accept GCSE equivalency")
+    expect(warning).to have_content("Accept English GCSE equivalency")
+    expect(warning).to have_content("Accept Maths GCSE equivalency")
+    expect(warning).to have_content("Additional GCSE equivalencies")
+  end
+
+  def then_i_do_not_see_the_copied_fields_warning
+    expect(gcse_requirements_page).not_to have_copy_content_warning
   end
 
   def and_i_click_save
-    publish_courses_gcse_requirements_page.save.click
+    gcse_requirements_page.save.click
   end
 
   def and_i_see_pending_gcse_and_equivalency_tests_errors
@@ -160,12 +181,12 @@ private
   end
 
   def and_i_set_the_gcse_requirements
-    publish_courses_gcse_requirements_page.pending_gcse_yes_radio.click
-    publish_courses_gcse_requirements_page.gcse_equivalency_yes_radio.click
+    gcse_requirements_page.pending_gcse_yes_radio.click
+    gcse_requirements_page.gcse_equivalency_yes_radio.click
   end
 
   def and_there_is_no_science_equivalency
-    expect(publish_courses_gcse_requirements_page).not_to have_science_equivalency
+    expect(gcse_requirements_page).not_to have_science_equivalency
   end
 
   def and_i_see_equivalency_errors
@@ -180,22 +201,20 @@ private
   end
 
   def when_i_fill_the_equivalency_requirements
-    publish_courses_gcse_requirements_page.english_equivalency.check
-    publish_courses_gcse_requirements_page.maths_equivalency.check
-    publish_courses_gcse_requirements_page.additional_requirements.set("Cycling Proficiency")
+    gcse_requirements_page.english_equivalency.check
+    gcse_requirements_page.maths_equivalency.check
+    gcse_requirements_page.additional_requirements.set("Cycling Proficiency")
   end
 
-  def and_i_am_on_the_course_page
+  def then_i_am_on_the_course_page
     expect(page).to have_current_path publish_provider_recruitment_cycle_course_path(
       provider.provider_code,
       course.recruitment_cycle.year,
       course.course_code,
     )
   end
-  alias_method :then_i_am_on_the_course_page, :and_i_am_on_the_course_page
 
   def and_i_see_the_success_summary
-    expect(publish_provider_courses_index_page.success_summary).to have_content(I18n.t("success.saved", value: "GCSE requirements"))
+    expect(publish_provider_courses_index_page.success_summary).to have_content("GCSE requirements updated")
   end
-  alias_method :then_i_see_the_success_summary, :and_i_see_the_success_summary
 end

--- a/spec/system/support/providers/courses/editing_publish_without_schools_spec.rb
+++ b/spec/system/support/providers/courses/editing_publish_without_schools_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe "Editing publish without schools as support", travel: mid_cycle d
     end
   end
 
+  context "when the course details are invalid" do
+    scenario "my ticked publish without schools checkbox survives the error" do
+      when_i_visit_the_edit_page_for(salaried_course)
+      when_i_tick_the_publish_without_schools_checkbox
+      and_i_enter_an_invalid_start_date
+      and_i_click_the_update_button
+      then_i_see_a_start_date_error
+      and_the_publish_without_schools_checkbox_is_still_ticked
+    end
+  end
+
   context "with an apprenticeship course" do
     scenario "I see the publish without schools checkbox" do
       when_i_visit_the_edit_page_for(apprenticeship_course)
@@ -27,9 +38,9 @@ RSpec.describe "Editing publish without schools as support", travel: mid_cycle d
   end
 
   context "with a fee course" do
-    scenario "the publish without schools checkbox is not available" do
+    scenario "I see the publish without schools checkbox" do
       when_i_visit_the_edit_page_for(fee_course)
-      then_i_do_not_see_the_publish_without_schools_checkbox
+      then_i_see_the_publish_without_schools_checkbox
     end
   end
 
@@ -71,11 +82,6 @@ private
     expect(support_provider_course_edit_page).to have_text("Allow this course to be published without schools attached")
   end
 
-  def then_i_do_not_see_the_publish_without_schools_checkbox
-    expect(support_provider_course_edit_page).to have_no_publish_without_schools_allowed_checkbox
-    expect(support_provider_course_edit_page).to have_no_text("Publishing this course without schools")
-  end
-
   def when_i_tick_the_publish_without_schools_checkbox
     support_provider_course_edit_page.publish_without_schools_allowed_checkbox.check
   end
@@ -84,11 +90,25 @@ private
     support_provider_course_edit_page.continue.click
   end
 
+  def and_i_enter_an_invalid_start_date
+    support_provider_course_edit_page.start_date_month.set("13")
+  end
+
+  def then_i_see_a_start_date_error
+    expect(page).to have_content("Start date format is invalid", wait: 0)
+  end
+
   def then_the_course_is_allowed_to_publish_without_schools(course)
     expect(course.reload.publish_without_schools_allowed).to be(true)
   end
 
   def then_the_publish_without_schools_checkbox_is_ticked
     expect(support_provider_course_edit_page.publish_without_schools_allowed_checkbox).to be_checked
+  end
+
+  # have_checked_field returns false rather than raising, so a missing or
+  # unticked checkbox fails here immediately instead of waiting on Capybara.
+  def and_the_publish_without_schools_checkbox_is_still_ticked
+    expect(page).to have_checked_field("Allow this course to be published without schools attached", wait: 0)
   end
 end

--- a/spec/test_setup_specs/provider_code_generator_spec.rb
+++ b/spec/test_setup_specs/provider_code_generator_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ProviderCodeGenerator do
+  # A code is a random letter followed by the sequence number, so ruling out
+  # every letter but Z leaves "Z30" as the only code that can be generated.
+  let(:all_codes_but_z30) { ("A".."Y").map { |letter| "#{letter}30" } }
+
+  before do
+    allow(Provider).to receive(:pluck).with(:provider_code).and_return([])
+  end
+
+  describe "#call" do
+    it "generates a code from the sequence number" do
+      expect(described_class.new(30).call).to match(/\A[A-Z]30\z/)
+    end
+
+    it "does not generate a code given to avoid" do
+      codes = Array.new(10) { described_class.new(30).call(avoid: all_codes_but_z30) }
+
+      expect(codes.uniq).to eq(%w[Z30])
+    end
+
+    it "does not generate a code that a provider already has" do
+      allow(Provider).to receive(:pluck).with(:provider_code).and_return(all_codes_but_z30)
+
+      codes = Array.new(10) { described_class.new(30).call }
+
+      expect(codes.uniq).to eq(%w[Z30])
+    end
+  end
+end

--- a/spec/validators/course_publishable_schools_presence_validator_spec.rb
+++ b/spec/validators/course_publishable_schools_presence_validator_spec.rb
@@ -53,7 +53,7 @@ describe CoursePublishableSchoolsPresenceValidator do
       [:salary,         false, false] => :blank,
       [:apprenticeship, false, true] => :no_error,
       [:apprenticeship, false, false] => :blank,
-      [:fee,            false, true] => :blank,
+      [:fee,            false, true] => :no_error,
       [:fee,            true,  true] => :no_error,
       [:fee,            false, false] => :blank,
     }.each do |(funding, has_school, exemption), expected|


### PR DESCRIPTION
## Context

We permit salary and apprenticeship courses to publish without course schools attached, if the course has been exempted by Support. 

We are now going to change it so that fee paying courses are allowed to behave the same way. This means that all funding types can be exempt from attaching course schools in future.

## Changes proposed in this pull request

- Allow Support users to exempt any course from requiring schools attached
- Relax the validation for exempt courses to permit any funding type
- Fix a flakey test regarding GCSE Grade

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
