### PR TITLE
Rollover details summary shows new school model data

### DIFF
--- a/app/queries/rollover_progress_query.rb
+++ b/app/queries/rollover_progress_query.rb
@@ -24,6 +24,10 @@ class RolloverProgressQuery
 
   delegate :count, to: :rolled_over_study_sites, prefix: true
 
+  delegate :count, to: :eligible_schools, prefix: true
+
+  delegate :count, to: :rolled_over_schools, prefix: true
+
   delegate :count, to: :rolled_over_courses, prefix: true
 
   delegate :count, to: :eligible_partnerships, prefix: true
@@ -87,6 +91,16 @@ class RolloverProgressQuery
 
   def rolled_over_study_sites
     @rolled_over_study_sites ||= @target_cycle.study_sites
+  end
+
+  def eligible_schools
+    @eligible_schools ||= @previous_target_cycle.provider_schools
+      .with_available_gias_school
+      .where(provider_id: eligible_providers.select(:id))
+  end
+
+  def rolled_over_schools
+    @rolled_over_schools ||= @target_cycle.provider_schools.with_available_gias_school
   end
 
   def rolled_over_partnerships

--- a/app/views/support/recruitment_cycles/show.html.erb
+++ b/app/views/support/recruitment_cycles/show.html.erb
@@ -119,6 +119,11 @@
             <% end %>
 
             <% summary_list.with_row do |row| %>
+              <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:schools_summary)) %>
+              <% row.with_value(text: t(".rollover_status.summary", total_eligible_count: @rollover_progress_query.eligible_schools_count, rolled_over_count: @rollover_progress_query.rolled_over_schools_count)) %>
+            <% end %>
+
+            <% summary_list.with_row do |row| %>
               <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:partnerships_summary)) %>
               <% row.with_value(text: t(".rollover_status.summary", total_eligible_count: @rollover_progress_query.eligible_partnerships_count, rolled_over_count: @rollover_progress_query.rolled_over_partnerships_count)) %>
             <% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -16,6 +16,7 @@ en:
         providers_summary: Rolled over providers
         courses_summary: Rolled over courses
         study_sites_summary: Rolled over study sites
+        schools_summary: Rolled over schools
         remaining_to_rollover: Remaining to rollover
         providers_without_published_courses: Providers without published courses (not rolled over)
     errors:

--- a/spec/queries/rollover_progress_query_spec.rb
+++ b/spec/queries/rollover_progress_query_spec.rb
@@ -168,6 +168,42 @@ RSpec.describe RolloverProgressQuery, type: :model do
     end
   end
 
+  describe "#eligible_schools" do
+    let!(:eligible_school) { create(:provider_school, provider: provider_with_own_course) }
+    let!(:ineligible_school) { create(:provider_school, provider: provider_without_courses) }
+    let!(:closed_school) do
+      create(
+        :provider_school,
+        provider: provider_with_own_course,
+        gias_school: create(:gias_school, :closed),
+      )
+    end
+
+    before do
+      given_we_have_providers_and_courses_on_previous_target_cycle
+    end
+
+    it "includes available schools belonging to eligible providers" do
+      expect(rollover_progress.eligible_schools).to contain_exactly(eligible_school)
+    end
+
+    it "returns the correct count through delegation" do
+      expect(rollover_progress.eligible_schools_count).to eq(1)
+    end
+  end
+
+  describe "#rolled_over_schools" do
+    let!(:rolled_over_school) { create(:provider_school, provider: rolled_over_provider) }
+
+    it "includes available schools in the target cycle" do
+      expect(rollover_progress.rolled_over_schools).to contain_exactly(rolled_over_school)
+    end
+
+    it "returns the correct count through delegation" do
+      expect(rollover_progress.rolled_over_schools_count).to eq(1)
+    end
+  end
+
   describe "#eligible_partnerships" do
     let(:accredited_provider) { create(:provider, :accredited_provider) }
     let(:rollable_partnership_one) do


### PR DESCRIPTION
## Context

The automated rollover progress summary displayed counts for providers, courses, study sites and partnerships, but not schools from the new school data model.

## Changes proposed in this pull request

- Add eligible and rolled-over `Provider::School` counts to the rollover progress query.
- Exclude closed GIAS schools, matching rollover behaviour.
- Display a new “Rolled over schools” row in the rollover progress summary.
- Add test coverage for eligible and rolled-over school counts.
- Keep existing study-site progress unchanged.

## Guidance to review

- Confirm the school count includes only available schools belonging to eligible providers.
- Confirm closed schools and schools belonging to ineligible providers are excluded.
- Confirm the rollover summary displays the rolled-over and expected school counts.
- Run:

```shell
bundle exec rspec spec/queries/rollover_progress_query_spec.rb
```

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.