### PR TITLE
Fix specs that exactly match generated data

### DIFF
--- a/spec/services/support/providers/schools/search_service_spec.rb
+++ b/spec/services/support/providers/schools/search_service_spec.rb
@@ -6,7 +6,7 @@ module Support
   module Providers
     module Schools
       describe SearchService do
-        let(:school) { create(:gias_school) }
+        let(:school) { create(:gias_school, town: "Bristol", postcode: "SW1A 1AA") }
 
         describe "#call" do
           it "can search by urn" do

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -239,14 +239,14 @@ RSpec.describe "Delete a provider's schools" do
 
   def and_i_cannot_delete_the_school
     expect(publish_school_delete_page).to have_text("You cannot remove this school")
-    expect(page).to have_content("#{provider_school.location_name} is a school for courses run by #{provider.provider_name}.")
-    expect(page).to have_content("To remove #{provider_school.location_name}, you must first remove the school from those courses.")
+    expect(page).to have_content("#{provider_school.decorate.location_name} is a school for courses run by #{provider.provider_name}.")
+    expect(page).to have_content("To remove #{provider_school.decorate.location_name}, you must first remove the school from those courses.")
     expect(publish_school_delete_page).not_to have_remove_school_button
   end
 
   def and_i_am_told_it_is_the_only_school
     expect(publish_school_delete_page).to have_text("You cannot remove this school")
-    expect(page).to have_content("#{provider_school.location_name} is the only school for #{provider.provider_name}.")
+    expect(page).to have_content("#{provider_school.decorate.location_name} is the only school for #{provider.provider_name}.")
     expect(page).to have_content("To remove it, you must first add another school.")
     expect(publish_school_delete_page).not_to have_remove_school_button
   end

--- a/spec/system/publish/providers/schools/provider_school_helper.rb
+++ b/spec/system/publish/providers/schools/provider_school_helper.rb
@@ -2,7 +2,7 @@
 
 module ProviderSchoolHelper
   def given_i_am_authenticated_as_a_provider_user
-    gias_school = create(:gias_school)
+    gias_school = create(:gias_school, name: "St Mary's Academy")
     provider = create(:provider, sites: [build(:site, **gias_school.school_attributes)])
     site = provider.sites.first
     create(:provider_school, provider:, gias_school:, site_code: site.code, uuid: site.uuid)


### PR DESCRIPTION
## Context

Noticed CI flaky tests comparing a fixed string against data Faker generates. 

Some specs are exact matches against Faker generated school info. Apostrophes and US format postcodes can cause unexpected (flaky) failures.

## Changes proposed in this pull request

Hard code school name and postcode to avoid flaky failures.

## Guidance to review

Used a UK postcode in the spec rather than fixing `Faker::Address.postcode`.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
