### PR TITLE
Make the BigQuery event specs assert, and stop them freezing Time

### DIFF
--- a/spec/lib/big_query/entity_event_spec.rb
+++ b/spec/lib/big_query/entity_event_spec.rb
@@ -13,8 +13,8 @@ module BigQuery
         it {  is_expected.to include("environment" => "test") }
 
         it "contains Time.now in iso8601" do
-          Time.freeze do
-            expected_time = Time.zone.now.iso8601
+          freeze_time do
+            expected_time = Time.zone.now.iso8601(6)
             expect(subject).to include("occurred_at" => expected_time)
           end
         end

--- a/spec/lib/big_query/request_event_spec.rb
+++ b/spec/lib/big_query/request_event_spec.rb
@@ -14,7 +14,7 @@ module BigQuery
         it {  is_expected.to include("event_type" => "web_request") }
 
         it "contains Time.now in iso8601" do
-          Time.freeze do
+          freeze_time do
             expected_time = Time.zone.now.iso8601
             expect(subject).to include("occurred_at" => expected_time)
           end


### PR DESCRIPTION
Duplicate of https://github.com/DFE-Digital/publish-teacher-training/pull/6339