### PR TITLE
Freeze time in the BigQuery event specs, not the Time class

### DIFF
--- a/spec/lib/big_query/entity_event_spec.rb
+++ b/spec/lib/big_query/entity_event_spec.rb
@@ -13,8 +13,8 @@ module BigQuery
         it {  is_expected.to include("environment" => "test") }
 
         it "contains Time.now in iso8601" do
-          Time.freeze do
-            expected_time = Time.zone.now.iso8601
+          freeze_time do
+            expected_time = Time.zone.now.iso8601(6)
             expect(subject).to include("occurred_at" => expected_time)
           end
         end

--- a/spec/lib/big_query/request_event_spec.rb
+++ b/spec/lib/big_query/request_event_spec.rb
@@ -14,7 +14,7 @@ module BigQuery
         it {  is_expected.to include("event_type" => "web_request") }
 
         it "contains Time.now in iso8601" do
-          Time.freeze do
+          freeze_time do
             expected_time = Time.zone.now.iso8601
             expect(subject).to include("occurred_at" => expected_time)
           end


### PR DESCRIPTION
## Context

`Time.freeze do` in these two specs is `Object#freeze` on the `Time` class, not ActiveSupport's `freeze_time`. So the block never runs.

## Changes proposed in this pull request

Use `freeze_time`.

## Guidance to review

Passing CI should be enough.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
