### PR TITLE
Fix flaky site code updates

### DIFF
--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -102,7 +102,7 @@ describe Provider::School do
       provider.update_columns(changed_at: 1.hour.ago)
 
       Timecop.freeze do
-        provider_school.update!(site_code: "Z")
+        provider_school.update!(site_code: "#{provider_school.site_code}X")
         expect(provider.reload.changed_at).to be_within(1.second).of(Time.zone.now)
       end
     end
@@ -218,7 +218,7 @@ describe Provider::School do
     it "touches them when a school is updated" do
       provider_school = create(:provider_school, provider:)
 
-      expect { provider_school.update!(site_code: "Z") }.to(change { exempt_course.reload.changed_at })
+      expect { provider_school.update!(site_code: "#{provider_school.site_code}X") }.to(change { exempt_course.reload.changed_at })
     end
 
     # `after_commit on: :update` fires even when Rails issued no UPDATE, and a


### PR DESCRIPTION
## Context

`spec/models/provider/school_spec.rb` is flaky.

The provider school factory creates site codes with `String#next`:

However, when there are already 26 schools, this is a no-op:

```ruby
provider_school.update!(site_code: "Z")
```

Which means `changed_at` isn't updated.

## Changes proposed in this pull request

Update with two character site code instead.

## Guidance to review

Run this on main and then in this branch to reproduce:

```
bundle exec parallel_rspec --pattern "spec/models/.*_spec.rb" -n 4 --only-group 2 --group-by filesize
```

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
