### PR TITLE
Update Schools list content and styling

### DIFF
--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -10,7 +10,10 @@ module Publish
 
       def index
         @filter = params[:filter]
-        @pagy, @schools = pagy(provider.schools.filtered_by(@filter).ordered_by_name, limit: PER_PAGE)
+        @pagy, @schools = pagy(
+          provider.schools.filtered_by(@filter).ordered_by_name.includes(:kept_courses),
+          limit: PER_PAGE,
+        )
       end
 
       def show; end
@@ -32,7 +35,7 @@ module Publish
           flash[:success] = "School removed"
           redirect_to publish_provider_recruitment_cycle_schools_path
         else
-          redirect_to delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid),
+          redirect_to school_delete_path_with_return,
                       flash: { warning: cannot_remove_school_message }
         end
       end
@@ -54,6 +57,45 @@ module Publish
         @school ||= provider.schools.find_by!(uuid: params[:uuid]).decorate
       end
       helper_method :school
+
+      def school_delete_return_path
+        if returning_to_schools_index?
+          publish_provider_recruitment_cycle_schools_path(
+            @provider.provider_code,
+            school.recruitment_cycle.year,
+            **schools_index_return_params,
+          )
+        else
+          publish_provider_recruitment_cycle_school_path(
+            @provider.provider_code,
+            school.recruitment_cycle.year,
+            school.uuid,
+          )
+        end
+      end
+      helper_method :school_delete_return_path
+
+      def school_delete_path_with_return
+        delete_publish_provider_recruitment_cycle_school_path(
+          @provider.provider_code,
+          school.recruitment_cycle.year,
+          school.uuid,
+          **school_delete_return_params,
+        )
+      end
+      helper_method :school_delete_path_with_return
+
+      def returning_to_schools_index?
+        params[:from] == "index"
+      end
+
+      def school_delete_return_params
+        params.permit(:from, :filter, :page).to_h.compact_blank.symbolize_keys
+      end
+
+      def schools_index_return_params
+        school_delete_return_params.except(:from)
+      end
 
       def site_params(param_form_key)
         params.expect(param_form_key => SchoolForm::FIELDS)

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -15,6 +15,7 @@ class Provider::School < ApplicationRecord
   belongs_to :gias_school
 
   has_many :course_schools, class_name: "Course::School", inverse_of: :provider_school, dependent: :destroy
+  has_many :kept_courses, -> { kept }, through: :course_schools, source: :course
 
   # Provider schools whose GIAS record is still available (i.e. not closed).
   # Used to keep closed schools out of the rollover.
@@ -70,5 +71,9 @@ class Provider::School < ApplicationRecord
       gias_school.county,
       gias_school.postcode,
     ].compact_blank.join(join_on_separator)
+  end
+
+  def courses_count
+    kept_courses.size
   end
 end

--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -11,7 +11,10 @@
   </td>
   <td class="govuk-table__cell remove">
     <%= govuk_link_to(
-      t("publish.providers.schools.index.remove"),
+      safe_join([
+        t("publish.providers.schools.index.remove"),
+        content_tag(:span, school.location_name, class: "govuk-visually-hidden"),
+      ], " "),
       delete_publish_provider_recruitment_cycle_school_path(
         @provider.provider_code,
         school.recruitment_cycle.year,

--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -3,14 +3,22 @@
     <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid) %>
 
     <%= render Publish::Schools::NewlyAddedTagComponent.new(school:) %>
+    <p class="govuk-body govuk-hint address"><%= school.full_address %></p>
   </th>
 
-  <td class="govuk-table__cell code">
-    <%= school.code %> <%= school.code == "-" ? "(dash)" : "" %>
+  <td class="govuk-table__cell courses-count">
+    <%= t("publish.providers.schools.index.courses_count", count: school.courses_count) %>
   </td>
-  <% if urn_required?(@recruitment_cycle.year.to_i) %>
-    <td class="govuk-table__cell urn">
-      <%= value_provided?(school.urn) %>
-    </td>
-  <% end %>
+  <td class="govuk-table__cell remove">
+    <%= govuk_link_to(
+      t("publish.providers.schools.index.remove"),
+      delete_publish_provider_recruitment_cycle_school_path(
+        @provider.provider_code,
+        school.recruitment_cycle.year,
+        school.uuid,
+        { from: :index, filter: @filter, page: params[:page] }.compact_blank,
+      ),
+      class: "app-link--destructive",
+    ) %>
+  </td>
 </tr>

--- a/app/views/publish/providers/schools/delete.html.erb
+++ b/app/views/publish/providers/schools/delete.html.erb
@@ -1,6 +1,6 @@
 <%= render PageTitle.new(title: "publish.providers.schools.delete") %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid)) %>
+  <%= govuk_back_link_to(school_delete_return_path) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -11,7 +11,7 @@
         <%= t("components.page_titles.publish.providers.schools.delete") %>
         </h1>
         <%= govuk_button_to "Remove school",
-          delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid),
+          school_delete_path_with_return,
           method: :delete,
           class: "govuk-button--warning" %>
       <% else %>
@@ -34,7 +34,7 @@
       <% end %>
     <% end %>
     <p class="govuk-body">
-        <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid)) %>
+        <%= govuk_link_to("Cancel", school_delete_return_path) %>
     </p>
   </div>
 </div>

--- a/app/views/publish/providers/schools/index.html.erb
+++ b/app/views/publish/providers/schools/index.html.erb
@@ -25,14 +25,8 @@
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col"><%= t(".name") %></th>
-            <th class="govuk-table__header" scope="col"><%= t(".code") %></th>
-            <% if urn_required?(@recruitment_cycle.year.to_i) %>
-              <th class="govuk-table__header" scope="col">
-                <abbr class="app-!-text-decoration-underline-dotted" title="<%= t(".urn_abbr") %>">
-                  <%= t(".urn") %>
-                </abbr>
-              </th>
-            <% end %>
+            <th class="govuk-table__header" scope="col"><%= t(".courses_attached") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".remove") %></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">

--- a/config/locales/en/publish/providers/schools.yml
+++ b/config/locales/en/publish/providers/schools.yml
@@ -6,10 +6,12 @@ en:
           title: Schools
           add_school: Add school
           add_multiple_school: Add multiple school
-          name: School name
-          code: School code
-          urn: URN
-          urn_abbr: Unique Reference Number
+          name: School
+          courses_attached: Number of courses attached
+          courses_count:
+            one: "%{count} course"
+            other: "%{count} courses"
+          remove: Remove school
         show:
           code: School code
           urn: URN

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -9,6 +9,7 @@ describe Provider::School do
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to belong_to(:gias_school) }
     it { is_expected.to have_many(:course_schools).class_name("Course::School").dependent(:destroy) }
+    it { is_expected.to have_many(:kept_courses).through(:course_schools).source(:course) }
   end
 
   describe ".with_available_gias_school" do
@@ -46,6 +47,23 @@ describe Provider::School do
       schools = create_list(:provider_school, 2)
 
       expect(described_class.filtered_by("")).to match_array(schools)
+    end
+  end
+
+  describe "#courses_count" do
+    it "counts kept courses attached to the school" do
+      provider_school = create(:provider_school)
+      kept_course = create(:course, provider: provider_school.provider)
+      discarded_course = create(:course, provider: provider_school.provider)
+      create(:course_school, course: kept_course, provider_school:, gias_school: provider_school.gias_school)
+      create(:course_school, course: discarded_course, provider_school:, gias_school: provider_school.gias_school)
+      discarded_course.discard
+
+      expect(provider_school.courses_count).to eq(1)
+    end
+
+    it "returns zero when a school has no courses" do
+      expect(create(:provider_school).courses_count).to eq(0)
     end
   end
 

--- a/spec/requests/publish/providers/schools_spec.rb
+++ b/spec/requests/publish/providers/schools_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe "Publish provider school show page", service: :publish do
         expect(response.body).not_to include("112992")
         expect(response.body).to include(publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid))
         expect(response.body).to include(delete_publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid))
+        expect(response.parsed_body.at_css(".remove a").text.squish).to eq("Remove school St Joseph's Catholic Primary School")
       end
 
       it "shows how many kept courses are attached to each school" do

--- a/spec/requests/publish/providers/schools_spec.rb
+++ b/spec/requests/publish/providers/schools_spec.rb
@@ -65,9 +65,27 @@ RSpec.describe "Publish provider school show page", service: :publish do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("St Joseph")
         expect(response.body).to include("Catholic Primary School")
-        expect(response.body).to include("A")
-        expect(response.body).to include("112992")
+        expect(response.body).to include("1 School Lane")
+        expect(response.body).to include("0 courses")
+        expect(response.body).to include("Number of courses attached")
+        expect(response.body).to include("Remove school")
+        expect(response.body).not_to include("School code")
+        expect(response.body).not_to include("112992")
         expect(response.body).to include(publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid))
+        expect(response.body).to include(delete_publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid))
+      end
+
+      it "shows how many kept courses are attached to each school" do
+        kept_course = create(:course, provider:)
+        discarded_course = create(:course, provider:)
+        create(:course_school, course: kept_course, provider_school:, gias_school:)
+        create(:course_school, course: discarded_course, provider_school:, gias_school:)
+        discarded_course.discard
+
+        get publish_provider_recruitment_cycle_schools_path(provider.provider_code, recruitment_cycle.year)
+
+        expect(response.body).to include("1 course")
+        expect(response.body).not_to include("2 courses")
       end
     end
   end
@@ -184,6 +202,32 @@ RSpec.describe "Publish provider school show page", service: :publish do
       expect(response.body).to include("Catholic Primary School")
     end
 
+    it "links back to the school page by default" do
+      get delete_publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid)
+
+      expect(response.body).to include(
+        publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid),
+      )
+    end
+
+    it "links back to the filtered schools list when opened from the index" do
+      get delete_publish_provider_recruitment_cycle_school_path(
+        provider.provider_code,
+        recruitment_cycle.year,
+        provider_school.uuid,
+        from: "index",
+        filter: "Bramblewood",
+      )
+
+      expect(response.body).to include(
+        publish_provider_recruitment_cycle_schools_path(
+          provider.provider_code,
+          recruitment_cycle.year,
+          filter: "Bramblewood",
+        ),
+      )
+    end
+
     context "when it is the provider's only school" do
       let!(:other_provider_school) { nil }
 
@@ -251,6 +295,29 @@ RSpec.describe "Publish provider school show page", service: :publish do
 
       expect(response).to redirect_to(delete_publish_provider_recruitment_cycle_school_path(provider.provider_code, provider.recruitment_cycle.year, provider_school.uuid))
       expect(flash[:warning]).to eq("This school could not be removed because it is your only school")
+    end
+
+    it "keeps the original return params when the school cannot be removed" do
+      course = create(:course, provider:)
+      create(:course_school, course:, gias_school:, provider_school:)
+
+      delete publish_provider_recruitment_cycle_school_path(
+        provider.provider_code,
+        provider.recruitment_cycle.year,
+        provider_school.uuid,
+        from: "index",
+        filter: "Bramblewood",
+      )
+
+      expect(response).to redirect_to(
+        delete_publish_provider_recruitment_cycle_school_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year,
+          provider_school.uuid,
+          from: "index",
+          filter: "Bramblewood",
+        ),
+      )
     end
   end
 end

--- a/spec/support/page_objects/sections/school.rb
+++ b/spec/support/page_objects/sections/school.rb
@@ -8,6 +8,9 @@ module PageObjects
       element :name, ".name"
       element :code, ".code"
       element :urn, ".urn"
+      element :address, ".address"
+      element :courses_count, ".courses-count"
+      element :remove_link, ".remove a"
       element :edit_link, ".name a"
     end
   end

--- a/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
@@ -125,7 +125,8 @@ RSpec.describe "Multiple schools" do
 
   def and_i_see_that_all_schools_are_created
     @gias_schools.each do |school|
-      expect(page).to have_css(".school-row", text: /#{school.name}.*#{school.urn}/)
+      expect(page).to have_css(".school-row", text: school.name)
+      expect(page).to have_css(".school-row", text: school.postcode)
     end
   end
 

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -13,10 +13,32 @@ RSpec.describe "Delete a provider's schools" do
     when_i_visit_the_publish_school_show_page
     and_i_click_remove_school_link
     then_i_am_on_the_school_delete_page
+    when_i_click_back
+    then_i_am_on_the_school_show_page
+
+    and_i_click_remove_school_link
     when_i_click_cancel
     then_i_am_on_the_school_show_page
 
     and_i_click_remove_school_link
+    and_i_click_remove_school_button
+    then_i_am_on_the_index_page
+    and_the_school_is_deleted
+  end
+
+  scenario "from the schools index page" do
+    given_i_am_authenticated_as_a_provider_user_with_two_schools
+    when_i_visit_the_schools_page
+    and_i_click_remove_school_from_the_index
+    then_i_am_on_the_school_delete_page
+    when_i_click_back
+    then_i_am_on_the_index_page
+
+    and_i_click_remove_school_from_the_index
+    when_i_click_cancel
+    then_i_am_on_the_index_page
+
+    and_i_click_remove_school_from_the_index
     and_i_click_remove_school_button
     then_i_am_on_the_index_page
     and_the_school_is_deleted
@@ -135,9 +157,10 @@ RSpec.describe "Delete a provider's schools" do
   def then_i_see_the_provider_school_listed_with_its_uuid
     row = school_row(future_gias_school.name)
 
-    expect(row.code).to have_text("- (dash)")
-    expect(row.urn).to have_text(future_gias_school.urn)
+    expect(row.address).to have_text(future_provider_school.full_address)
+    expect(row.courses_count).to have_text("0 courses")
     expect(row.edit_link[:href]).to include(future_provider_school.uuid)
+    expect(row.remove_link[:href]).to include(future_provider_school.uuid)
   end
 
   def when_i_click_the_provider_school
@@ -203,12 +226,20 @@ RSpec.describe "Delete a provider's schools" do
     click_link_or_button "Remove school"
   end
 
+  def and_i_click_remove_school_from_the_index
+    school_row(provider_school.location_name).remove_link.click
+  end
+
   def then_i_am_on_the_school_delete_page
     expect(publish_school_delete_page).to be_displayed
   end
 
   def when_i_click_cancel
     click_link_or_button "Cancel"
+  end
+
+  def when_i_click_back
+    click_link_or_button "Back"
   end
 
   def and_i_click_remove_school_button

--- a/spec/system/publish/providers/schools/provider_school_helper.rb
+++ b/spec/system/publish/providers/schools/provider_school_helper.rb
@@ -20,9 +20,17 @@ module ProviderSchoolHelper
     expect(publish_schools_index_page.schools.size).to eq(1)
 
     provider_school = provider.schools.first
-    expect(publish_schools_index_page.schools.first.name).to have_text(provider_school.location_name)
-    expect(publish_schools_index_page.schools.first.code).to have_text(provider_school.code)
-    expect(publish_schools_index_page.schools.first.urn).to have_text(provider_school.urn)
+    row = publish_schools_index_page.schools.first
+    expect(row.name).to have_text(provider_school.location_name)
+    expect(row.address).to have_text(provider_school.full_address)
+    expect(row.courses_count).to have_text("0 courses")
+    expect(row.remove_link[:href]).to include(
+      delete_publish_provider_recruitment_cycle_school_path(
+        provider.provider_code,
+        provider.recruitment_cycle_year,
+        provider_school.uuid,
+      ),
+    )
   end
 
   def then_i_am_on_the_index_page


### PR DESCRIPTION
## Context

Providers need a clearer schools list: school code and URN are less useful on this page than where the school is, how many courses use it, and a way to remove it without opening the school first.

Without a return path, the remove journey always sent people back to the school details page. From the list, Back and Cancel should return to the list, including any filter or page they were on.

## Changes proposed in this pull request

- Drop school code and URN from the Publish schools table.
- Show the address under the school name, using `govuk-body govuk-hint`.
- Add a **Number of courses attached** column (`1 course` / `12 courses`), counting kept courses only.
- Add a **Remove school** column with a destructive link into the existing delete journey.
- Send Back and Cancel to the schools list when removal starts from the index (preserving filter and page), and to the school page when it starts from school details.

School details still show code and URN. Support’s schools list is unchanged.

## Guidance to review

Check the Publish schools list:

- Address sits under the name; code and URN are gone.
- Course counts exclude discarded courses.
- **Remove school** from the list: Back and Cancel return to the list (try with a filter and another page).
- **Remove school** from school details: Back and Cancel still return to that school.
- Successful removal still lands on the list.

Worth a look at `school_delete_return_path` in `Publish::Providers::SchoolsController` and whether `from=index` is the right way to carry the return path.

Covered by request, model, and system specs around the list, course counts, and delete Back/Cancel.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.