### PR TITLE
Add Solid Cache plumbing while keeping Redis as the live cache store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 ARG ZLIB_VERSION=1.3.2-r0
+ARG LIBEXPAT_VERSION=2.8.4-r0
 
 FROM ruby:3.4.10-alpine3.23 AS middleman
 ARG ZLIB_VERSION
+ARG LIBEXPAT_VERSION
 # TODO: remove zlib pin when ruby:3.4.8-alpine3.23 base image is refreshed.
-RUN apk add --no-cache zlib=${ZLIB_VERSION} libxml2
+RUN apk add --no-cache zlib=${ZLIB_VERSION} libexpat=${LIBEXPAT_VERSION} libxml2
 RUN apk add --update --no-cache npm git build-base
 
 COPY docs/Gemfile docs/Gemfile.lock /
@@ -22,8 +24,9 @@ RUN bundle exec middleman build --build-dir=../public
 
 FROM ruby:3.4.10-alpine3.23
 ARG ZLIB_VERSION
+ARG LIBEXPAT_VERSION
 
-RUN apk add --no-cache zlib=${ZLIB_VERSION} libxml2 yaml-dev
+RUN apk add --no-cache zlib=${ZLIB_VERSION} libexpat=${LIBEXPAT_VERSION} libxml2 yaml-dev
 
 RUN apk add --update --no-cache tzdata && \
   cp /usr/share/zoneinfo/Europe/London /etc/localtime && \

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,9 @@ gem "rails", "8.1.3.1"
 # Use PostgreSQL as the database for Active Record
 gem "pg"
 
+# Database-backed Rails cache (schema prepared on deploy; Redis remains the live store)
+gem "solid_cache", "~> 1.0"
+
 # Authorisation
 gem "pundit"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -756,6 +756,10 @@ GEM
     skylight (7.1.1)
       activesupport (>= 7.2.0)
     smart_properties (1.17.0)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     strong_migrations (2.8.0)
       activerecord (>= 7.2)
     super_diff (0.19.0)
@@ -908,6 +912,7 @@ DEPENDENCIES
   simplecov (< 1.2)
   site_prism (~> 6.0)
   skylight
+  solid_cache (~> 1.0)
   strong_migrations (~> 2.8)
   super_diff
   timecop

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -183,3 +183,10 @@
   - statement
   - data_source
   - created_at
+  :solid_cache_entries:
+  - id
+  - key
+  - value
+  - created_at
+  - key_hash
+  - byte_size

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,35 @@
+default: &default
+  store_options:
+    # Unused while Redis is the live cache_store. Cap matches Azure Redis C1 (1GB).
+    max_age: <%= 30.days.to_i %>
+    max_size: <%= 1.gigabytes %>
+    namespace: <%= Rails.env %>
+    expiry_method: :job
+    expiry_queue: low_priority
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+
+qa:
+  <<: *default
+
+review:
+  <<: *default
+
+staging:
+  <<: *default
+
+sandbox:
+  <<: *default
+
+loadtest:
+  <<: *default
+
+rollover:
+  <<: *default

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,7 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
+  # Redis remains the live store; solid_cache_entries lives on the primary DB for a later cutover.
   config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL", "") }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).

--- a/config/initializers/active_record_config.rb
+++ b/config/initializers/active_record_config.rb
@@ -3,6 +3,7 @@
 require_dependency Rails.root.join("app/lib/multiple_parameters_date_type")
 
 ActiveRecord::SchemaDumper.ignore_tables |= %w[
+  airbyte_heartbeat
   geography_columns
   geometry_columns
   layer

--- a/config/initializers/solid_cache.rb
+++ b/config/initializers/solid_cache.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# App-wide pluralize_table_names is false. Solid Cache's schema uses the gem default.
+ActiveSupport.on_load(:solid_cache) do
+  self.pluralize_table_names = true
+end

--- a/db/migrate/20260827153000_create_solid_cache_tables.rb
+++ b/db/migrate/20260827153000_create_solid_cache_tables.rb
@@ -1,0 +1,14 @@
+class CreateSolidCacheTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table "solid_cache_entries" do |t|
+      t.binary "key", limit: 1024, null: false
+      t.binary "value", limit: 536_870_912, null: false
+      t.datetime "created_at", null: false
+      t.integer "key_hash", limit: 8, null: false
+      t.integer "byte_size", limit: 4, null: false
+      t.index %w[byte_size], name: "index_solid_cache_entries_on_byte_size"
+      t.index %w[key_hash byte_size], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+      t.index %w[key_hash], name: "index_solid_cache_entries_on_key_hash", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_21_100824) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_153000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -577,6 +577,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_100824) do
     t.index ["latitude", "longitude"], name: "index_site_on_latitude_and_longitude"
     t.index ["site_type"], name: "index_site_on_site_type"
     t.index ["uuid"], name: "index_sites_unique_uuid", unique: true
+  end
+
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.integer "byte_size", null: false
+    t.datetime "created_at", null: false
+    t.binary "key", null: false
+    t.bigint "key_hash", null: false
+    t.binary "value", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
   create_table "statistic", force: :cascade do |t|

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -1,6 +1,16 @@
 DELETE FROM session;
 DELETE FROM audit;
 
+-- Solid Cache blobs are opaque (keys can include postcodes/addresses).
+-- Skip if the dump predates the solid_cache_entries migration.
+-- TRUNCATE rather than DELETE: after cutover this table can grow toward the 1GB cap.
+DO $$
+BEGIN
+  TRUNCATE solid_cache_entries;
+EXCEPTION
+  WHEN undefined_table THEN NULL;
+END $$;
+
 UPDATE "user"
        SET email=concat('anonimized-user-',id,'@example.org'),
            first_name='anon',

--- a/docs/database-diagram.mmd
+++ b/docs/database-diagram.mmd
@@ -152,7 +152,6 @@ erDiagram
 		integer gias_school_id FK
 		integer id PK
 		integer provider_school_id FK
-		text site_code
 	}
 	CourseEnrichment {
 		integer course_id FK
@@ -201,6 +200,7 @@ erDiagram
 		text address2
 		text address3
 		text county
+		geography geo_location
 		text group_code
 		integer id PK
 		float latitude
@@ -375,6 +375,13 @@ erDiagram
 		text status
 		text vac_status
 	}
+	"SolidCache::Entry" {
+		integer byte_size
+		integer id PK
+		binary key
+		integer key_hash
+		binary value
+	}
 	Statistic {
 		integer id PK
 		jsonb json_data
@@ -442,64 +449,68 @@ erDiagram
 	SiteStatus o|--}o "Audited::Audit" : ""
 	User o|--}o "Audited::Audit" : ""
 	Associated o|--}o "Audited::Audit" : ""
-	Provider ||--}o "Provider::School" : ""
-	GiasSchool ||--}o "Provider::School" : ""
-	"Provider::School" ||--}o "Course::School" : ""
-	Course ||--}o "Course::School" : ""
-	GiasSchool ||--}o "Course::School" : ""
-	Candidate ||--}o "Candidate::EmailAlert" : ""
-	User ||--}o UserPermission : ""
-	Provider ||--}o UserPermission : ""
-	User ||--}o UserNotification : ""
-	Provider ||--}o UserNotification : ""
+	Authenticable ||--}o Authentication : ""
+	User ||--}o Authentication : ""
+	User o|--}o "Blazer::Audit" : ""
+	"Blazer::Query" o|--}o "Blazer::Audit" : ""
+	User o|--}o "Blazer::Check" : ""
+	"Blazer::Query" ||--}o "Blazer::Check" : ""
+	User o|--}o "Blazer::Dashboard" : ""
+	"Blazer::Dashboard" ||--}o "Blazer::DashboardQuery" : ""
+	"Blazer::Dashboard" o|..}o "Blazer::Query" : ""
+	"Blazer::Query" ||--}o "Blazer::DashboardQuery" : ""
+	User o|--}o "Blazer::Query" : ""
 	Sessionable ||--}o Session : ""
 	Candidate ||--}o Session : ""
 	User ||--}o Session : ""
-	Authenticable ||--}o Authentication : ""
-	User ||--}o Authentication : ""
-	User ||--}o OrganisationUser : ""
-	User o|..}o Organisation : ""
-	User o|..}o Provider : ""
-	User o|--}o CourseEnrichment : ""
-	User o|--}o ProvidersOnboardingFormRequest : ""
-	SubjectGroup o|--}o Subject : ""
-	SubjectArea ||--}o Subject : ""
-	Subject ||--}o CourseSubject : ""
-	Subject o|..}| Course : ""
-	Subject ||--}o FinancialIncentive : ""
-	Course ||--}o StudySitePlacement : ""
-	Site ||--}o StudySitePlacement : ""
-	Site ||--}o SiteStatus : ""
-	Course ||--}o SiteStatus : ""
+	Candidate o|--}o Authentication : ""
 	Candidate ||--}o SavedCourse : ""
-	Course ||--}o SavedCourse : ""
-	RecruitmentCycle ||--}o Provider : ""
-	RecruitmentCycle o|..}o Course : ""
-	RecruitmentCycle o|..}o Site : ""
+	Candidate o|..}o Course : ""
 	Candidate ||--}o RecentSearch : ""
+	Candidate ||--}o "Candidate::EmailAlert" : ""
+	Provider ||--}o Contact : ""
+	Provider ||--}o Course : ""
+	Course ||--}o CourseSubject : ""
+	Course ||--}o "Course::School" : ""
+	Course o|..}o GiasSchool : ""
+	Course o|..}| Subject : ""
+	Course o|..}o FinancialIncentive : ""
+	Course ||--}o SiteStatus : ""
+	Course ||--}o StudySitePlacement : ""
+	Course ||--}o SavedCourse : ""
+	Course o|..}o Site : ""
+	Course ||--}o CourseEnrichment : ""
+	GiasSchool ||--}o "Course::School" : ""
+	"Provider::School" ||--}o "Course::School" : ""
+	CourseEnrichment o|..|o Provider : ""
+	Subject ||--}o CourseSubject : ""
+	Subject ||--}o FinancialIncentive : ""
+	Organisation ||--}o OrganisationUser : ""
+	Organisation o|..}o User : ""
+	Organisation o{--}o Provider : ""
+	User ||--}o OrganisationUser : ""
+	RecruitmentCycle ||--}o Provider : ""
+	Provider o|..}o User : ""
+	Provider ||--}o UserPermission : ""
+	Provider ||--}o Site : ""
+	Provider ||--}o "Provider::School" : ""
+	Provider o|..}o GiasSchool : ""
+	Provider ||--}o UserNotification : ""
 	Provider ||--|o ProviderUCASPreference : ""
 	Provider ||--}o ProviderPartnership : ""
-	Organisation ||--}o OrganisationUser : ""
-	Organisation o{--}o Provider : ""
-	Course ||--}o CourseSubject : ""
-	Course ||--}o CourseEnrichment : ""
-	CourseEnrichment o|..|o Provider : ""
-	Provider ||--}o Contact : ""
-	Candidate o|--}o Authentication : ""
-	Candidate o|..}o Course : ""
-	Provider ||--}o Site : ""
-	Provider o|..}o GiasSchool : ""
-	Provider ||--}o Course : ""
 	Provider o|..}o Provider : ""
-	Course o|..}o GiasSchool : ""
-	Course o|..}o FinancialIncentive : ""
-	Course o|..}o Site : ""
-	User o|--}o "Blazer::Query" : ""
-	"Blazer::Query" ||--}o "Blazer::Check" : ""
-	"Blazer::Query" ||--}o "Blazer::DashboardQuery" : ""
-	"Blazer::Query" o|..}o "Blazer::Dashboard" : ""
-	"Blazer::Query" o|--}o "Blazer::Audit" : ""
-	"Blazer::Dashboard" ||--}o "Blazer::DashboardQuery" : ""
-	User o|--}o "Blazer::Dashboard" : ""
-	User o|--}o "Blazer::Check" : ""
-	User o|--}o "Blazer::Audit" : ""
+	GiasSchool ||--}o "Provider::School" : ""
+	"Provider::School" o|..}o Course : ""
+	User o|--}o ProvidersOnboardingFormRequest : ""
+	RecruitmentCycle o|..}o Course : ""
+	RecruitmentCycle o|..}o Site : ""
+	RecruitmentCycle o|..}o "Provider::School" : ""
+	RecruitmentCycle o|..}o "Course::School" : ""
+	RecruitmentCycle o|..}o GiasSchool : ""
+	Site ||--}o SiteStatus : ""
+	Site ||--}o StudySitePlacement : ""
+	SubjectGroup o|--}o Subject : ""
+	SubjectArea ||--}o Subject : ""
+	User ||--}o UserNotification : ""
+	User ||--}o UserPermission : ""
+	User o|--}o CourseEnrichment : ""

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -12,4 +12,8 @@ RSpec.describe "Application config" do
     expect(Rails.application.config.action_dispatch.rescue_responses["PG::ConnectionBad"])
       .to eq :service_unavailable
   end
+
+  it "does not dump the Airbyte heartbeat table into schema.rb" do
+    expect(ActiveRecord::SchemaDumper.ignore_tables).to include("airbyte_heartbeat")
+  end
 end

--- a/spec/config/solid_cache_spec.rb
+++ b/spec/config/solid_cache_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Solid Cache" do
+  it "uses the primary database (no separate cache DB)" do
+    # Pins the Apply-style wiring: cache.yml must not set `database: cache`.
+    # That misconfig would expect an Azure database we do not provision.
+    expect(SolidCache.configuration.connects_to).to be_nil
+    expect(SolidCache::Entry.connection_db_config.name).to eq("primary")
+  end
+end

--- a/spec/db/scripts_spec.rb
+++ b/spec/db/scripts_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe "db/scripts" do
     expect { run_script("sanitise") }.not_to raise_error
   end
 
+  it "wipes solid_cache_entries" do
+    store = ActiveSupport::Cache.lookup_store(:solid_cache_store)
+    store.write("sanitise-cache-probe", "secret")
+    expect(SolidCache::Entry.count).to be_positive
+
+    run_script("sanitise")
+
+    expect(SolidCache::Entry.count).to eq(0)
+  end
+
   it "integration_setup.sql runs cleanly against the current schema" do
     # The provider insert requires a recruitment cycle (recruitment_cycle_id is NOT NULL).
     create(:recruitment_cycle)


### PR DESCRIPTION
## Context

We want to move Find/Publish cache off Redis onto Solid Cache, following Apply: a `solid_cache_entries` table on the **primary** Postgres, not a second Azure database.

Prod Redis cache is a C1 (1GB) instance at ~140MB with no evictions, so we do not need `extra_databases` or a terraform-modules promotion. Redis stays the live `cache_store`. This PR only lays the table and dump hygiene down so a later PR can switch the store.

Cache blobs can include postcodes and addresses. Redis is not in Postgres dumps today; a table on the primary is. Sanitised dumps (review/local) must wipe the table.

## Changes proposed in this pull request

- Add `solid_cache` and create `solid_cache_entries` on the primary database (Apply-shaped columns/indexes).
- Keep `config.cache_store = :redis_cache_store`. `config/cache.yml` is unused until cutover; `max_size` is 1GB to match the C1 SKU.
- Wipe `solid_cache_entries` in `db/scripts/sanitise.sql` (no-op if the table is missing). Block the table from analytics.
- Regenerated `docs/database-diagram.mmd` on migrate (adds `SolidCache::Entry`; also picks up stale `main` schema such as `GiasSchool.geo_location` and dropped `Course::School.site_code`).

No UI changes.

## Guidance to review

- Confirm Redis is still the live store and there is no `CACHE_DATABASE_URL` / `extra_databases` / `database: cache`.
- Migration and `schema.rb` should match Apply’s `solid_cache_entries` shape.
- Sanitise should delete cache rows and tolerate dumps from before the migration.
- The mermaid diff is mostly rails-erd reorder; the new entity is the cache table.
