### PR TITLE
Add Blazer statement timeout and slow query caching

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -2,3 +2,21 @@ override_csp: true
 data_sources:
   main:
     url: <%= Rails.configuration.x.read_only_database_url %>
+
+    # Statement timeout, in seconds. Without this a slow query against
+    # production runs unbounded.
+    timeout: 30
+
+    # Cache results of slow queries. Blazer.cache defaults to Rails.cache,
+    # which is Redis today, so this needs no extra infrastructure.
+    #
+    # Revisit when Rails.cache moves to SolidCache on Postgres: this writes
+    # whole result sets (which often contain personal data) into
+    # solid_cache_entries, where they persist unencrypted for expires_in and
+    # appear in backups. Consider encrypt: true on the cache store, a shorter
+    # expires_in, or setting Blazer.cache to a separate store in
+    # config/initializers/blazer.rb.
+    cache:
+      mode: slow # cache only queries slower than slow_threshold
+      expires_in: 60 # minutes
+      slow_threshold: 15 # seconds


### PR DESCRIPTION
## Context

Blazer runs arbitrary SQL against production with no statement timeout, so a badly shaped query holds a connection open for as long as it takes. This came out of a wider review of our Blazer install, and it is the config-only half of that work.

The part worth knowing: `Blazer.async` is `false` by default and we never set it, so before this change Blazer wrote nothing to `Rails.cache` at all. Turning on `cache.mode: slow` is what introduces those writes, and what it writes is whole result sets. That matters because Blazer queries routinely select provider contact emails and candidate details, and because `Rails.cache` is moving from Redis to SolidCache on Postgres, where those blobs would persist unencrypted and land in backups. The config carries a comment saying so rather than leaving it for whoever does that migration to discover.

Two things I ruled out. Setting `statement_timeout` on the database role instead of in Blazer: `config.x.read_only_database_url` is just `DATABASE_URL` (`config/environments/production.rb:7`), so there is no separate role to hang it off. And pinning `Blazer.cache` to its own store now: on Redis today it buys nothing, so it belongs with the SolidCache move.

## Changes proposed in this pull request

- Blazer statements now run with a 30 second statement timeout. The SQL adapter issues `SET LOCAL statement_timeout` per query, since queries are already wrapped in a transaction.
- Results of queries taking 15 seconds or more are cached for 60 minutes. Faster queries are not cached.

No UI changes.

## Guidance to review

Check the settings parse as intended:

```
bin/rails runner 'ds = Blazer.data_sources["main"]; puts "#{ds.timeout} #{ds.cache_mode} #{ds.cache_expires_in} #{ds.cache_slow_threshold}"'
```

Expect `30 slow 60.0 15.0`.

The numbers are the judgement call and the part I would most like a second opinion on. 30 seconds is generous enough for the heavier estate-wide queries in the install but short of anything pathological; 15 seconds as the caching threshold means only genuinely slow queries get their results written anywhere. If the SolidCache timeline is nearer than I think, dropping the `cache` block and keeping only `timeout` is a clean four-line revert.

## Checklist

- [ ] I have moved hard-coded strings to locale files. Not applicable, no user-facing strings.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests. Not applicable, no HTML changes.
