### PR TITLE
Expose additional course enrichment fields in public API

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -177,16 +177,28 @@ module API
         end
 
         enrichment_attribute :about_course
+        enrichment_attribute :additional_fees
+        enrichment_attribute :assessment_methods
         enrichment_attribute :course_length
+        enrichment_attribute :duration_per_school
         enrichment_attribute :fee_details
         enrichment_attribute :fee_international
         enrichment_attribute :fee_domestic, :fee_uk_eu
+        enrichment_attribute :fee_schedule
         enrichment_attribute :financial_support
         enrichment_attribute :how_school_placements_work
         enrichment_attribute :interview_process
+        enrichment_attribute :interview_location
         enrichment_attribute :other_requirements
         enrichment_attribute :personal_qualities
+        enrichment_attribute :placement_school_activities
+        enrichment_attribute :placement_selection_criteria
         enrichment_attribute :salary_details
+        enrichment_attribute :salary_fee_details
+        enrichment_attribute :support_and_mentorship
+        enrichment_attribute :theoretical_training_activities
+        enrichment_attribute :theoretical_training_duration
+        enrichment_attribute :theoretical_training_location
       end
     end
   end

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -5,6 +5,23 @@ weight: 2
 
 # Release Notes
 
+## 21 August 2026
+
+We have introduced twelve new fields to the `CourseAttributes` schema which expose additional course information entered by providers. Each is a nullable string, and all except `interview_location` are markdown formatted.
+
+- Add `additional_fees` field to `CourseAttributes`. Further information about any additional course fees or costs.
+- Add `assessment_methods` field to `CourseAttributes`. Information about how trainees will be assessed.
+- Add `duration_per_school` field to `CourseAttributes`. Information about how much time trainees will spend in each placement school.
+- Add `fee_schedule` field to `CourseAttributes`. Information about when fees are due.
+- Add `interview_location` field to `CourseAttributes`. Information about where interviews will take place. One of `online`, `in person` or `both`.
+- Add `placement_school_activities` field to `CourseAttributes`. Information about what trainees will do in their placement schools.
+- Add `placement_selection_criteria` field to `CourseAttributes`. Information about how placement schools are selected for trainees.
+- Add `salary_fee_details` field to `CourseAttributes`. Information about course fees for salaried courses.
+- Add `support_and_mentorship` field to `CourseAttributes`. Information about how trainees will be supported and mentored during school placements.
+- Add `theoretical_training_activities` field to `CourseAttributes`. Information about what trainees will do during theoretical training.
+- Add `theoretical_training_duration` field to `CourseAttributes`. Information about how much time trainees will spend in theoretical training.
+- Add `theoretical_training_location` field to `CourseAttributes`. Information about where theoretical training will take place.
+
 ## 22 July 2026
 
 - Add `has_course_schools` to the `meta` of the course locations response (`CourseLocationListResponse`). This boolean is `true` when the returned locations are the course's own attached schools, and `false` when they are the provider's schools returned as a fallback because the course is permitted to publish without schools and has none of its own.

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -7,13 +7,17 @@ weight: 2
 
 ## 21 August 2026
 
-We have introduced twelve new fields to the `CourseAttributes` schema which expose additional course information entered by providers. Each is a nullable string, and all except `interview_location` are markdown formatted.
+We have introduced twelve new fields to the `CourseAttributes` schema. Together they carry the course content that `about_course`, `fee_details` and `how_school_placements_work` stopped returning for 2026 recruitment cycle courses (see the October 2025 entry below).
+
+Providers have been entering this content in Publish since the 2026 cycle opened in October 2025, so these fields are already populated for published 2026 cycle courses rather than filling up from today. Courses from earlier cycles return `null` for all twelve.
+
+Each field is a nullable string. All are markdown formatted except `interview_location`, which returns one of `online`, `in person` or `both`.
 
 - Add `additional_fees` field to `CourseAttributes`. Further information about any additional course fees or costs.
 - Add `assessment_methods` field to `CourseAttributes`. Information about how trainees will be assessed.
 - Add `duration_per_school` field to `CourseAttributes`. Information about how much time trainees will spend in each placement school.
 - Add `fee_schedule` field to `CourseAttributes`. Information about when fees are due.
-- Add `interview_location` field to `CourseAttributes`. Information about where interviews will take place. One of `online`, `in person` or `both`.
+- Add `interview_location` field to `CourseAttributes`. Information about where interviews will take place.
 - Add `placement_school_activities` field to `CourseAttributes`. Information about what trainees will do in their placement schools.
 - Add `placement_selection_criteria` field to `CourseAttributes`. Information about how placement schools are selected for trainees.
 - Add `salary_fee_details` field to `CourseAttributes`. Information about course fees for salaried courses.
@@ -25,6 +29,12 @@ We have introduced twelve new fields to the `CourseAttributes` schema which expo
 ## 22 July 2026
 
 - Add `has_course_schools` to the `meta` of the course locations response (`CourseLocationListResponse`). This boolean is `true` when the returned locations are the course's own attached schools, and `false` when they are the provider's schools returned as a fallback because the course is permitted to publish without schools and has none of its own.
+
+## October 2025
+
+This change shipped with the opening of the 2026 recruitment cycle but was not announced at the time. It is recorded here for completeness.
+
+- `about_course`, `fee_details` and `how_school_placements_work` in `CourseAttributes` return `null` for any course whose latest published content was created or updated from the 2026 recruitment cycle onwards. Providers now enter this information as a set of more granular fields, which the API began returning on 21 August 2026 (see above). Courses from earlier cycles are unaffected and continue to return their existing values.
 
 ## 19 September 2024
 

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -32,6 +32,13 @@ Deprecation:
 
 - Deprecate `salary_details` in `CourseAttributes`. From the 2027 recruitment cycle, providers enter this information as `salary_fee_details` instead, so `salary_details` is not populated for salaried courses in the 2027 cycle onwards. The field is still returned, and courses in the 2026 cycle and earlier are unaffected and continue to return their existing values.
 
+## 23 July 2026
+
+- Add `school_experience_required` field to `CourseAttributes`. A boolean indicating whether school experience is required or strongly recommended for this course.
+- Add `school_experience_required_content` field to `CourseAttributes`. A markdown string giving details of the school experience expected for this course.
+
+Both fields are included in responses from the 2027 recruitment cycle onwards. For 2026 recruitment cycle courses and earlier they are omitted from the `attributes` object altogether rather than returned as `null`, so clients should treat the key as optional.
+
 ## 22 July 2026
 
 - Add `has_course_schools` to the `meta` of the course locations response (`CourseLocationListResponse`). This boolean is `true` when the returned locations are the course's own attached schools, and `false` when they are the provider's schools returned as a fallback because the course is permitted to publish without schools and has none of its own.

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -7,9 +7,11 @@ weight: 2
 
 ## 21 August 2026
 
-We have introduced twelve new fields to the `CourseAttributes` schema. Together they carry the course content that `about_course`, `fee_details` and `how_school_placements_work` stopped returning for 2026 recruitment cycle courses (see the October 2025 entry below).
+We have introduced twelve new fields to the `CourseAttributes` schema, and are deprecating `salary_details`.
 
-Providers have been entering this content in Publish since the 2026 cycle opened in October 2025, so these fields are already populated for published 2026 cycle courses rather than filling up from today. Courses from earlier cycles return `null` for all twelve.
+Eleven of the new fields carry the course content that `about_course`, `fee_details` and `how_school_placements_work` stopped returning for 2026 recruitment cycle courses (see the October 2025 entry below). Providers have been entering that content in Publish since the 2026 cycle opened in October 2025, so those eleven are already populated for published 2026 cycle courses rather than filling up from today. Courses from earlier cycles return `null`.
+
+The twelfth, `salary_fee_details`, belongs to the 2027 recruitment cycle and is covered by the deprecation note at the end of this entry. It returns `null` for 2026 cycle courses and earlier.
 
 Each field is a nullable string. All are markdown formatted except `interview_location`, which returns one of `online`, `in person` or `both`.
 
@@ -25,6 +27,10 @@ Each field is a nullable string. All are markdown formatted except `interview_lo
 - Add `theoretical_training_activities` field to `CourseAttributes`. Information about what trainees will do during theoretical training.
 - Add `theoretical_training_duration` field to `CourseAttributes`. Information about how much time trainees will spend in theoretical training.
 - Add `theoretical_training_location` field to `CourseAttributes`. Information about where theoretical training will take place.
+
+Deprecation:
+
+- Deprecate `salary_details` in `CourseAttributes`. From the 2027 recruitment cycle, providers enter this information as `salary_fee_details` instead, so `salary_details` is not populated for salaried courses in the 2027 cycle onwards. The field is still returned, and courses in the 2026 cycle and earlier are unaffected and continue to return their existing values.
 
 ## 22 July 2026
 

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -486,16 +486,28 @@ RSpec.describe API::Public::V1::CoursesController do
                 subject_codes
                 required_qualifications
                 about_course
+                additional_fees
+                assessment_methods
                 course_length
+                duration_per_school
                 fee_details
                 fee_international
                 fee_domestic
+                fee_schedule
                 financial_support
                 how_school_placements_work
                 interview_process
+                interview_location
                 other_requirements
                 personal_qualities
+                placement_school_activities
+                placement_selection_criteria
                 salary_details
+                salary_fee_details
+                support_and_mentorship
+                theoretical_training_activities
+                theoretical_training_duration
+                theoretical_training_location
                 can_sponsor_skilled_worker_visa
                 can_sponsor_student_visa
                 campaign_name

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -98,9 +98,13 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:code).with_value(course.course_code) }
   it { is_expected.to have_attribute(:course_length).with_value(course.latest_published_enrichment.course_length) }
   it { is_expected.to have_attribute(:created_at).with_value(course.created_at.iso8601) }
+  it { is_expected.to have_attribute(:duration_per_school).with_value(course.latest_published_enrichment.duration_per_school) }
+  it { is_expected.to have_attribute(:additional_fees).with_value(course.latest_published_enrichment.additional_fees) }
+  it { is_expected.to have_attribute(:assessment_methods).with_value(course.latest_published_enrichment.assessment_methods) }
   it { is_expected.to have_attribute(:fee_details).with_value(nil) }
   it { is_expected.to have_attribute(:fee_international).with_value(course.latest_published_enrichment.fee_international) }
   it { is_expected.to have_attribute(:fee_domestic).with_value(course.latest_published_enrichment.fee_uk_eu) }
+  it { is_expected.to have_attribute(:fee_schedule).with_value(course.latest_published_enrichment.fee_schedule) }
   it { is_expected.to have_attribute(:findable).with_value(course.findable?) }
   it { is_expected.to have_attribute(:funding_type).with_value("apprenticeship") }
   it { is_expected.to have_attribute(:gcse_subjects_required).with_value(%w[maths english science]) }
@@ -110,6 +114,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:has_vacancies).with_value(course.has_vacancies?) }
   it { is_expected.to have_attribute(:how_school_placements_work).with_value(course.latest_published_enrichment.how_school_placements_work) }
   it { is_expected.to have_attribute(:interview_process).with_value(course.latest_published_enrichment.interview_process) }
+  it { is_expected.to have_attribute(:interview_location).with_value(course.latest_published_enrichment.interview_location) }
   it { is_expected.to have_attribute(:is_send).with_value(course.is_send?) }
   it { is_expected.to have_attribute(:last_published_at).with_value(course.last_published_at.iso8601) }
   it { is_expected.to have_attribute(:level).with_value(course.level) }
@@ -117,6 +122,8 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:open_for_applications).with_value(course.open_for_applications?) }
   it { is_expected.to have_attribute(:other_requirements).with_value(course.latest_published_enrichment.other_requirements) }
   it { is_expected.to have_attribute(:personal_qualities).with_value(course.latest_published_enrichment.personal_qualities) }
+  it { is_expected.to have_attribute(:placement_school_activities).with_value(course.latest_published_enrichment.placement_school_activities) }
+  it { is_expected.to have_attribute(:placement_selection_criteria).with_value(course.latest_published_enrichment.placement_selection_criteria) }
   it { is_expected.to have_attribute(:program_type).with_value(course.program_type) }
   it { is_expected.to have_attribute(:qualifications).with_value(%w[qts pgce]) }
   it { is_expected.to have_attribute(:required_qualifications).with_value(course.latest_published_enrichment.required_qualifications) }
@@ -125,7 +132,12 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:required_qualifications_science).with_value("must_have_qualification_at_application_time") }
   it { is_expected.to have_attribute(:running).with_value(course.findable?) }
   it { is_expected.to have_attribute(:salary_details).with_value(course.latest_published_enrichment.salary_details) }
+  it { is_expected.to have_attribute(:salary_fee_details).with_value(course.latest_published_enrichment.salary_fee_details) }
   it { is_expected.to have_attribute(:scholarship_amount).with_value(nil) }
+  it { is_expected.to have_attribute(:support_and_mentorship).with_value(course.latest_published_enrichment.support_and_mentorship) }
+  it { is_expected.to have_attribute(:theoretical_training_activities).with_value(course.latest_published_enrichment.theoretical_training_activities) }
+  it { is_expected.to have_attribute(:theoretical_training_duration).with_value(course.latest_published_enrichment.theoretical_training_duration) }
+  it { is_expected.to have_attribute(:theoretical_training_location).with_value(course.latest_published_enrichment.theoretical_training_location) }
   it { is_expected.to have_attribute(:can_sponsor_skilled_worker_visa) }
   it { is_expected.to have_attribute(:can_sponsor_student_visa) }
   it { is_expected.to have_attribute(:campaign_name) }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -493,14 +493,14 @@
           "salary_details": {
             "type": "string",
             "nullable": true,
-            "description": "Salary details about this course.",
+            "description": "Salary details about this course. This field is being deprecated after the 2026 recruitment cycle, and is not populated for 2027 recruitment cycle courses onwards, where `salary_fee_details` is used instead.",
             "example": "Successful applicants will be employed as unqualified teachers on at least Point 1 of the Unqualified Teachers' Pay Scale for the duration of the programme."
           },
           "salary_fee_details": {
             "type": "string",
             "nullable": true,
             "format": "markdown",
-            "description": "Information about course fees for salaried courses.",
+            "description": "Information about course fees for salaried courses. Populated for 2027 recruitment cycle courses onwards, where it replaces `salary_details`.",
             "example": "The employing school covers the course fee. Trainees do not pay tuition fees."
           },
           "school_experience_required": {

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -142,6 +142,13 @@
             "nullable": true,
             "example": "2FR"
           },
+          "additional_fees": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Further information about any additional course fees or costs.",
+            "example": "Trainees are responsible for travel costs to placement schools."
+          },
           "age_minimum": {
             "type": "integer",
             "description": "The minimum age of pupils this course is specified for.",
@@ -157,6 +164,13 @@
             "format": "date",
             "description": "Date from which applications can be submitted. This field is being deprecated after 2025 recruitment cycle.",
             "example": "2019-10-08"
+          },
+          "assessment_methods": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about how trainees will be assessed.",
+            "example": "Trainees are assessed through observations, written assignments and portfolio evidence."
           },
           "bursary_amount": {
             "type": "integer",
@@ -197,6 +211,13 @@
             "description": "Timestamp of when this course was created.",
             "example": "2019-06-13T10:44:31Z"
           },
+          "duration_per_school": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about how much time trainees will spend in each placement school.",
+            "example": "Trainees usually spend one term in their first school and two terms in their second school."
+          },
           "fee_details": {
             "type": "string",
             "nullable": true,
@@ -215,6 +236,13 @@
             "nullable": true,
             "description": "Fee in GBP for UK students.",
             "example": 9200
+          },
+          "fee_schedule": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about when fees are due.",
+            "example": "Fees are paid in three instalments during the academic year."
           },
           "financial_support": {
             "type": "string",
@@ -296,6 +324,17 @@
             "description": "Additional information about how the interview process will work for applicants.",
             "example": "At your interview day you will take part in a combination of group and individual interviews with members of the programme team, and you may also be asked to undertake written or presentation tasks, depending on your subject."
           },
+          "interview_location": {
+            "type": "string",
+            "nullable": true,
+            "description": "Information about where interviews will take place.",
+            "example": "both",
+            "enum": [
+              "online",
+              "in person",
+              "both"
+            ]
+          },
           "is_send": {
             "type": "boolean",
             "description": "Does this course have a SEND specialism?",
@@ -341,6 +380,20 @@
             "format": "markdown",
             "description": "This field is being deprecated after 2024 recruitment cycle.",
             "example": null
+          },
+          "placement_school_activities": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about what trainees will do in their placement schools.",
+            "example": "Trainees observe lessons, plan teaching activities and gradually take on classroom responsibilities."
+          },
+          "placement_selection_criteria": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about how placement schools are selected for trainees.",
+            "example": "We match trainees to schools based on subject, phase, location and training needs."
           },
           "program_type": {
             "type": "string",
@@ -443,6 +496,13 @@
             "description": "Salary details about this course.",
             "example": "Successful applicants will be employed as unqualified teachers on at least Point 1 of the Unqualified Teachers' Pay Scale for the duration of the programme."
           },
+          "salary_fee_details": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about course fees for salaried courses.",
+            "example": "The employing school covers the course fee. Trainees do not pay tuition fees."
+          },
           "school_experience_required": {
             "type": "boolean",
             "nullable": true,
@@ -501,6 +561,34 @@
               "type": "string",
               "example": "00"
             }
+          },
+          "support_and_mentorship": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about how trainees will be supported and mentored during school placements.",
+            "example": "Each trainee has a subject mentor, a professional mentor and regular reviews with the course team."
+          },
+          "theoretical_training_activities": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about what trainees will do during theoretical training.",
+            "example": "Trainees attend seminars, subject workshops and independent study sessions."
+          },
+          "theoretical_training_duration": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about how much time trainees will spend in theoretical training.",
+            "example": "Trainees spend one day a week in centre-based training."
+          },
+          "theoretical_training_location": {
+            "type": "string",
+            "nullable": true,
+            "format": "markdown",
+            "description": "Information about where theoretical training will take place.",
+            "example": "Theoretical training takes place at the provider's main campus and online."
           },
           "visa_sponsorship_application_deadline_at": {
             "type": "string",

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -131,7 +131,7 @@
             "type": "string",
             "nullable": true,
             "format": "markdown",
-            "description": "Short factual summary of the course.",
+            "description": "Short factual summary of the course. Returns null for courses published or updated from the 2026 recruitment cycle onwards, where this information is instead split across `placement_school_activities`, `theoretical_training_activities`, `assessment_methods` and `support_and_mentorship`.",
             "example": "The Secondary PGCE consists of three core modules: two Master's-level modules, which are assessed through written assignments, and the Professional Practice module, which is assessed by the observation of practical teaching in placement schools."
           },
           "accredited_provider_code": {
@@ -222,7 +222,7 @@
             "type": "string",
             "nullable": true,
             "format": "markdown",
-            "description": "Further details about the fees for this course, if applicable.",
+            "description": "Further details about the fees for this course, if applicable. Returns null for courses published or updated from the 2026 recruitment cycle onwards, where this information is instead split across `additional_fees`, `fee_schedule` and `salary_fee_details`.",
             "example": "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable."
           },
           "fee_international": {
@@ -314,7 +314,7 @@
             "type": "string",
             "nullable": true,
             "format": "markdown",
-            "description": "Additional information about the schools applicants will be teaching in.",
+            "description": "Additional information about the schools applicants will be teaching in. Returns null for courses published or updated from the 2026 recruitment cycle onwards, where this information is instead split across `placement_selection_criteria`, `duration_per_school`, `theoretical_training_location` and `theoretical_training_duration`.",
             "example": "You will spend two-thirds of your time (120 days) in schools, working with art and design mentors who support you through your two school placements."
           },
           "interview_process": {

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -35,6 +35,12 @@ properties:
     minLength: 3
     nullable: true
     example: 2FR
+  additional_fees:
+    type: string
+    nullable: true
+    format: markdown
+    description: Further information about any additional course fees or costs.
+    example: "Trainees are responsible for travel costs to placement schools."
   age_minimum:
     type: integer
     description: >-
@@ -50,6 +56,12 @@ properties:
     format: date
     description: "Date from which applications can be submitted. This field is being deprecated after 2025 recruitment cycle."
     example: "2019-10-08"
+  assessment_methods:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about how trainees will be assessed.
+    example: "Trainees are assessed through observations, written assignments and portfolio evidence."
   bursary_amount:
     type: integer
     nullable: true
@@ -85,6 +97,12 @@ properties:
     format: date-time
     description: "Timestamp of when this course was created."
     example: "2019-06-13T10:44:31Z"
+  duration_per_school:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about how much time trainees will spend in each placement school.
+    example: "Trainees usually spend one term in their first school and two terms in their second school."
   fee_details:
     type: string
     nullable: true
@@ -101,6 +119,12 @@ properties:
     nullable: true
     description: "Fee in GBP for UK students."
     example: 9200
+  fee_schedule:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about when fees are due.
+    example: "Fees are paid in three instalments during the academic year."
   financial_support:
     type: string
     nullable: true
@@ -173,6 +197,15 @@ properties:
       and individual interviews with members of the programme team, and
       you may also be asked to undertake written or presentation tasks,
       depending on your subject.
+  interview_location:
+    type: string
+    nullable: true
+    description: Information about where interviews will take place.
+    example: both
+    enum:
+      - online
+      - in person
+      - both
   is_send:
     type: boolean
     description: "Does this course have a SEND specialism?"
@@ -216,6 +249,18 @@ properties:
     description: >-
       This field is being deprecated after 2024 recruitment cycle.
     example:
+  placement_school_activities:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about what trainees will do in their placement schools.
+    example: "Trainees observe lessons, plan teaching activities and gradually take on classroom responsibilities."
+  placement_selection_criteria:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about how placement schools are selected for trainees.
+    example: "We match trainees to schools based on subject, phase, location and training needs."
   program_type:
     type: string
     description: >-
@@ -295,6 +340,12 @@ properties:
       Successful applicants will be employed as unqualified teachers on
       at least Point 1 of the Unqualified Teachers' Pay Scale for the
       duration of the programme.
+  salary_fee_details:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about course fees for salaried courses.
+    example: "The employing school covers the course fee. Trainees do not pay tuition fees."
   school_experience_required:
     type: boolean
     nullable: true
@@ -345,6 +396,30 @@ properties:
     items:
       type: string
       example: "00"
+  support_and_mentorship:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about how trainees will be supported and mentored during school placements.
+    example: "Each trainee has a subject mentor, a professional mentor and regular reviews with the course team."
+  theoretical_training_activities:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about what trainees will do during theoretical training.
+    example: "Trainees attend seminars, subject workshops and independent study sessions."
+  theoretical_training_duration:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about how much time trainees will spend in theoretical training.
+    example: "Trainees spend one day a week in centre-based training."
+  theoretical_training_location:
+    type: string
+    nullable: true
+    format: markdown
+    description: Information about where theoretical training will take place.
+    example: "Theoretical training takes place at the provider's main campus and online."
   visa_sponsorship_application_deadline_at:
     type: string
     nullable: true

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -337,7 +337,10 @@ properties:
   salary_details:
     type: string
     nullable: true
-    description: "Salary details about this course."
+    description: >-
+      Salary details about this course. This field is being deprecated after the
+      2026 recruitment cycle, and is not populated for 2027 recruitment cycle
+      courses onwards, where `salary_fee_details` is used instead.
     example: >-
       Successful applicants will be employed as unqualified teachers on
       at least Point 1 of the Unqualified Teachers' Pay Scale for the
@@ -346,7 +349,9 @@ properties:
     type: string
     nullable: true
     format: markdown
-    description: Information about course fees for salaried courses.
+    description: >-
+      Information about course fees for salaried courses. Populated for 2027
+      recruitment cycle courses onwards, where it replaces `salary_details`.
     example: "The employing school covers the course fee. Trainees do not pay tuition fees."
   school_experience_required:
     type: boolean

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -18,7 +18,8 @@ properties:
     type: string
     nullable: true
     format: markdown
-    description: Short factual summary of the course.
+    description: >-
+      Short factual summary of the course. Returns null for courses published or updated from the 2026 recruitment cycle onwards, where this information is instead split across `placement_school_activities`, `theoretical_training_activities`, `assessment_methods` and `support_and_mentorship`.
     example: >-
       The Secondary PGCE consists of three core modules: two
       Master's-level modules, which are assessed through written
@@ -107,7 +108,8 @@ properties:
     type: string
     nullable: true
     format: markdown
-    description: "Further details about the fees for this course, if applicable."
+    description: >-
+      Further details about the fees for this course, if applicable. Returns null for courses published or updated from the 2026 recruitment cycle onwards, where this information is instead split across `additional_fees`, `fee_schedule` and `salary_fee_details`.
     example: "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable."
   fee_international:
     type: integer
@@ -181,7 +183,7 @@ properties:
     nullable: true
     format: markdown
     description: >-
-      Additional information about the schools applicants will be teaching in.
+      Additional information about the schools applicants will be teaching in. Returns null for courses published or updated from the 2026 recruitment cycle onwards, where this information is instead split across `placement_selection_criteria`, `duration_per_school`, `theoretical_training_location` and `theoretical_training_duration`.
     example: >-
       You will spend two-thirds of your time (120 days) in schools,
       working with art and design mentors who support you through your


### PR DESCRIPTION
## Context

  Providers have been entering long-form course content in Publish since the 2026 cycle opened in October 2025, but the API never returned it. At the same time `about_course`, `fee_details` and
  `how_school_placements_work` began returning `null` for 2026 cycle courses, so that content was not reachable through the API at all.

  The surprising part is how much of this shipped without a release note. The nullification went out with the 2026 cycle unannounced, and `school_experience_required` / `school_experience_required_content` have
  been in the published schema since July with no entry. This PR exposes the replacement fields and backfills the missing notes.

  Nothing is removed or renamed. The API is unversioned, so the 2027 changes are delayed additions and deprecations.

  ## Changes proposed in this pull request

  **API** — serialize twelve enrichment fields on `CourseAttributes`: `additional_fees`, `assessment_methods`, `duration_per_school`, `fee_schedule`, `interview_location`, `placement_school_activities`,
  `placement_selection_criteria`, `salary_fee_details`, `support_and_mentorship`, `theoretical_training_activities`, `theoretical_training_duration`, `theoretical_training_location`.

  **Schema** — document the twelve fields in `CourseAttributes.yml` and regenerate `api_spec.json`. Add notes to `about_course`, `fee_details` and `how_school_placements_work` naming the fields that replace them,
  and to `salary_details` / `salary_fee_details` covering the 2027 swap.

  **Release notes** — three entries:

  - **21 August 2026** — the twelve new fields, plus the `salary_details` deprecation. Eleven are 2026 cycle content and are already populated; `salary_fee_details` is a 2027 field.
  - **23 July 2026** — backdated, for the two school experience fields.
  - **October 2025** — backdated, for the nullification.

  ## Guidance to review

  Read `docs/source/release-notes.html.md.erb` top-down first. The three entries are meant to be read together, since the twelve additions only make sense against the October 2025 nullification.

  The `api_spec.json` diff is generated, not hand-edited. Regenerate with `bundle exec rake rswag:specs:swaggerize` to confirm it matches. Note the generator strips the trailing newline, which I restored by hand
  to keep the diff small.

  Specs all pass: serializable_course_spec (92), public v1 courses_controller_spec (25), rswag swaggerize (12), and the docs site suite (4).

  Three things I would like a second opinion on:

  1. **The October 2025 heading has no day.** Cycle dates live in the `recruitment_cycles` table rather than config, so I could not derive the 2026 cycle open date. Pin it if you know it.
  2. **Two gating styles are in play** and the notes deliberately distinguish them. Nullified fields keep their key; conditional fields (school experience) are absent from `attributes` entirely. Worth checking
  that wording reads clearly to an external consumer.
  3. **`salary_details` is described as still returned but unpopulated from 2027.** It is not in `NULLIFY_ENRICHMENT_ATTRIBUTES` and nothing blanks stored values. If the intent is to actively null it like the
  other three, that is a code change and this note needs rewording.

  ## Checklist

  - [ ] I have moved hard-coded strings to locale files. — n/a, no UI changes
  - [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests. — n/a, no HTML changes