### PR TITLE
Cap Dependabot at 8 open PRs and ignore the Redis-blocked gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,34 +4,54 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 8
     labels:
       - deploy
       - dependencies
       - ruby
+    groups:
+      dev-and-test:
+        dependency-type: development
     ignore:
       - dependency-name: audited
+      # Sidekiq 7+ requires Redis 7+. Azure Cache for Redis is on 6
+      # (terraform/aks/databases.tf), so anything in this chain is unmergeable
+      # until the infrastructure moves. See commit 9c1f006f.
       - dependency-name: sidekiq
+      - dependency-name: sidekiq-cron
+      - dependency-name: redis
+      - dependency-name: mock_redis
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 8
     labels:
       - deploy
       - dependencies
       - javascript
+    groups:
+      dev-dependencies:
+        dependency-type: development
   - package-ecosystem: bundler
     directory: "/docs"
     schedule:
       interval: daily
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 8
+    groups:
+      docs:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directories:
       - "/"
       - "/.github/actions/*"
     schedule:
       interval: daily
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 8
     labels:
       - github_actions
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Context 

Caps Dependabot at 8 open PRs across all four update configs (bundler `/`, npm `/`, bundler `/docs`, github-actions), down from 10/15/15/15. The limits were raised to 15 as a workaround back when Dependabot stopped working and were never lowered again, so the worst case was 55 open PRs — all merged by hand on the Support developer rota.

Some of those PRs could never be merged at all. Sidekiq is pinned below 7 because Sidekiq 7 requires Redis 7+ and our Azure Cache for Redis instances are on 6 — an infrastructure gate, not a Gemfile one. Only `sidekiq` was in the ignore list, so Dependabot kept re-opening PRs for the rest of that chain; the `mock_redis` 0.54.0 PR has been open and unmergeable since May. This adds `sidekiq-cron`, `redis` and `mock_redis` to the ignore list, with a comment recording why — that rationale previously lived only in a commit message.

It also adds conservative grouping, which is what makes a limit of 8 workable: a grouped PR counts as one against the limit, so the queue keeps moving instead of filling up with trivial patch bumps. Only dev and test dependencies are grouped (plus docs and github-actions, one PR each) — production gems and npm `dependencies` stay ungrouped so a breakage is still attributable to a single dependency. If a group ever gets stuck on one bad member, the fix is `exclude-patterns` or an `ignore` entry for that package.
