### PR TITLE
Move error reporting rate limiter onto Rails.cache

### DIFF
--- a/app/lib/error_reporting/rate_limiter.rb
+++ b/app/lib/error_reporting/rate_limiter.rb
@@ -1,30 +1,32 @@
 module ErrorReporting
-  # Use Redis to keep track of errors reported.
-  # If more than threshold of any error exists then report
-  # Always delete entries older than the window
+  # Count errors in Rails.cache using per-minute counters.
+  # Report when the total across the window reaches the threshold.
   #
-  # Return true if more than threshold entries exist withiing the window
+  # Returns true when the threshold has been reached within the window.
   class RateLimiter
+    BUCKET = 1.minute
+
     def self.report?(key:, threshold:, window: 1.hour)
-      redis = RedisClient.cache
-      now = Time.zone.now.utc.to_f
-      events_key = "error_reporting:events:#{key}"
+      now = Time.zone.now
+      bucket = now.to_i / BUCKET.to_i
+      expires_in = window.to_i + BUCKET.to_i
 
-      count = redis.multi { |r|
-        # Add one or more members to a sorted set
-        r.zadd(events_key, now, "#{now}-#{SecureRandom.hex(4)}")
-        # Remove all members in a sorted set within the given scores.
-        r.zremrangebyscore(events_key, "-inf", now - window.to_i)
-        # Set a key's time to live in seconds.
-        r.expire(events_key, window.to_i + 60)
-        # Get the number of members in a sorted set.
-        r.zcard(events_key)
-      }.last
+      current = Rails.cache.increment(cache_key(key, bucket), 1, expires_in: expires_in)
+      return true if current.nil?
 
-      count >= threshold
-    rescue Redis::BaseError => e
-      Rails.logger.tagged("ErrorReporting::RateLimiter") { |l| l.error(e.message) }
+      minutes = window.to_i / BUCKET.to_i
+      previous_keys = (1...minutes).map { |offset| cache_key(key, bucket - offset) }
+      previous_total = Rails.cache.read_multi(*previous_keys, raw: true).values.sum(&:to_i)
+
+      current + previous_total >= threshold
+    rescue StandardError => e
+      Rails.logger.tagged("ErrorReporting::RateLimiter") { |l| l.error(e.full_message) }
       true
     end
+
+    def self.cache_key(key, bucket)
+      "error_reporting:#{key}:#{bucket}"
+    end
+    private_class_method :cache_key
   end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -4,8 +4,4 @@ class RedisClient
   def self.current
     @current ||= Redis.new(url: ENV.fetch("REDIS_WORKER_URL", nil))
   end
-
-  def self.cache
-    @cache ||= Redis.new(url: ENV.fetch("REDIS_CACHE_URL") { ENV.fetch("REDIS_WORKER_URL", nil) })
-  end
 end

--- a/spec/lib/error_reporting/rate_limiter_spec.rb
+++ b/spec/lib/error_reporting/rate_limiter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ErrorReporting::RateLimiter do
     expect(described_class.report?(key: "a", threshold: 10)).to be true
   end
 
-  it "uses a sliding window so old events age out" do
+  it "ages out counts from outside the window" do
     Timecop.freeze do
       10.times { described_class.report?(key: "x", threshold: 10, window: 1.hour) }
       expect(described_class.report?(key: "x", threshold: 10, window: 1.hour)).to be true
@@ -25,9 +25,23 @@ RSpec.describe ErrorReporting::RateLimiter do
     end
   end
 
-  it "fails open if Redis raises" do
-    allow(RedisClient.cache).to receive(:multi).and_raise(Redis::TimeoutError)
+  it "fails open if the cache raises" do
+    allow(Rails.cache).to receive(:increment).and_raise(StandardError)
 
     expect(described_class.report?(key: "x", threshold: 10)).to be true
+  end
+
+  it "fails open if the cache returns nil" do
+    allow(Rails.cache).to receive(:increment).and_return(nil)
+
+    expect(described_class.report?(key: "x", threshold: 10)).to be true
+  end
+
+  it "reads previous buckets as raw values for Redis compatibility" do
+    allow(Rails.cache).to receive_messages(increment: 1, read_multi: {})
+
+    described_class.report?(key: "x", threshold: 10, window: 2.minutes)
+
+    expect(Rails.cache).to have_received(:read_multi).with(a_string_matching(/error_reporting:x:\d+/), raw: true)
   end
 end

--- a/spec/support/mock_redis.rb
+++ b/spec/support/mock_redis.rb
@@ -8,6 +8,5 @@ RSpec.configure do |config|
     allow(Redis).to receive(:new).and_return(mock_redis)
 
     RedisClient.current.flushdb
-    RedisClient.cache.flushdb
   end
 end


### PR DESCRIPTION
## Context

`ErrorReporting::RateLimiter` was the only code path still talking to Redis via `RedisClient.cache`. Everything else already uses `Rails.cache`. This moves the limiter onto `Rails.cache` so we can drop that dedicated Redis client.

No infra or cache-store changes — production still uses Redis via `redis_cache_store`.

## Changes proposed in this pull request

- Refactor `ErrorReporting::RateLimiter` to store event timestamps in `Rails.cache` (sliding window kept)
- Update the rate limiter specs
- Remove `RedisClient.cache` from `config/initializers/redis.rb` and `spec/support/mock_redis.rb`
