### PR TITLE
Remove no visited state from banner links

### DIFF
--- a/app/views/publish/_rollover_notification_banner.html.erb
+++ b/app/views/publish/_rollover_notification_banner.html.erb
@@ -3,10 +3,10 @@
     text: "Action required by 28 September: check and schedule your courses",
   ) %>
   <p class="govuk-body">
-    Courses for the 2026 to 2027 recruitment cycle will be published on <%= govuk_link_to("Find teacher training courses", find_root_url, no_visited_state: true) %> on 29 September. Before this, you need to check and schedule your rolled over courses. If you do not schedule your courses, candidates will not be able to see them when Find opens.
+    Courses for the 2026 to 2027 recruitment cycle will be published on <%= govuk_link_to("Find teacher training courses", find_root_url) %> on 29 September. Before this, you need to check and schedule your rolled over courses. If you do not schedule your courses, candidates will not be able to see them when Find opens.
   </p>
 
   <p class="govuk-body">
-    Read <%= govuk_link_to("guidance on rolling over courses to a new recruitment cycle", roll_over_courses_to_a_new_recruitment_cycle_path, no_visited_state: true) %> if you need help.
+    Read <%= govuk_link_to("guidance on rolling over courses to a new recruitment cycle", roll_over_courses_to_a_new_recruitment_cycle_path) %> if you need help.
   </p>
 <% end %>


### PR DESCRIPTION
## Context

I set the links in the rollover notification banner so that they would never show visited state but I shouldn't have.

## Changes proposed in this pull request

Allow the links to have visited state

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
