### PR TITLE
Update training partners CSV

### DIFF
--- a/app/controllers/publish/providers/training_partners/course_exports_controller.rb
+++ b/app/controllers/publish/providers/training_partners/course_exports_controller.rb
@@ -17,7 +17,7 @@ module Publish
       private
 
         def courses
-          @courses ||= provider.current_accredited_courses
+          @courses ||= provider.current_accredited_courses.preload(:enrichments, :latest_enrichment, :sites)
         end
 
         def data_export

--- a/app/services/exports/accredited_course_list.rb
+++ b/app/services/exports/accredited_course_list.rb
@@ -4,18 +4,25 @@ require "csv"
 
 module Exports
   class AccreditedCourseList
+    include ActionView::Helpers::NumberHelper
+    include CourseColumns
+
     CSV_HEADERS = [
-      "Provider code",
       "Provider",
+      "Provider code",
+      "Course name",
       "Course code",
-      "Course",
-      "Study mode",
-      "Programme type",
-      "Qualification",
       "Status",
+      "Age range",
+      "Fee or salary",
+      "Qualification",
+      "Full time or part time",
+      "Start date",
+      "Course length",
+      "UK fee",
+      "Non-UK fee",
       "View on Find",
-      "Applications open from",
-      "Campus Codes",
+      "Campus codes",
     ].freeze
 
     def initialize(courses:)
@@ -23,22 +30,27 @@ module Exports
     end
 
     def data
-      CSV.generate(headers: CSV_HEADERS, write_headers: true) do |csv|
+      BYTE_ORDER_MARK + CSV.generate(headers: CSV_HEADERS, write_headers: true) do |csv|
         courses.find_each do |course|
           decorated_course = course.decorate
+          enrichment = reported_enrichment(course)
 
           csv << [
-            decorated_course.provider.provider_code,
-            decorated_course.provider.provider_name,
-            decorated_course.course_code,
-            decorated_course.name,
-            decorated_course.study_mode&.humanize,
-            decorated_course.program_type&.humanize,
+            course.provider.provider_name,
+            course.provider.provider_code,
+            course.name,
+            course.course_code,
+            course.content_status&.to_s&.humanize,
+            age_range(course),
+            I18n.t("publish.courses.course_table.funding.#{course.funding}"),
             decorated_course.outcome,
-            decorated_course.content_status&.to_s&.humanize,
+            course.study_mode_description.capitalize,
+            start_date(course),
+            course_length(enrichment&.course_length),
+            number_to_currency(enrichment&.fee_uk_eu),
+            number_to_currency(enrichment&.fee_international),
             decorated_course.find_url,
-            I18n.l(decorated_course.applications_open_from&.to_date),
-            decorated_course.sites&.map(&:code)&.join(" "),
+            course.sites.map(&:code).sort.join(" "),
           ]
         end
       end

--- a/app/services/exports/accredited_course_list.rb
+++ b/app/services/exports/accredited_course_list.rb
@@ -50,7 +50,7 @@ module Exports
             number_to_currency(enrichment&.fee_uk_eu),
             number_to_currency(enrichment&.fee_international),
             decorated_course.find_url,
-            course.sites.map(&:code).sort.join(" "),
+            campus_codes(course),
           ]
         end
       end
@@ -63,5 +63,12 @@ module Exports
   private
 
     attr_reader :courses
+
+    def campus_codes(course)
+      course.sites
+        .map(&:code)
+        .sort_by { |code| [code == Provider::School::MAIN_SITE_CODE ? 1 : 0, code] }
+        .join(" ")
+    end
   end
 end

--- a/app/services/exports/course_columns.rb
+++ b/app/services/exports/course_columns.rb
@@ -16,5 +16,23 @@ module Exports
 
       course.decorate.age_range
     end
+
+    # Use status as CourseEnrichment#draft? also counts rolled_over
+    def reported_enrichment(course)
+      settled = course.enrichments.reject { |enrichment| enrichment.status == "draft" }
+      settled.max_by { |enrichment| [enrichment.created_at, enrichment.id] } || course.latest_enrichment
+    end
+
+    def start_date(course)
+      return if course.start_date.blank?
+
+      I18n.l(course.start_date.to_date, format: :short)
+    end
+
+    def course_length(value)
+      return if value.blank?
+
+      I18n.t("courses.summary_card_component.length_value.#{value}", default: value)
+    end
   end
 end

--- a/app/services/exports/course_information_list.rb
+++ b/app/services/exports/course_information_list.rb
@@ -61,29 +61,11 @@ module Exports
       Publish::Courses::Query.call(provider:).preload(:enrichments)
     end
 
-    # Use status as CourseEnrichment#draft? also counts rolled_over
-    def reported_enrichment(course)
-      settled = course.enrichments.reject { |enrichment| enrichment.status == "draft" }
-      settled.max_by { |enrichment| [enrichment.created_at, enrichment.id] } || course.latest_enrichment
-    end
-
     def accredited_provider(course)
       code = course.accredited_provider_code
       return provider.provider_name if code.blank? || code == provider.provider_code
 
       course[:group_name] || code
-    end
-
-    def start_date(course)
-      return if course.start_date.blank?
-
-      I18n.l(course.start_date.to_date, format: :short)
-    end
-
-    def course_length(value)
-      return if value.blank?
-
-      I18n.t("courses.summary_card_component.length_value.#{value}", default: value)
     end
   end
 end

--- a/spec/requests/publish/training_partner_course_exports_spec.rb
+++ b/spec/requests/publish/training_partner_course_exports_spec.rb
@@ -2,18 +2,49 @@
 
 require "rails_helper"
 
-describe "Publish::ProvidersController" do
+describe "Publish::Providers::TrainingPartners::CourseExportsController" do
   include DfESignInUserHelper
 
-  describe "/publish/providers/suggest" do
-    context "when the user is authenticated" do
-      it "is successful" do
-        provider = create(:provider)
-        user = create(:user, providers: [provider])
+  let(:accreditor) { create(:accredited_provider) }
+  let(:user) { create(:user, providers: [accreditor]) }
 
+  def download
+    get "/publish/organisations/#{accreditor.provider_code}/#{accreditor.recruitment_cycle.year}/training-providers-courses.csv"
+  end
+
+  describe "/training-providers-courses" do
+    context "when the user is attached to the accredited provider" do
+      before do
+        create(:course, provider: create(:provider), accrediting_provider: accreditor)
         login_user(user)
-        get "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/training-providers-courses.csv"
+        download
+      end
+
+      it "sends a CSV" do
         expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/csv")
+      end
+
+      it "sends it as a dated attachment" do
+        expect(response.headers["Content-Disposition"])
+          .to include("attachment", "courses-#{Time.zone.today}.csv")
+      end
+    end
+
+    context "when the user is not attached to the accredited provider" do
+      it "is forbidden" do
+        login_user(create(:user, providers: [create(:provider)]))
+        download
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the user is not authenticated" do
+      it "is redirected to sign in" do
+        download
+
+        expect(response).to redirect_to("/sign-in")
       end
     end
   end

--- a/spec/services/exports/accredited_course_list_spec.rb
+++ b/spec/services/exports/accredited_course_list_spec.rb
@@ -4,41 +4,91 @@ require "rails_helper"
 
 module Exports
   describe AccreditedCourseList do
-    let(:course) do
+    subject(:export) { described_class.new(courses: accreditor.current_accredited_courses) }
+
+    let(:accreditor) { create(:accredited_provider) }
+    let(:training_partner) { create(:provider, provider_name: "Partner University", provider_code: "1OJ") }
+
+    def rows
+      CSV.parse(export.data.delete_prefix(Exports::CourseColumns::BYTE_ORDER_MARK), headers: true)
+    end
+
+    def create_partner_course(*traits, **attributes)
       create(
         :course,
-        site_statuses: [create(:site_status, :full_time_vacancies, :findable)],
-        enrichments: [build(:course_enrichment, :published)],
+        *traits,
+        provider: training_partner,
+        accrediting_provider: accreditor,
+        **attributes,
       )
     end
 
-    let(:decorated_course) { CourseDecorator.new(course) }
-
-    subject { described_class.new(courses: Course.where(id: course)) }
-
     describe "#data" do
-      let(:expected_output) do
-        {
-          "Provider code" => decorated_course.provider.provider_code,
-          "Provider" => decorated_course.provider.provider_name,
-          "Course code" => decorated_course.course_code,
-          "Course" => decorated_course.name,
-          "Study mode" => decorated_course.study_mode&.humanize,
-          "Programme type" => decorated_course.program_type&.humanize,
-          "Qualification" => decorated_course.outcome,
-          "Status" => decorated_course.content_status&.to_s&.humanize,
-          "View on Find" => decorated_course.find_url,
-          "Applications open from" => I18n.l(decorated_course.applications_open_from&.to_date),
-          "Campus Codes" => decorated_course.sites&.map(&:code)&.join(" "),
-        }
-      end
-
-      it "sets the correct headers" do
-        expect(subject.data.lines[0].strip).to eq(expected_output.keys.join(","))
-      end
-
       it "sets the correct row values" do
-        expect(subject.data.lines[1].strip).to eq(expected_output.values.join(","))
+        create_partner_course(
+          :secondary,
+          :fee,
+          :resulting_in_pgce_with_qts,
+          name: "Design and technology",
+          course_code: "K442",
+          age_range_in_years: "11_to_16",
+          study_mode: :full_time,
+          start_date: Time.zone.local(training_partner.recruitment_cycle_year.to_i, 9, 1),
+          site_statuses: [create(:site_status, :full_time_vacancies, :findable, site: create(:site, code: "K"))],
+          enrichments: [build(:course_enrichment, :published, course_length: "OneYear", fee_uk_eu: 9_535, fee_international: 21_500)],
+        )
+
+        expect(rows.first.to_h).to eq(
+          "Provider" => "Partner University",
+          "Provider code" => "1OJ",
+          "Course name" => "Design and technology",
+          "Course code" => "K442",
+          "Status" => "Published",
+          "Age range" => "11 to 16",
+          "Fee or salary" => "Fee-paying",
+          "Qualification" => "QTS with PGCE",
+          "Full time or part time" => "Full time",
+          "Start date" => "September #{training_partner.recruitment_cycle_year}",
+          "Course length" => "1 year",
+          "UK fee" => "£9,535",
+          "Non-UK fee" => "£21,500",
+          "View on Find" => "http://find.localhost/course/1OJ/K442",
+          "Campus codes" => "K",
+        )
+      end
+
+      it "leads with the byte order mark so Excel reads the fee columns as UTF-8" do
+        create_partner_course(:fee, enrichments: [build(:course_enrichment, :published, fee_uk_eu: 9_535)])
+
+        expect(export.data).to start_with(Exports::CourseColumns::BYTE_ORDER_MARK)
+      end
+
+      it "reports a rolled-over course's own status and fees, which the model counts as draft" do
+        create_partner_course(:fee, enrichments: [
+          build(:course_enrichment, :rolled_over, fee_uk_eu: 9_000, course_length: "OneYear"),
+        ])
+
+        expect(rows.first.to_h).to include(
+          "Status" => "Rolled over", "UK fee" => "£9,000", "Course length" => "1 year",
+        )
+      end
+
+      it "lists campus codes in a stable order, whatever order the sites load in" do
+        create_partner_course(site_statuses: [
+          create(:site_status, :findable, site: create(:site, code: "M")),
+          create(:site_status, :findable, site: create(:site, code: "A")),
+          create(:site_status, :findable, site: create(:site, code: "8")),
+        ])
+
+        expect(rows.first["Campus codes"]).to eq("8 A M")
+      end
+
+      it "leaves the enrichment columns empty when there is no enrichment" do
+        create_partner_course(:salary)
+
+        expect(rows.first.to_h).to include(
+          "Status" => "Draft", "Course length" => nil, "UK fee" => nil, "Non-UK fee" => nil,
+        )
       end
     end
   end

--- a/spec/services/exports/accredited_course_list_spec.rb
+++ b/spec/services/exports/accredited_course_list_spec.rb
@@ -83,6 +83,15 @@ module Exports
         expect(rows.first["Campus codes"]).to eq("8 A M")
       end
 
+      it "lists the main site code last so Excel does not read the cell as a formula" do
+        create_partner_course(site_statuses: [
+          create(:site_status, :findable, site: create(:site, code: Provider::School::MAIN_SITE_CODE)),
+          create(:site_status, :findable, site: create(:site, code: "F")),
+        ])
+
+        expect(rows.first["Campus codes"]).to eq("F -")
+      end
+
       it "leaves the enrichment columns empty when there is no enrichment" do
         create_partner_course(:salary)
 

--- a/spec/services/provider_urn_identification_service_spec.rb
+++ b/spec/services/provider_urn_identification_service_spec.rb
@@ -14,7 +14,7 @@ describe ProviderURNIdentificationService do
     it "returns correct hash" do
       expect(subject[:unfound_urns]).to be_blank
       expect(subject[:duplicate_urns]).to be_blank
-      expect(subject[:new_urns]).to eq(new_urns)
+      expect(subject[:new_urns]).to match_array(new_urns)
     end
   end
 
@@ -25,7 +25,7 @@ describe ProviderURNIdentificationService do
     it "returns correct hash" do
       expect(subject[:unfound_urns]).to eq(%w[unfound])
       expect(subject[:duplicate_urns]).to be_blank
-      expect(subject[:new_urns]).to eq(new_urns)
+      expect(subject[:new_urns]).to match_array(new_urns)
     end
   end
 
@@ -39,7 +39,7 @@ describe ProviderURNIdentificationService do
 
       expect(subject[:unfound_urns]).to eq(%w[unfound])
       expect(subject[:duplicate_urns]).to eq([existing_school.urn])
-      expect(subject[:new_urns]).to eq(new_urns)
+      expect(subject[:new_urns]).to match_array(new_urns)
     end
   end
 
@@ -54,7 +54,7 @@ describe ProviderURNIdentificationService do
 
       expect(subject[:unfound_urns]).to eq([closed_school.urn])
       expect(subject[:duplicate_urns]).to eq([existing_school.urn])
-      expect(subject[:new_urns]).to eq(new_urns)
+      expect(subject[:new_urns]).to match_array(new_urns)
     end
   end
 end


### PR DESCRIPTION
## Context

Accredited providers told us they need more detail about their training
partners courses to check the courses are accurate.

## Changes proposed in this pull request

Update training partners CSV as per https://trello.com/c/w2pAqKdW/1837-update-training-partners-csv

## Guidance to review

The card contradicts itself on Provider code: "Remove data" drops it, the column order and the mock keep it. Kept it in.

Campus codes now sorted.

Download CSV.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
