### PR TITLE
Serve robots.txt from a route instead of a static file

### DIFF
--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -10,6 +10,8 @@ class RobotsController < ActionController::Base
   # rubocop:enable Rails/ApplicationController
 
   def show
+    expires_in 1.day, public: true
+
     render template: robots_template, formats: :text, layout: false, content_type: "text/plain"
   end
 

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Served from a route rather than public/, because a static file is host-blind:
+# Find, Publish, the API and the test environments share one public directory.
+#
+# Not ApplicationController: enforce_basic_auth returns 401 wherever basic auth
+# is enabled, and Google reads any 4xx on robots.txt as "no restrictions".
+# rubocop:disable Rails/ApplicationController
+class RobotsController < ActionController::Base
+  # rubocop:enable Rails/ApplicationController
+
+  def show
+    render template: "robots/disallow", formats: :text, layout: false, content_type: "text/plain"
+  end
+end

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -10,6 +10,18 @@ class RobotsController < ActionController::Base
   # rubocop:enable Rails/ApplicationController
 
   def show
-    render template: "robots/disallow", formats: :text, layout: false, content_type: "text/plain"
+    render template: robots_template, formats: :text, layout: false, content_type: "text/plain"
+  end
+
+private
+
+  def robots_template
+    indexable? ? "robots/allow" : "robots/disallow"
+  end
+
+  # Not Rails.env: staging, sandbox, QA and review all run RAILS_ENV=production.
+  def indexable?
+    Settings.environment.name == "production" &&
+      request.host == URI.parse(Settings.find_url).host
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <%= tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
     <%= tag.meta(property: "og:image", content: image_path("govuk-opengraph-image.png")) %>
     <%= tag.meta(name: "theme-color", content: "#0b0c0c") %>
+    <%= tag.meta(name: "robots", content: "noindex, nofollow") %>
     <%= tag.meta(name: "format-detection", content: "telephone=no") %>
 
     <%= favicon_link_tag image_path("favicon.ico"), type: nil, sizes: "48x48" %>

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -16,6 +16,7 @@
     <%= tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
     <%= tag.meta(property: "og:image", content: image_path("govuk-opengraph-image.png")) %>
     <%= tag.meta(name: "theme-color", content: "#0b0c0c") %>
+    <%= tag.meta(name: "robots", content: "noindex, nofollow") %>
     <%= tag.meta(name: "format-detection", content: "telephone=no") %>
 
     <%= favicon_link_tag image_path("favicon.ico"), type: nil, sizes: "48x48" %>

--- a/app/views/robots/allow.text.raw
+++ b/app/views/robots/allow.text.raw
@@ -1,5 +1,6 @@
-# The search engines named below may index Find. Everything else,
-# including AI training crawlers, is blocked by the final group.
+# The crawlers named below may index Find: search engines, and the link
+# preview bots that fetch a page when someone shares a link. Everything
+# else, including AI training crawlers, is blocked by the final group.
 
 User-agent: Googlebot
 User-agent: Googlebot-Image
@@ -7,6 +8,12 @@ User-agent: bingbot
 User-agent: DuckDuckBot
 User-agent: Slurp
 User-agent: Applebot
+User-agent: Twitterbot
+User-agent: facebookexternalhit
+User-agent: LinkedInBot
+User-agent: Slackbot-LinkExpanding
+User-agent: Discordbot
+User-agent: WhatsApp
 Disallow: /auth/
 Disallow: /sign-out
 Disallow: /candidate/

--- a/app/views/robots/allow.text.raw
+++ b/app/views/robots/allow.text.raw
@@ -1,0 +1,31 @@
+# The search engines named below may index Find. Everything else,
+# including AI training crawlers, is blocked by the final group.
+
+User-agent: Googlebot
+User-agent: Googlebot-Image
+User-agent: bingbot
+User-agent: DuckDuckBot
+User-agent: Slurp
+User-agent: Applebot
+Disallow: /auth/
+Disallow: /sign-out
+Disallow: /candidate/
+Disallow: /email-alerts/
+Disallow: /track_click
+Disallow: /track_apply_to_course_click
+Disallow: /geolocation-suggestions
+Disallow: /feedback
+Disallow: /cycles
+Disallow: /maintenance
+Disallow: /cycle-has-ended
+Disallow: /course/*/apply
+Disallow: /course/*/confirm-apply
+Disallow: /course/*/school-experience-interstitial
+Disallow: /course/*/git/
+Disallow: /course/*/provider/website
+Allow: /
+
+User-agent: *
+Disallow: /
+
+Sitemap: https://find-teacher-training-courses.service.gov.uk/sitemap.xml

--- a/app/views/robots/disallow.text.raw
+++ b/app/views/robots/disallow.text.raw
@@ -1,0 +1,3 @@
+# This host is not intended to be found in search results.
+User-agent: *
+Disallow: /

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   get :sha, controller: :heartbeat
   get :reporting, controller: :reporting
 
+  # Drawn outside the host constraints: the response varies by host, but the
+  # route must answer on every one of them.
+  get "/robots.txt", to: "robots#show", format: false
+
   constraints host: Settings.api_hosts do
     draw(:external_api)
   end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-User-agent: *
-Disallow: /
-Allow: https://find-teacher-training-courses.service.gov.uk/sitemap.xml
-Sitemap: https://find-teacher-training-courses.service.gov.uk/sitemap.xml

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -39,6 +39,19 @@ describe "robots.txt" do
       expect(response.body).not_to include("User-agent: Applebot-Extended")
     end
 
+    it "welcomes link preview bots, so shared course links render a preview card" do
+      expect(response.body).to include("User-agent: Twitterbot")
+      expect(response.body).to include("User-agent: facebookexternalhit")
+      expect(response.body).to include("User-agent: LinkedInBot")
+      expect(response.body).to include("User-agent: Slackbot-LinkExpanding")
+      expect(response.body).to include("User-agent: Discordbot")
+      expect(response.body).to include("User-agent: WhatsApp")
+    end
+
+    it "does not welcome meta-externalagent, so Meta's training crawler falls to the block" do
+      expect(response.body).not_to include("User-agent: meta-externalagent")
+    end
+
     it "keeps candidate and authentication pages out of search results" do
       expect(response.body).to include("Disallow: /candidate/")
       expect(response.body).to include("Disallow: /auth/")

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "robots.txt" do
+  def stub_environment(name)
+    allow(Settings.environment).to receive(:name).and_return(name)
+  end
+
+  def expect_everything_blocked
+    expect(response.body).to include("User-agent: *\nDisallow: /")
+    expect(response.body).not_to include("Googlebot")
+  end
+
+  it "responds as plain text" do
+    host! URI.parse(Settings.find_url).host
+    get "/robots.txt"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("text/plain")
+  end
+
+  it "blocks everything on the Find host" do
+    stub_environment("production")
+    host! URI.parse(Settings.find_url).host
+    get "/robots.txt"
+
+    expect_everything_blocked
+  end
+
+  context "on a non-canonical Find host in production" do
+    it "blocks everything, so the temporary domain cannot compete with the canonical one" do
+      stub_environment("production")
+      host! "find-temp.teacherservices.cloud"
+      get "/robots.txt"
+
+      expect_everything_blocked
+    end
+  end
+
+  context "on the Publish host in production" do
+    it "blocks everything" do
+      stub_environment("production")
+      host! URI.parse(Settings.publish_url).host
+      get "/robots.txt"
+
+      expect_everything_blocked
+    end
+  end
+
+  context "on the API host in production" do
+    it "blocks everything" do
+      stub_environment("production")
+      host! URI.parse(Settings.api_url).host
+      get "/robots.txt"
+
+      expect_everything_blocked
+    end
+  end
+
+  context "outside production" do
+    %w[staging sandbox qa review development].each do |environment|
+      it "blocks everything in #{environment}, even on the Find host" do
+        stub_environment(environment)
+        host! URI.parse(Settings.find_url).host
+        get "/robots.txt"
+
+        expect_everything_blocked
+      end
+    end
+  end
+end

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -24,6 +24,11 @@ describe "robots.txt" do
       expect(response.media_type).to eq("text/plain")
     end
 
+    it "may be cached by shared caches for a day" do
+      expect(response.headers["Cache-Control"]).to include("max-age=86400")
+      expect(response.headers["Cache-Control"]).to include("public")
+    end
+
     it "welcomes the search engines we have approved" do
       expect(response.body).to include("User-agent: Googlebot")
       expect(response.body).to include("User-agent: bingbot")

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -12,20 +12,63 @@ describe "robots.txt" do
     expect(response.body).not_to include("Googlebot")
   end
 
-  it "responds as plain text" do
-    host! URI.parse(Settings.find_url).host
-    get "/robots.txt"
+  context "on the canonical Find host in production" do
+    before do
+      stub_environment("production")
+      host! URI.parse(Settings.find_url).host
+      get "/robots.txt"
+    end
 
-    expect(response).to have_http_status(:ok)
-    expect(response.media_type).to eq("text/plain")
-  end
+    it "responds as plain text" do
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/plain")
+    end
 
-  it "blocks everything on the Find host" do
-    stub_environment("production")
-    host! URI.parse(Settings.find_url).host
-    get "/robots.txt"
+    it "welcomes the search engines we have approved" do
+      expect(response.body).to include("User-agent: Googlebot")
+      expect(response.body).to include("User-agent: bingbot")
+      expect(response.body).to include("User-agent: DuckDuckBot")
+      expect(response.body).to include("User-agent: Applebot")
+    end
 
-    expect_everything_blocked
+    it "blocks every crawler it does not name, including AI crawlers" do
+      expect(response.body).to include("User-agent: *\nDisallow: /")
+    end
+
+    it "does not welcome Applebot-Extended, so Apple's training crawler falls to the block" do
+      expect(response.body).not_to include("User-agent: Applebot-Extended")
+    end
+
+    it "keeps candidate and authentication pages out of search results" do
+      expect(response.body).to include("Disallow: /candidate/")
+      expect(response.body).to include("Disallow: /auth/")
+      expect(response.body).to include("Disallow: /sign-out")
+    end
+
+    it "keeps unsubscribe links containing personal tokens out of search results" do
+      expect(response.body).to include("Disallow: /email-alerts/")
+    end
+
+    it "keeps tracking redirects and internal endpoints out of search results" do
+      expect(response.body).to include("Disallow: /track_click")
+      expect(response.body).to include("Disallow: /geolocation-suggestions")
+      expect(response.body).to include("Disallow: /cycles")
+    end
+
+    # A blank line would terminate the group, leaving approved crawlers with
+    # no rules at all.
+    it "keeps the approved group contiguous, with no blank line before its rules" do
+      group = response.body[/^User-agent: Googlebot$.*?^Allow: \/$/m]
+
+      expect(group).to be_present
+      expect(group.lines.map(&:chomp)).to all(be_present)
+    end
+
+    it "advertises the sitemap on the canonical domain" do
+      expect(response.body).to include(
+        "Sitemap: https://find-teacher-training-courses.service.gov.uk/sitemap.xml",
+      )
+    end
   end
 
   context "on a non-canonical Find host in production" do


### PR DESCRIPTION
## Context

  `robots.txt` has served `Disallow: /` since January 2023, added in a commit about enabling Find routes in staging. There were no restrictions before that.

  Two effects. Find's sitemap, regenerated daily with over a thousand course URLs, has never been processed, because `Disallow: /` covers `/sitemap.xml` itself. And Find's course pages are absent from search
  results. An `Allow:` line added later to exempt the sitemap used an absolute URL where the standard requires a path, so parsers discard it.

  Editing the file in place was rejected. `ActionDispatch::Static` matches on path and ignores the Host header, so Find, Publish, the API and every non-production environment receive identical bytes, and all of
  those hosts serve content publicly. A route is the only way to vary the response.

  A blocklist of named AI crawlers was rejected in favour of an allowlist, which covers new crawlers without further edits.

  `RobotsController` does not inherit `ApplicationController`, because `enforce_basic_auth` returns 401 wherever basic auth is enabled and Google treats any 4xx on `robots.txt` as no restrictions. `indexable?`
  tests `Settings.environment.name` rather than `Rails.env`, since non-production environments run `RAILS_ENV=production`.

  ## Changes proposed in this pull request

  - `robots.txt` varies by host. Only the canonical production Find domain admits crawlers; Publish, the API, `find-temp` and all non-production hosts keep the blanket block.
  - Approved search engines and link preview bots may crawl Find. Everything else, including AI training crawlers, falls to `User-agent: * / Disallow: /`. Applebot and `facebookexternalhit` are approved;
  `Applebot-Extended` and `meta-externalagent` are not.
  - Candidate accounts, authentication, unsubscribe links, tracking redirects and JSON endpoints are disallowed.
  - The response is cacheable for a day, matching `Find::SitemapsController`.
  - Add `noindex` meta tags to support and publish layouts

  No UI changes, so no screenshots.

  ## Guidance to review

  `bundle exec rspec spec/requests/robots_spec.rb` covers every host and environment.

  Check the disallow list hardest. It was derived from `config/routes/find.rb`, and a missing entry means a page gets indexed that should not be. `/candidate/`, `/auth/` and `/email-alerts/` matter most, the last
  because those URLs carry personal access tokens.

  The approved crawler list is a product decision as much as a technical one, particularly `facebookexternalhit`. Dropping it is a one-line change.

  Not addressed here: allowing `/results` with query parameters lets Google crawl unbounded filter combinations. That needs `rel=canonical` and selective `noindex`, which is a separate ticket.
## Checklist

- [ ] I have moved hard-coded strings to locale files. — n/a, no user-facing strings; `robots.txt` is a machine-read file with a fixed English format.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests. — n/a, no HTML changed.