### PR TITLE
Update composite actions off deprecated Node 20 runtime

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -63,20 +63,20 @@ runs:
         fi;
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Setup Terraform ${{ env.TERRAFORM_VERSION }}
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: ${{ env.TERRAFORM_VERSION }}
 
-    - uses: azure/login@v2
+    - uses: azure/login@v3
       with:
         tenant-id: ${{ inputs.azure-tenant-id }}
         subscription-id: ${{ inputs.azure-subscription-id }}
         client-id: ${{ inputs.azure-client-id }}
 
-    - uses: google-github-actions/auth@v2
+    - uses: google-github-actions/auth@v3
       with:
         project_id: rugged-abacus-218110
         workload_identity_provider: projects/712009772377/locations/global/workloadIdentityPools/publish-teacher-training/providers/publish-teacher-training

--- a/.github/actions/restore/action.yml
+++ b/.github/actions/restore/action.yml
@@ -58,7 +58,7 @@ runs:
           echo "app_name=publish-${{ env.app_environment }}" >> $GITHUB_ENV
         fi
 
-    - uses: azure/login@v2
+    - uses: azure/login@v3
       with:
         tenant-id: ${{ inputs.azure-tenant-id }}
         subscription-id: ${{ inputs.azure-subscription-id }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,9 @@ updates:
       interval: daily
     open-pull-requests-limit: 15
   - package-ecosystem: github-actions
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: daily
     open-pull-requests-limit: 15


### PR DESCRIPTION
## Context
The composite actions under `.github/actions/` were several majors behind the
  workflows and all still on the deprecated **node20** runtime:

  | Action | Was | Now |
  | --- | --- | --- |
  | `actions/checkout` | v4 | v7 |
  | `hashicorp/setup-terraform` | v3 | v4 |
  | `azure/login` | v2 | v3 |
  | `google-github-actions/auth` | v2 | v3 |

  All four new majors run on node24. The only input change across them is
  `google-github-actions/auth` v3 dropping `retries`, `backoff` and
  `backoff_limit` — none of which we pass.

  ## Why they drifted

  The `github-actions` entry in `.github/dependabot.yml` only set `directory: "/"`,
  which Dependabot resolves to `.github/workflows` plus a root `action.yml`.
  Composite actions under `.github/actions/` were never scanned, so the workflows
  stayed current while these fell four majors behind.

  Switched to the `directories` key (which supports globs, unlike `directory`) so
  each composite action directory is scanned from now on.

  ## Not included

  - `DFE-Digital/github-actions/*@master` (8 refs) — floating on `master`, so they
    self-update. Not deprecated, but unpinned. SHA-pinning is a separate call.
  - `grafana/setup-k6` — SHA-pinned at v0.0.1; couldn't confirm whether a newer
    commit exists.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
