### PR TITLE
Exclude closed courses from email alerts

### DIFF
--- a/app/mailers/email_alert_mailer.rb
+++ b/app/mailers/email_alert_mailer.rb
@@ -25,7 +25,7 @@ class EmailAlertMailer < GovukNotifyRails::Mailer
     @unsubscribe_url = unsubscribe_url(email_alert)
     @utm_params = UTM_PARAMS
 
-    search_params = email_alert.search_params
+    search_params = email_alert.search_params_for_matching
     search_params[:order] = "newest_course" if @remaining_count.positive?
     @search_url = find_results_url(search_params)
     @summary_rows = build_summary_rows(

--- a/app/models/candidate/email_alert.rb
+++ b/app/models/candidate/email_alert.rb
@@ -23,6 +23,12 @@ class Candidate
       params
     end
 
+    # Alerts only ever offer courses a candidate can still apply to, so both the
+    # matching and the "view more" link in the email have to agree on that.
+    def search_params_for_matching
+      search_params.merge(applications_open: true)
+    end
+
     def unsubscribe!
       update!(unsubscribed_at: Time.current)
     end

--- a/app/services/find/process_weekly_email_alerts_service.rb
+++ b/app/services/find/process_weekly_email_alerts_service.rb
@@ -32,7 +32,9 @@ module Find
   private
 
     def find_matching_courses(alert, recently_published_ids)
-      ::Courses::Query.call(params: alert.search_params.dup).where(id: recently_published_ids)
+      params = alert.search_params.dup.merge(applications_open: true)
+
+      ::Courses::Query.call(params:).where(id: recently_published_ids)
     end
   end
 end

--- a/app/services/find/process_weekly_email_alerts_service.rb
+++ b/app/services/find/process_weekly_email_alerts_service.rb
@@ -32,9 +32,7 @@ module Find
   private
 
     def find_matching_courses(alert, recently_published_ids)
-      params = alert.search_params.dup.merge(applications_open: true)
-
-      ::Courses::Query.call(params:).where(id: recently_published_ids)
+      ::Courses::Query.call(params: alert.search_params_for_matching).where(id: recently_published_ids)
     end
   end
 end

--- a/spec/mailers/email_alert_mailer_spec.rb
+++ b/spec/mailers/email_alert_mailer_spec.rb
@@ -131,6 +131,33 @@ describe EmailAlertMailer do
       body = mail.govuk_notify_personalisation[:body]
       expect(body).not_to include("order=newest_course")
     end
+
+    it "filters the search URL to open courses so it cannot offer what the alert excluded" do
+      many_courses = create_list(:course, 4, :published, :with_accrediting_provider)
+      mail = described_class.weekly_digest(email_alert, many_courses)
+
+      body = mail.govuk_notify_personalisation[:body]
+      view_more_url = body[%r{\(\S*/results\?\S+\)}].delete("()")
+
+      expect(view_more_url).to include("applications_open=true")
+    end
+
+    context "when the alert saved criteria of its own" do
+      let(:email_alert) do
+        create(:email_alert, candidate:, subjects: %w[C1], search_attributes: { "funding" => "salary" })
+      end
+
+      it "keeps them alongside the forced open filter" do
+        many_courses = create_list(:course, 4, :published, :with_accrediting_provider)
+        mail = described_class.weekly_digest(email_alert, many_courses)
+
+        body = mail.govuk_notify_personalisation[:body]
+        view_more_url = body[%r{\(\S*/results\?\S+\)}].delete("()")
+
+        expect(view_more_url).to include("applications_open=true")
+        expect(view_more_url).to include("funding=salary")
+      end
+    end
   end
 
   describe "sanitisation of user-controlled input" do

--- a/spec/models/candidate/email_alert_spec.rb
+++ b/spec/models/candidate/email_alert_spec.rb
@@ -71,6 +71,40 @@ RSpec.describe Candidate::EmailAlert, type: :model do
     end
   end
 
+  describe "#search_params_for_matching" do
+    it "forces the applications open filter on top of the saved criteria" do
+      email_alert = build(
+        :email_alert,
+        subjects: %w[C1],
+        search_attributes: { "funding" => "salary" },
+      )
+
+      result = email_alert.search_params_for_matching
+
+      expect(result).to eq(
+        funding: "salary",
+        subjects: %w[C1],
+        applications_open: true,
+      )
+    end
+
+    it "keeps the filter on when the alert already saved it" do
+      email_alert = build(:email_alert, subjects: [], search_attributes: { "applications_open" => "true" })
+
+      result = email_alert.search_params_for_matching
+
+      expect(result).to eq(applications_open: true)
+    end
+
+    it "leaves the saved criteria untouched" do
+      email_alert = build(:email_alert, subjects: [], search_attributes: { "level" => "primary" })
+
+      email_alert.search_params_for_matching
+
+      expect(email_alert.search_params).to eq(level: "primary")
+    end
+  end
+
   describe "subscription limit validation" do
     it "is valid when below the subscription limit" do
       candidate = create(:candidate)

--- a/spec/services/find/process_weekly_email_alerts_service_integration_spec.rb
+++ b/spec/services/find/process_weekly_email_alerts_service_integration_spec.rb
@@ -241,6 +241,15 @@ module Find
         job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
         expect(job["arguments"].second).to contain_exactly(open_biology.id)
       end
+
+      it "sends no email when every recently published match is closed" do
+        create_findable_course(name: "Closed Biology", subjects: [biology], application_status: :closed)
+
+        create(:email_alert, candidate:, subjects: %w[C1])
+
+        expect { described_class.call(since: 1.week.ago) }
+          .not_to have_enqueued_job(EmailAlertMailerJob)
+      end
     end
 
     describe "edge cases" do

--- a/spec/services/find/process_weekly_email_alerts_service_integration_spec.rb
+++ b/spec/services/find/process_weekly_email_alerts_service_integration_spec.rb
@@ -250,6 +250,21 @@ module Find
         expect { described_class.call(since: 1.week.ago) }
           .not_to have_enqueued_job(EmailAlertMailerJob)
       end
+
+      it "excludes closed courses even when the alert saved the applications open filter" do
+        open_biology = create_findable_course(name: "Open Biology", subjects: [biology])
+        create_findable_course(name: "Closed Biology", subjects: [biology], application_status: :closed)
+
+        create(:email_alert, candidate:,
+                             subjects: %w[C1],
+                             search_attributes: { "applications_open" => "true" })
+
+        expect { described_class.call(since: 1.week.ago) }
+          .to have_enqueued_job(EmailAlertMailerJob).once
+
+        job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
+        expect(job["arguments"].second).to contain_exactly(open_biology.id)
+      end
     end
 
     describe "edge cases" do

--- a/spec/services/find/process_weekly_email_alerts_service_integration_spec.rb
+++ b/spec/services/find/process_weekly_email_alerts_service_integration_spec.rb
@@ -228,6 +228,21 @@ module Find
       end
     end
 
+    describe "courses closed for applications" do
+      it "excludes a closed course from an otherwise matching set" do
+        open_biology = create_findable_course(name: "Open Biology", subjects: [biology])
+        create_findable_course(name: "Closed Biology", subjects: [biology], application_status: :closed)
+
+        create(:email_alert, candidate:, subjects: %w[C1])
+
+        expect { described_class.call(since: 1.week.ago) }
+          .to have_enqueued_job(EmailAlertMailerJob).once
+
+        job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
+        expect(job["arguments"].second).to contain_exactly(open_biology.id)
+      end
+    end
+
     describe "edge cases" do
       it "handles an alert with no subjects and no location (broad match)" do
         create_findable_course(name: "Any course", subjects: [biology])

--- a/spec/services/find/process_weekly_email_alerts_service_spec.rb
+++ b/spec/services/find/process_weekly_email_alerts_service_spec.rb
@@ -114,6 +114,29 @@ module Find
         expect(BatchDelivery).to have_received(:new)
           .with(relation: anything, stagger_over: 1.hour, batch_size: 100)
       end
+
+      it "does not enqueue a job when the only recently published course is closed for applications" do
+        course = create(:course, :published, :with_full_time_sites, :closed)
+        course.enrichments.first.update!(last_published_timestamp_utc: 2.days.ago)
+
+        create(:email_alert, candidate:, subjects: [])
+
+        expect { described_class.call(since: 1.week.ago) }
+          .not_to have_enqueued_job(EmailAlertMailerJob)
+      end
+
+      it "enqueues only the courses that are open for applications" do
+        open_course = create(:course, :published_postgraduate)
+        open_course.enrichments.first.update!(last_published_timestamp_utc: 2.days.ago)
+        closed_course = create(:course, :published, :with_full_time_sites, :closed)
+        closed_course.enrichments.first.update!(last_published_timestamp_utc: 2.days.ago)
+
+        alert = create(:email_alert, candidate:, subjects: [])
+
+        expect { described_class.call(since: 1.week.ago) }
+          .to have_enqueued_job(EmailAlertMailerJob)
+          .with(alert.id, [open_course.id])
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Candidates were getting email alerts that listed courses which are closed for applications. Clicking one of those courses in the email took them to a page saying it is not accepting applications. This happens because the alert reuses the Find search query, and that query only hides closed courses when the candidate ticked the "Applications open" box. Most saved alerts never ticked it, so closed courses were counted in the total and listed in the email.

The alert now always leaves closed courses out, whatever the candidate saved. If every new course that week is closed, no email is sent at all. Find search itself is not changed: it still shows closed courses with a "Closed" tag, which is right for browsing but wrong for an alert. Five specs cover this, split across five commits. Two unit specs fail without the fix, and three end to end specs check a mixed set of open and closed courses, a set where all are closed, and an alert that had already ticked the box.
