### PR TITLE
Add a filter box to the provider schools list

### DIFF
--- a/app/components/publish/providers/schools/filter_component.html.erb
+++ b/app/components/publish/providers/schools/filter_component.html.erb
@@ -1,0 +1,38 @@
+<%= form_with(url: index_path, method: :get, local: true) do |f| %>
+  <div class="app-school-search">
+    <div class="govuk-form-group govuk-!-margin-bottom-3">
+      <label class="govuk-label govuk-label--m" for="filter">
+        <%= t(".label") %>
+      </label>
+
+      <div class="govuk-hint" id="filter-hint"><%= t(".hint") %></div>
+
+      <div class="app-school-search__row">
+        <%# The controller wraps the field alone: it enhances the first
+            non-hidden input it finds, which must be the box and not the
+            Search button. %>
+        <div <%= tag.attributes(data: remote_autocomplete_data(path: suggestions_path, format: "school")) %>>
+          <%= text_field_tag :filter,
+                filter,
+                class: "govuk-input",
+                autocomplete: "off",
+                aria: { describedby: "filter-hint" } %>
+        </div>
+
+        <%= f.submit t(".button"), class: "govuk-button", data: { module: "govuk-button" } %>
+      </div>
+    </div>
+
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      <%= govuk_link_to t(".clear"), index_path %>
+    </p>
+  </div>
+<% end %>
+
+<%# Below the panel rather than in it: the line describes the list that follows,
+    not the box that produced it. %>
+<% if showing_results? %>
+  <p class="govuk-body">
+    <%= t(".showing_results_html", filter:) %>
+  </p>
+<% end %>

--- a/app/components/publish/providers/schools/filter_component.rb
+++ b/app/components/publish/providers/schools/filter_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Publish
+  module Providers
+    module Schools
+      # The filter box above the provider's paginated list of schools.
+      #
+      # Without JavaScript it is a plain text field that GETs the schools index,
+      # which does the narrowing server-side. The remote-autocomplete controller
+      # enhances it with suggestions drawn from the provider's own schools, so
+      # the dropdown only ever offers rows the list can be narrowed down to.
+      class FilterComponent < ViewComponent::Base
+        include RemoteAutocompleteHelper
+
+        def initialize(provider:, recruitment_cycle:, results_count:, filter: nil)
+          super()
+
+          @provider = provider
+          @recruitment_cycle = recruitment_cycle
+          @results_count = results_count
+          @filter = filter
+        end
+
+        # The list says what it was filtered by only when it has rows to show:
+        # on an empty list the index's own "No schools found" message says it,
+        # and repeating the term above it reads as a contradiction.
+        def showing_results?
+          filter.present? && results_count.positive?
+        end
+
+        def index_path
+          publish_provider_recruitment_cycle_schools_path(provider.provider_code, recruitment_cycle.year)
+        end
+
+        def suggestions_path
+          filter_publish_provider_recruitment_cycle_schools_path(provider.provider_code, recruitment_cycle.year)
+        end
+
+      private
+
+        attr_reader :provider, :recruitment_cycle, :filter, :results_count
+      end
+    end
+  end
+end

--- a/app/controllers/publish/providers/schools/filter_controller.rb
+++ b/app/controllers/publish/providers/schools/filter_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Publish
+  module Providers
+    module Schools
+      # Suggestions for the filter box above the provider's list of schools.
+      #
+      # Scoped to the schools the provider has already added, so every
+      # suggestion is a row the filter can actually narrow the list down to.
+      class FilterController < ApplicationController
+        MIN_QUERY_LENGTH = 3
+        LIMIT = 15
+
+        def index
+          return head :bad_request if query.to_s.length < MIN_QUERY_LENGTH
+
+          render json: suggestions
+        end
+
+      private
+
+        def suggestions
+          provider
+            .schools
+            .filtered_by(query)
+            .ordered_by_name
+            .limit(LIMIT)
+            .map { |school| { name: school.location_name, town: school.town, postcode: school.postcode } }
+        end
+
+        # `query` rather than `filter`: this is the shared remote-autocomplete
+        # controller's parameter, the same one api/school_suggestions answers to.
+        # The list's own narrowing is `filter` - see SchoolsController#index.
+        def query
+          params[:query]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -9,7 +9,8 @@ module Publish
       PER_PAGE = 20
 
       def index
-        @pagy, @schools = pagy(provider.schools.ordered_by_name, limit: PER_PAGE)
+        @filter = params[:filter]
+        @pagy, @schools = pagy(provider.schools.filtered_by(@filter).ordered_by_name, limit: PER_PAGE)
       end
 
       def show; end

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -20,6 +20,18 @@ class Provider::School < ApplicationRecord
   # Used to keep closed schools out of the rollover.
   scope :with_available_gias_school, -> { joins(:gias_school).merge(GiasSchool.available) }
 
+  # Narrows the list to schools whose GIAS record matches the given text -
+  # name, town, postcode or URN, per GiasSchool's own search scope.
+  #
+  # The match runs as a subquery rather than a merge because pg_search builds
+  # its own SELECT and ORDER BY for ranking, which would fight `ordered_by_name`
+  # and pagy's count over the same relation.
+  scope :filtered_by, lambda { |filter|
+    next all if filter.blank?
+
+    where(gias_school_id: GiasSchool.search(filter).select(:id))
+  }
+
   scope :ordered_by_name, -> { joins(:gias_school).includes(:gias_school).order("gias_school.name") }
 
   delegate :recruitment_cycle, :provider_code, to: :provider, allow_nil: true

--- a/app/views/publish/providers/schools/index.html.erb
+++ b/app/views/publish/providers/schools/index.html.erb
@@ -13,6 +13,13 @@
     <p class="govuk-body">
       <%= t(".gias_school_text_html", link: govuk_link_to(t(".gias_link_text"), t(".gias_url"))) %>
     </p>
+    <%= render Publish::Providers::Schools::FilterComponent.new(
+      provider: @provider,
+      recruitment_cycle: @recruitment_cycle,
+      results_count: @pagy.count,
+      filter: @filter,
+    ) %>
+
     <% if @schools.any? %>
       <table class="govuk-table app-table--vertical-align-middle app-table--no-collapse">
         <thead class="govuk-table__head">
@@ -37,6 +44,13 @@
       recruitment_cycle: @recruitment_cycle,
       provider: @provider,
     ) %>
+    <% elsif @filter.present? %>
+      <div class="app-school-search__no-results">
+        <p class="govuk-body">
+          <%= t(".no_results") %>
+          <%= govuk_link_to t(".view_all_schools"), publish_provider_recruitment_cycle_schools_path(@provider.provider_code, @recruitment_cycle.year) %>
+        </p>
+      </div>
     <% end %>
   </div>
 </div>

--- a/config/locales/en/components/publish/providers/schools/filter_component.yml
+++ b/config/locales/en/components/publish/providers/schools/filter_component.yml
@@ -1,0 +1,10 @@
+en:
+  publish:
+    providers:
+      schools:
+        filter_component:
+          label: Search for a school in the list
+          hint: Enter the name of a school, university or college. You can also enter a postcode or URN.
+          button: Search
+          clear: Clear search
+          showing_results_html: Showing results for <strong>“%{filter}”</strong>

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -145,6 +145,8 @@ en:
       schools: # file
         index:
           gias_school_text_html: You can only add schools that are on %{link}.
+          no_results: No schools found with that search.
+          view_all_schools: View all schools
           gias_link_text: Get Information About Schools (GIAS)
           gias_url: https://get-information-schools.service.gov.uk/Search?SelectedTab=Establishments
       study_site_search:

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -90,7 +90,6 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
 
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"
-    get "schools"
 
     resources :recruitment_cycles, param: :year, constraints: CycleYearConstraint.new, path: "", only: [:show] do
       get "/about", on: :member, to: "providers#about"
@@ -357,6 +356,8 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
           end
 
           collection do
+            get "/filter", to: "schools/filter#index"
+
             get "/search", to: "schools/search#new"
             post "/search", to: "schools/search#create"
             put "/search", to: "schools/search#update"

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -20,6 +20,35 @@ describe Provider::School do
     end
   end
 
+  describe ".filtered_by" do
+    it "matches on the GIAS school name" do
+      matching = create(:provider_school, gias_school: create(:gias_school, name: "Bramblewood Primary"))
+      create(:provider_school, gias_school: create(:gias_school, name: "Harborne Academy"))
+
+      expect(described_class.filtered_by("Bramblewood")).to contain_exactly(matching)
+    end
+
+    it "matches on the GIAS school postcode" do
+      matching = create(:provider_school, gias_school: create(:gias_school, postcode: "SY2 5RJ"))
+      create(:provider_school, gias_school: create(:gias_school, postcode: "B17 9NG"))
+
+      expect(described_class.filtered_by("SY2")).to contain_exactly(matching)
+    end
+
+    it "matches on the GIAS school URN" do
+      matching = create(:provider_school, gias_school: create(:gias_school, urn: "123456"))
+      create(:provider_school, gias_school: create(:gias_school, urn: "654321"))
+
+      expect(described_class.filtered_by("123456")).to contain_exactly(matching)
+    end
+
+    it "returns every school when the filter is blank" do
+      schools = create_list(:provider_school, 2)
+
+      expect(described_class.filtered_by("")).to match_array(schools)
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:site_code) }
 

--- a/spec/requests/publish/providers/schools/filter_spec.rb
+++ b/spec/requests/publish/providers/schools/filter_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Publish provider schools filter suggestions", service: :publish do
+  include DfESignInUserHelper
+
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
+  let(:provider) { create(:provider, recruitment_cycle:) }
+
+  def suggestions_path(query)
+    filter_publish_provider_recruitment_cycle_schools_path(
+      provider.provider_code,
+      recruitment_cycle.year,
+      query:,
+    )
+  end
+
+  before { login_user(create(:user, providers: [provider])) }
+
+  it "suggests the provider's schools matching the filter" do
+    create(
+      :provider_school,
+      provider:,
+      gias_school: create(:gias_school, name: "Bramblewood Primary", town: "Leeds", postcode: "LS1 1AA"),
+    )
+    create(:provider_school, provider:, gias_school: create(:gias_school, name: "Harborne Academy"))
+
+    get suggestions_path("Bramblewood")
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to eq(
+      [{ "name" => "Bramblewood Primary", "town" => "Leeds", "postcode" => "LS1 1AA" }],
+    )
+  end
+
+  it "does not suggest another provider's schools" do
+    create(
+      :provider_school,
+      provider: create(:provider, recruitment_cycle:),
+      gias_school: create(:gias_school, name: "Bramblewood Primary"),
+    )
+
+    get suggestions_path("Bramblewood")
+
+    expect(response.parsed_body).to be_empty
+  end
+
+  it "rejects a filter shorter than three characters" do
+    get suggestions_path("Br")
+
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "keeps the filter on the index's pagination links" do
+    stub_const("Publish::Providers::SchoolsController::PER_PAGE", 1)
+    create(:provider_school, provider:, gias_school: create(:gias_school, name: "Bramblewood Primary"))
+    create(:provider_school, provider:, gias_school: create(:gias_school, name: "Bramblewood Secondary"))
+
+    get publish_provider_recruitment_cycle_schools_path(
+      provider.provider_code, recruitment_cycle.year, filter: "Bramblewood"
+    )
+
+    expect(response.body).to include("Bramblewood Primary")
+    expect(response.body).not_to include("Bramblewood Secondary")
+    expect(response.body).to include("page=2&amp;filter=Bramblewood").or include("filter=Bramblewood&amp;page=2")
+  end
+
+  it "forbids a user who does not belong to the provider" do
+    login_user(create(:user, providers: [create(:provider, recruitment_cycle:)]))
+
+    get suggestions_path("Bramblewood")
+
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/spec/system/publish/providers/schools/filter_schools_spec.rb
+++ b/spec/system/publish/providers/schools/filter_schools_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Filter a provider's list of schools" do
+  scenario "Provider narrows the list down to one school and clears it again" do
+    given_i_am_authenticated_as_a_provider_user_with_schools
+    when_i_visit_the_schools_page
+    then_i_see_all_of_my_schools
+    and_i_can_clear_the_filter
+
+    when_i_filter_for("Bramblewood")
+    then_i_only_see_the_matching_school
+    and_i_am_told_what_i_filtered_for("Bramblewood")
+
+    when_i_clear_the_filter
+    then_i_see_all_of_my_schools
+
+    when_i_filter_for("Nowhereville")
+    then_i_am_told_there_are_no_results
+    and_i_am_not_told_what_i_filtered_for("Nowhereville")
+
+    when_i_choose_to_view_all_schools
+    then_i_see_all_of_my_schools
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_schools
+    provider = create(:provider)
+
+    create(:provider_school, provider:, gias_school: create(:gias_school, name: "Bramblewood Primary"))
+    create(:provider_school, provider:, gias_school: create(:gias_school, name: "Harborne Academy"))
+
+    given_i_am_authenticated(user: create(:user, providers: [provider]))
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def when_i_visit_the_schools_page
+    visit publish_provider_recruitment_cycle_schools_path(
+      provider.provider_code, provider.recruitment_cycle_year
+    )
+  end
+
+  def then_i_see_all_of_my_schools
+    expect(page).to have_text("Bramblewood Primary")
+    expect(page).to have_text("Harborne Academy")
+  end
+
+  def and_i_can_clear_the_filter
+    expect(page).to have_link("Clear search")
+  end
+
+  def and_i_am_told_what_i_filtered_for(text)
+    expect(page).to have_text("Showing results for “#{text}”")
+    expect(page).to have_css("strong", text: "“#{text}”")
+  end
+
+  def and_i_am_not_told_what_i_filtered_for(text)
+    expect(page).to have_no_text("Showing results for “#{text}”")
+  end
+
+  def when_i_filter_for(text)
+    fill_in "Search for a school in the list", with: text
+    click_on "Search"
+  end
+
+  def then_i_only_see_the_matching_school
+    expect(page).to have_text("Bramblewood Primary")
+    expect(page).to have_no_text("Harborne Academy")
+  end
+
+  def when_i_clear_the_filter
+    click_on "Clear search"
+  end
+
+  def then_i_am_told_there_are_no_results
+    expect(page).to have_text("No schools found with that search.")
+    expect(page).to have_no_text("Bramblewood Primary")
+  end
+
+  def when_i_choose_to_view_all_schools
+    click_on "View all schools"
+  end
+end

--- a/spec/system/publish/providers/schools/filter_schools_suggestions_spec.rb
+++ b/spec/system/publish/providers/schools/filter_schools_suggestions_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Suggestions in the provider schools filter", :js, type: :system do
+  scenario "Provider picks a school from the suggestions and filters the list" do
+    given_i_am_authenticated_as_a_provider_user_with_schools
+    when_i_visit_the_schools_page
+    then_i_see_all_of_my_schools
+
+    when_i_type_into_the_filter("Bramble")
+    then_only_my_matching_school_is_suggested
+
+    when_i_choose_the_suggestion
+    and_i_filter_the_list
+    then_i_only_see_the_matching_school
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_schools
+    provider = create(:provider)
+
+    create(
+      :provider_school,
+      provider:,
+      gias_school: create(:gias_school, name: "Bramblewood Primary", town: "Leeds", postcode: "LS1 1AA"),
+    )
+    create(:provider_school, provider:, gias_school: create(:gias_school, name: "Harborne Academy"))
+
+    given_i_am_authenticated(user: create(:user, providers: [provider]))
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def when_i_visit_the_schools_page
+    visit publish_provider_recruitment_cycle_schools_path(
+      provider.provider_code, provider.recruitment_cycle_year
+    )
+  end
+
+  def then_i_see_all_of_my_schools
+    expect(page).to have_text("Bramblewood Primary")
+    expect(page).to have_text("Harborne Academy")
+  end
+
+  def when_i_type_into_the_filter(text)
+    fill_in "Search for a school in the list", with: text
+  end
+
+  def suggestions
+    page.find("ul.autocomplete__menu")
+  end
+
+  def then_only_my_matching_school_is_suggested
+    expect(suggestions).to have_text("Bramblewood Primary (Leeds, LS1 1AA)")
+    expect(suggestions).to have_no_text("Harborne Academy")
+  end
+
+  def when_i_choose_the_suggestion
+    suggestions.find("li", text: "Bramblewood Primary").click
+  end
+
+  def and_i_filter_the_list
+    click_on "Search"
+  end
+
+  def then_i_only_see_the_matching_school
+    expect(page).to have_text("Bramblewood Primary")
+    expect(page).to have_no_text("Harborne Academy")
+  end
+end


### PR DESCRIPTION
## Context

  The provider schools list paginates twenty at a time with no way to reach a particular school, so a provider with sixty pages through them by hand.

  Two things worth knowing. The suggestions endpoint answers to `?query=`, not `?filter=`, because the shared `remote-autocomplete` Stimulus controller hardcodes that parameter, the same one  `api/school_suggestions` already answers to. The list's own narrowing stays `filter`. And `Provider::School.filtered_by` matches through a subquery rather than a `merge`, because pg_search builds its own SELECT  and ORDER BY for ranking, which fights `ordered_by_name` and pagy's count.

  I considered giving `Publish::Schools::SearchPanelComponent` a remote mode instead of adding a component, but it filters checkboxes in the DOM where this submits a form, so the flag would have changed nearly  everything while the course schools page and wizard step still depend on the old behaviour. I also considered swapping the table client-side; a full page GET keeps pagination, the back button and shareable URLs  for free, and works with JavaScript off.

  ## Changes proposed in this pull request

  - A filter box above the list. It GETs the index, which narrows server-side and paginates as before.
  - A provider-scoped suggestions endpoint feeds the autocomplete, so every suggestion is a school already in the list.
  - Filtering to nothing shows "No results found" and a link back, rather than a bare page.

  Screenshots to follow.

  ## Guidance to review

  Run the three new spec files under `spec/system/publish/providers/schools/` and `spec/requests/publish/providers/schools/`, then filter a provider's schools page by name, postcode and URN.

  The subquery in `filtered_by` is the part I am least sure of. Separately, the suggestions system spec is the repo's first JS-level coverage of `remote-autocomplete`, and it is what caught the `?query=` bug;  worth a view on whether it is the right shape to copy for the other autocompletes.

  ## Checklist

  - [x] I have moved hard-coded strings to locale files.
  - [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests. Nothing to remove: the branch adds no `data-qa` attributes and touches no file containing one.