### PR TITLE
Remove duplicate schools remodel cycle year from settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,8 +4,6 @@ environment:
 
 support_email: becomingateacher@digital.education.gov.uk
 
-schools_remodel_cycle_year: 2026
-
 # The canonical URL of the Find service
 find_url: https://find.localhost
 


### PR DESCRIPTION
## Context

config/settings.yml had schools_remodel_cycle_year defined twice.

## Changes proposed in this pull request

Remove the duplicate schools_remodel_cycle_year: 2026 entry from config/settings.yml, keeping the original single definition.


