### PR TITLE
School data: Fix uuid resolver during rollover

### DIFF
--- a/app/services/provider_schools/sync_legacy_site_uuids.rb
+++ b/app/services/provider_schools/sync_legacy_site_uuids.rb
@@ -32,13 +32,14 @@ module ProviderSchools
 
     def legacy_site_uuid_for(provider_school)
       legacy_site_uuids = legacy_site_uuids_by_identity.fetch(identity_for(provider_school), [])
-      return legacy_site_uuids.first if legacy_site_uuids.one?
+      return legacy_site_uuids.first if legacy_site_uuids.any?
 
       raise LegacySiteMismatchError, mismatch_message(provider_school, legacy_site_uuids)
     end
 
     def legacy_site_uuids_by_identity
       @legacy_site_uuids_by_identity ||= Site.school.kept.where(provider:)
+        .order(:id)
         .pluck(:urn, :code, :uuid)
         .each_with_object({}) do |(urn, code, uuid), index|
           (index[[urn, code]] ||= []) << uuid
@@ -51,7 +52,7 @@ module ProviderSchools
 
     def mismatch_message(provider_school, legacy_site_uuids)
       count = legacy_site_uuids.size
-      "expected one legacy site for provider=#{provider.id} " \
+      "expected at least one legacy site for provider=#{provider.id} " \
         "provider_school=#{provider_school.id} " \
         "site_code=#{provider_school.site_code} " \
         "urn=#{provider_school.gias_school.urn.inspect}, found #{count}"

--- a/spec/services/provider_schools/sync_legacy_site_uuids_spec.rb
+++ b/spec/services/provider_schools/sync_legacy_site_uuids_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe ProviderSchools::SyncLegacySiteUuids do
     expect(provider_school.reload.uuid).to eq(legacy_site.uuid)
   end
 
+  context "when duplicate legacy sites match" do
+    let!(:duplicate_site) do
+      build(:site, provider:, code: legacy_site.code, urn: gias_school.urn).tap do |site|
+        site.save!(validate: false)
+      end
+    end
+
+    it "uses one of the matching legacy site UUIDs" do
+      sync_uuids
+
+      expect([legacy_site.uuid, duplicate_site.uuid]).to include(provider_school.reload.uuid)
+    end
+  end
+
   context "when no matching legacy site exists" do
     before { legacy_site.destroy! }
 
@@ -47,7 +61,7 @@ RSpec.describe ProviderSchools::SyncLegacySiteUuids do
       expect { sync_uuids }
         .to raise_error(
           described_class::LegacySiteMismatchError,
-          /expected one legacy site for provider=#{provider.id}/,
+          /expected at least one legacy site for provider=#{provider.id}/,
         )
     end
   end


### PR DESCRIPTION
## Context

As we have duplicate Sites the current UUID resolver will error when trying to resolve a Provider::School to a legacy site. This PR will now resolve even if there are multiple Sites with the same urn and provider_id

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
