### PR TITLE
Attribute Blazer queries to the current user

### DIFF
--- a/app/controllers/blazer/application_controller.rb
+++ b/app/controllers/blazer/application_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Blazer::BaseController is defined inside `module Blazer` and inherits from the
+# unqualified `ApplicationController`, so Ruby resolves it to this class rather
+# than the top-level one. Blazer then calls `current_user` on it to attribute
+# queries, dashboards and audits. Without this, `Blazer.user_method` finds no
+# `current_user` and silently records nothing.
+module Blazer
+  class ApplicationController < ::ApplicationController
+    def current_user
+      @current_user ||= UserFromCookie.authenticated_user(request)
+    end
+  end
+end

--- a/spec/system/publish/blazer_spec.rb
+++ b/spec/system/publish/blazer_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe "Blazer SQL tool" do
     then_i_am_taken_to_the_blazer_page
   end
 
+  scenario "creating a dashboard records me as its creator" do
+    given_i_am_authenticated_as_an_admin_who_is_authorised_to_access_blazer
+    when_i_create_a_dashboard_named("Recruitment cycle overview")
+    then_the_dashboard_is_credited_to_me
+  end
+
   def given_i_am_authenticated_as_a_non_admin
     given_i_am_authenticated(user: create(:user, :with_provider))
   end
@@ -58,6 +64,18 @@ RSpec.describe "Blazer SQL tool" do
 
   def then_i_should_be_redirected_to_the_courses_index_page
     expect(publish_provider_courses_index_page).to be_displayed
+  end
+
+  def when_i_create_a_dashboard_named(name)
+    visit blazer.new_dashboard_path
+    fill_in "Name", with: name
+    click_button "Save"
+  end
+
+  def then_the_dashboard_is_credited_to_me
+    dashboard = Blazer::Dashboard.find_by(name: "Recruitment cycle overview")
+
+    expect(dashboard.creator).to eq(current_user)
   end
 
   def then_i_am_redirected_to_sign_in


### PR DESCRIPTION
## Context

Blazer records no user against anything. 94 of 164 saved queries have a null `creator_id`, and 3,986 of 6,555 audits have a null `user_id`, including every audit recorded in 2026.

`Blazer::BaseController` is declared inside `module Blazer` and inherits from the unqualified `ApplicationController`, so Ruby resolves it to the top-level one. That class defines no `current_user`, and Blazer's lookup is guarded:

```ruby
def blazer_user
  send(Blazer.user_method) if Blazer.user_method && respond_to?(Blazer.user_method, true)
end
```

So it returns `nil` silently. Broken by `d37167e09` (2025-05-29), which moved `current_user` into `Publish::Authentication`; before that Blazer inherited it for free. Last audit with a user is 2025-05-30, first without is 2025-06-16.

Beyond the blank ownership column, this disables Blazer's **Mine** and **Viewed** filters, makes `@query.editable?(blazer_user)` evaluate against `nil`, and stops the `#`-prefixed private-query convention working, since that keys off creator.

Existing records are not backfilled. Inferring owners from audit timing was considered and rejected: a guessed owner presented as fact is worse than a blank. This fixes new records only.

## Changes proposed in this pull request

Adds `app/controllers/blazer/application_controller.rb`, which Ruby's constant lookup finds ahead of the top-level one, and defines `current_user` on it using `UserFromCookie.authenticated_user(request)`, the same lookup `BlazerAdminConstraint` already uses to gate the route.

## Guidance to review

New scenario in `spec/system/publish/blazer_spec.rb`: fork a query, name it, create it, assert the creator is the signed-in admin. It fails with `Expected nil` on `main` and passes here. Run it with `bundle exec rspec spec/system/publish/blazer_spec.rb`.

To check by hand, sign in to `/blazer` as an admin with `blazer_access`, create a query, and confirm it shows under **Mine**.

The audit side of the fix is not covered by a test. Any audit needs SQL to actually run, and `config/environments/test.rb:80` points the Blazer data source at `postgres://localhost/...` with no credentials, so it fails at `establish_connection` before `RunStatement` writes the audit row. Both paths call the same `blazer_user`, so the creator scenario covers the mechanism. Giving the test data source credentials is a separate change.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
