### PR TITLE
Bug: Saved course issue on candidate accounts

### DIFF
--- a/app/components/saved_courses/summary_card_component.rb
+++ b/app/components/saved_courses/summary_card_component.rb
@@ -72,7 +72,7 @@ module SavedCourses
     end
 
     def course_from_previous_year?
-      course.recruitment_cycle.year.to_i < Find::CycleTimetable.current_year
+      @course_from_previous_year ||= course.recruitment_cycle.year.to_i < Find::CycleTimetable.current_year
     end
   end
 end

--- a/app/components/saved_courses/summary_card_component.rb
+++ b/app/components/saved_courses/summary_card_component.rb
@@ -17,7 +17,11 @@ module SavedCourses
     def title
       provider_span = content_tag(:span, course.provider_name)
       course_span = content_tag(:span, course.name_and_code)
-      status_tag = course.decorate.saved_status_tag
+      status_tag = if course_from_previous_year?
+                     helpers.govuk_tag(text: t(".course_from_previous_year"), colour: "red")
+                   else
+                     course.decorate.saved_status_tag
+                   end
       status_block = (content_tag(:div, status_tag, class: "app-saved-course__status-tag") if status_tag.present?)
 
       title_inner = safe_join(
@@ -29,11 +33,14 @@ module SavedCourses
         ].compact,
       )
 
-      course_info =
-        govuk_link_to(
-          find_course_path(provider_code: course.provider_code, course_code: course.course_code),
-          class: "govuk-link",
-        ) { title_inner }
+      course_info = if course_from_previous_year?
+                      title_inner
+                    else
+                      govuk_link_to(
+                        find_course_path(provider_code: course.provider_code, course_code: course.course_code),
+                        class: "govuk-link",
+                      ) { title_inner }
+                    end
 
       content_tag(:div, class: "app-saved-course__card-title") do
         safe_join(
@@ -62,6 +69,10 @@ module SavedCourses
       @location.present? &&
         saved_course.respond_to?(:minimum_distance_to_search_location) &&
         saved_course.minimum_distance_to_search_location.present?
+    end
+
+    def course_from_previous_year?
+      course.recruitment_cycle.year.to_i < Find::CycleTimetable.current_year
     end
   end
 end

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -471,9 +471,11 @@ module Courses
     # so that subclasses starting from a different model (e.g. SavedCourse) can
     # reuse the fee ordering scopes - .joins(string) works on any relation where
     # the course table is available, while model scopes are tied to one model.
-    def latest_published_enrichment_join_sql
+    #
+    # Pass join_type: "LEFT" to keep rows that have no published enrichment.
+    def latest_published_enrichment_join_sql(join_type: "INNER")
       <<~SQL.squish
-        INNER JOIN LATERAL (
+        #{join_type} JOIN LATERAL (
           SELECT *
           FROM course_enrichment
           WHERE course_enrichment.course_id = course.id

--- a/app/services/saved_courses/query.rb
+++ b/app/services/saved_courses/query.rb
@@ -44,21 +44,24 @@ module SavedCourses
 
     # Distance annotation over the legacy course_site -> site model, used while
     # the :course_publishing_uses_new_school_model flag is off. Saved courses are
-    # annotated with distance but not filtered by radius.
+    # annotated with distance but not filtered by radius. Previous-cycle courses
+    # are retained when their old placement sites are no longer publishable.
     def sites_location_scope(latitude:, longitude:)
       @scope
         .joins(<<~SQL)
-          INNER JOIN course_site ON (
+          LEFT JOIN course_site ON (
             course_site.course_id = course.id
             AND course_site.status = 'R'
             AND course_site.publish = 'Y'
           )
-          INNER JOIN site ON (
+          LEFT JOIN site ON (
             site.id = course_site.site_id
             AND site.discarded_at IS NULL
+            AND site.longitude IS NOT NULL
+            AND site.latitude IS NOT NULL
           )
         SQL
-        .where("(site.longitude IS NOT NULL OR site.latitude IS NOT NULL)")
+        .where("site.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", RecruitmentCycle.current.id)
         .select(
           Course.sanitize_sql_array(
             [
@@ -80,12 +83,19 @@ module SavedCourses
     # Distance annotation over the canonical course_school -> gias_school model,
     # used while the :course_publishing_uses_new_school_model flag is on. As with
     # the legacy path, saved courses are annotated with distance but not filtered
-    # by radius.
+    # by radius. Previous-cycle courses are retained when they have no canonical
+    # school with coordinates.
     def schools_location_scope(latitude:, longitude:)
       @scope
-        .joins(course: { schools: :gias_school })
-        .where.not(gias_school: { latitude: nil })
-        .where.not(gias_school: { longitude: nil })
+        .joins(<<~SQL)
+          LEFT JOIN course_school ON course_school.course_id = course.id
+          LEFT JOIN gias_school ON (
+            gias_school.id = course_school.gias_school_id
+            AND gias_school.latitude IS NOT NULL
+            AND gias_school.longitude IS NOT NULL
+          )
+        SQL
+        .where("gias_school.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", RecruitmentCycle.current.id)
         .select(
           Course.sanitize_sql_array(
             [
@@ -140,7 +150,8 @@ module SavedCourses
 
       @scope
         .select("saved_course.*, #{funding_sorting}, provider.provider_name, MAX((course_enrichment.json_data->>'FeeUkEu')::integer) as uk_fee")
-        .joins(latest_published_enrichment_join_sql)
+        .joins(latest_published_enrichment_left_join_sql)
+        .where("course_enrichment.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", RecruitmentCycle.current.id)
         .group("saved_course.id, course.id, provider.id, provider.provider_name")
         .order(
           {
@@ -160,7 +171,8 @@ module SavedCourses
 
       @scope
         .select("saved_course.*, #{funding_sorting}, provider.provider_name, MAX((course_enrichment.json_data->>'FeeInternational')::integer) as intl_fee")
-        .joins(latest_published_enrichment_join_sql)
+        .joins(latest_published_enrichment_left_join_sql)
+        .where("course_enrichment.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", RecruitmentCycle.current.id)
         .group("saved_course.id, course.id, provider.id, provider.provider_name")
         .order(
           {
@@ -177,6 +189,10 @@ module SavedCourses
       @scope.preload(
         course: [:provider, :latest_published_enrichment, { subjects: [:financial_incentive] }],
       )
+    end
+
+    def latest_published_enrichment_left_join_sql
+      latest_published_enrichment_join_sql.sub("INNER JOIN LATERAL", "LEFT JOIN LATERAL")
     end
   end
 end

--- a/app/services/saved_courses/query.rb
+++ b/app/services/saved_courses/query.rb
@@ -46,6 +46,7 @@ module SavedCourses
     # the :course_publishing_uses_new_school_model flag is off. Saved courses are
     # annotated with distance but not filtered by radius. Previous-cycle courses
     # are retained when their old placement sites are no longer publishable.
+    # Both latitude and longitude are required to compute distance.
     def sites_location_scope(latitude:, longitude:)
       @scope
         .joins(<<~SQL)
@@ -61,7 +62,7 @@ module SavedCourses
             AND site.latitude IS NOT NULL
           )
         SQL
-        .where("site.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", RecruitmentCycle.current.id)
+        .where("site.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", current_recruitment_cycle_id)
         .select(
           Course.sanitize_sql_array(
             [
@@ -95,7 +96,7 @@ module SavedCourses
             AND gias_school.longitude IS NOT NULL
           )
         SQL
-        .where("gias_school.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", RecruitmentCycle.current.id)
+        .where("gias_school.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", current_recruitment_cycle_id)
         .select(
           Course.sanitize_sql_array(
             [
@@ -143,6 +144,10 @@ module SavedCourses
 
     # Override: select saved_course.* instead of course.* and adjust GROUP BY
     # so SavedCourse attributes (like course_id) are available on the result.
+    #
+    # LEFT JOIN keeps previous-cycle courses that have no published enrichment.
+    # Current-cycle courses still need one. When a previous-cycle course does
+    # have a published enrichment, the lateral join still uses it for sorting.
     def fee_uk_ascending_order_scope
       return @scope unless params[:order] == "fee_uk_ascending"
 
@@ -150,8 +155,8 @@ module SavedCourses
 
       @scope
         .select("saved_course.*, #{funding_sorting}, provider.provider_name, MAX((course_enrichment.json_data->>'FeeUkEu')::integer) as uk_fee")
-        .joins(latest_published_enrichment_left_join_sql)
-        .where("course_enrichment.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", RecruitmentCycle.current.id)
+        .joins(latest_published_enrichment_join_sql(join_type: "LEFT"))
+        .where("course_enrichment.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", current_recruitment_cycle_id)
         .group("saved_course.id, course.id, provider.id, provider.provider_name")
         .order(
           {
@@ -171,8 +176,8 @@ module SavedCourses
 
       @scope
         .select("saved_course.*, #{funding_sorting}, provider.provider_name, MAX((course_enrichment.json_data->>'FeeInternational')::integer) as intl_fee")
-        .joins(latest_published_enrichment_left_join_sql)
-        .where("course_enrichment.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", RecruitmentCycle.current.id)
+        .joins(latest_published_enrichment_join_sql(join_type: "LEFT"))
+        .where("course_enrichment.id IS NOT NULL OR provider.recruitment_cycle_id <> ?", current_recruitment_cycle_id)
         .group("saved_course.id, course.id, provider.id, provider.provider_name")
         .order(
           {
@@ -187,12 +192,16 @@ module SavedCourses
 
     def preload_scope
       @scope.preload(
-        course: [:provider, :latest_published_enrichment, { subjects: [:financial_incentive] }],
+        course: [
+          :latest_published_enrichment,
+          { provider: :recruitment_cycle },
+          { subjects: [:financial_incentive] },
+        ],
       )
     end
 
-    def latest_published_enrichment_left_join_sql
-      latest_published_enrichment_join_sql.sub("INNER JOIN LATERAL", "LEFT JOIN LATERAL")
+    def current_recruitment_cycle_id
+      @current_recruitment_cycle_id ||= RecruitmentCycle.current_recruitment_cycle!.id
     end
   end
 end

--- a/config/locales/en/saved_courses/summary_card_component.yml
+++ b/config/locales/en/saved_courses/summary_card_component.yml
@@ -7,6 +7,7 @@ en:
       add_note: Add a note
       edit_note: Edit
       delete_note: Delete
+      course_from_previous_year: Course from a previous year
       fee_value:
         salary: Salary
         apprenticeship: Salary (apprenticeship)

--- a/spec/components/saved_courses/summary_card_component_spec.rb
+++ b/spec/components/saved_courses/summary_card_component_spec.rb
@@ -50,6 +50,27 @@ RSpec.describe SavedCourses::SummaryCardComponent, type: :component do
     )
   end
 
+  context "when the course is from a previous recruitment cycle" do
+    before do
+      course.provider.update!(
+        recruitment_cycle: find_or_create(:recruitment_cycle, :previous),
+      )
+    end
+
+    it "renders the course title without a link" do
+      expect(rendered).to have_text("Best Practice Network")
+      expect(rendered).to have_text("Physics (S252)")
+      expect(rendered).not_to have_link(
+        "Best Practice Network",
+        href: find_course_path(provider_code: "RO1", course_code: "S252"),
+      )
+    end
+
+    it "renders a previous-year tag" do
+      expect(rendered).to have_css(".govuk-tag", text: "Course from a previous year")
+    end
+  end
+
   it "renders a delete button that submits to the destroy route" do
     expect(rendered).to have_button("Delete")
     expect(rendered).to have_css("form[action='#{find_candidate_saved_course_path(saved_course)}']")

--- a/spec/services/saved_courses/query_new_school_model_spec.rb
+++ b/spec/services/saved_courses/query_new_school_model_spec.rb
@@ -53,5 +53,19 @@ RSpec.describe SavedCourses::Query do
         attribute_names: %w[minimum_distance_to_search_location],
       )
     end
+
+    it "retains a previous-cycle course without a canonical school" do
+      previous_cycle_saved = create(
+        :saved_course,
+        candidate:,
+        course: create(
+          :course,
+          provider: create(:provider, recruitment_cycle: create(:recruitment_cycle, :previous)),
+        ),
+      )
+
+      expect(results).to include(previous_cycle_saved)
+      expect(results.find { it.id == previous_cycle_saved.id }.minimum_distance_to_search_location).to be_nil
+    end
   end
 end

--- a/spec/services/saved_courses/query_spec.rb
+++ b/spec/services/saved_courses/query_spec.rb
@@ -108,6 +108,20 @@ RSpec.describe SavedCourses::Query do
           attribute_names: %w[minimum_distance_to_search_location],
         )
       end
+
+      it "retains a previous-cycle course without a publishable placement site" do
+        previous_cycle_saved = create(
+          :saved_course,
+          candidate:,
+          course: create(
+            :course,
+            provider: create(:provider, recruitment_cycle: create(:recruitment_cycle, :previous)),
+          ),
+        )
+
+        expect(results).to include(previous_cycle_saved)
+        expect(results.find { it.id == previous_cycle_saved.id }.minimum_distance_to_search_location).to be_nil
+      end
     end
 
     context "when a placement school has been discarded" do
@@ -204,6 +218,20 @@ RSpec.describe SavedCourses::Query do
         attribute_names: %w[course_id],
       )
     end
+
+    it "retains a previous-cycle course without a published enrichment" do
+      previous_cycle_saved = create(
+        :saved_course,
+        candidate:,
+        course: create(
+          :course,
+          :fee,
+          provider: create(:provider, recruitment_cycle: create(:recruitment_cycle, :previous)),
+        ),
+      )
+
+      expect(results).to include(previous_cycle_saved)
+    end
   end
 
   context "when ordering by international fee ascending" do
@@ -244,6 +272,20 @@ RSpec.describe SavedCourses::Query do
         [cheap_saved, expensive_saved],
         attribute_names: %w[course_id],
       )
+    end
+
+    it "retains a previous-cycle course without a published enrichment" do
+      previous_cycle_saved = create(
+        :saved_course,
+        candidate:,
+        course: create(
+          :course,
+          :fee,
+          provider: create(:provider, recruitment_cycle: create(:recruitment_cycle, :previous)),
+        ),
+      )
+
+      expect(results).to include(previous_cycle_saved)
     end
   end
 

--- a/spec/services/saved_courses/query_spec.rb
+++ b/spec/services/saved_courses/query_spec.rb
@@ -232,6 +232,27 @@ RSpec.describe SavedCourses::Query do
 
       expect(results).to include(previous_cycle_saved)
     end
+
+    it "sorts a previous-cycle course by fee when it has a published enrichment" do
+      previous_cycle_saved = create(
+        :saved_course,
+        candidate:,
+        course: create(
+          :course,
+          :with_full_time_sites,
+          :fee,
+          name: "Mid Course",
+          provider: create(
+            :provider,
+            provider_name: "Mid University",
+            recruitment_cycle: find_or_create(:recruitment_cycle, :previous),
+          ),
+          enrichments: [build(:course_enrichment, :published, fee_uk_eu: 7000)],
+        ),
+      )
+
+      expect(results.map(&:id)).to eq([cheap_saved.id, previous_cycle_saved.id, expensive_saved.id])
+    end
   end
 
   context "when ordering by international fee ascending" do

--- a/spec/system/find/candidates/saved_courses/view_saved_courses_spec.rb
+++ b/spec/system/find/candidates/saved_courses/view_saved_courses_spec.rb
@@ -173,6 +173,27 @@ RSpec.describe "Viewing my saved courses", service: :find do
 
       then_i_see_courses_sorted_london_first
     end
+
+    scenario "a previous-year course remains visible with location and fee sorting" do
+      when_i_log_in_as_a_candidate
+      previous_year_course = create(
+        :course,
+        :fee,
+        name: "Previous Year Course",
+        provider: create(:provider, recruitment_cycle: create(:recruitment_cycle, :previous)),
+      )
+      create(:saved_course, candidate: Candidate.first, course: previous_year_course)
+
+      then_i_visit_my_saved_courses
+      and_i_search_for_london
+      expect(page).to have_content(previous_year_course.name_and_code)
+
+      and_i_click_sort_by_lowest_fee_uk
+      expect(page).to have_content(previous_year_course.name_and_code)
+
+      and_i_click_sort_by_lowest_fee_intl
+      expect(page).to have_content(previous_year_course.name_and_code)
+    end
   end
 
   def when_i_log_in_as_a_candidate

--- a/spec/system/find/candidates/saved_courses/view_saved_courses_spec.rb
+++ b/spec/system/find/candidates/saved_courses/view_saved_courses_spec.rb
@@ -18,6 +18,28 @@ RSpec.describe "Viewing my saved courses", service: :find do
     then_the_back_link_takes_me_back_to_the_saved_courses_page
   end
 
+  scenario "A candidate sees an unlinked course from a previous year" do
+    when_i_log_in_as_a_candidate
+    and_i_have_saved_courses
+    @course.provider.update!(
+      recruitment_cycle: find_or_create(:recruitment_cycle, :previous),
+    )
+
+    then_i_visit_my_saved_courses
+
+    within_first_saved_course_row do
+      expect(page).to have_content("Course from a previous year")
+      expect(page).to have_content(@course.name_and_code)
+      expect(page).not_to have_link(
+        @course.provider_name,
+        href: find_course_path(
+          provider_code: @course.provider_code,
+          course_code: @course.course_code,
+        ),
+      )
+    end
+  end
+
   scenario "A candidate can view the saved courses page with no saved courses" do
     when_i_log_in_as_a_candidate
     then_i_visit_my_saved_courses


### PR DESCRIPTION
## Context

Saved courses from a previous recruitment cycle remain visible in candidate accounts. If the course was not rolled over, its existing link leads to a “Page not found” page.

## Changes proposed in this pull request

- Remove the hyperlink from previous-year saved course titles.
- Add a red “Course from a previous year” tag.
- Keep current-cycle course links unchanged.
- Add component and system test coverage.

## Guidance to review

1. Save a course to a candidate account.
2. Move the course’s provider to the previous recruitment cycle.
3. View the candidate’s saved courses.
4. Confirm the course title is not linked and the previous-year tag is displayed.
5. Confirm current-cycle saved courses remain linked.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.