### PR TITLE
Fix location search grouping error on new school data model feature flag

### DIFF
--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -379,6 +379,7 @@ module Courses
       @scope
         .joins(nearby_courses)
         .select("course.*, provider.provider_name, (nearby_courses.distance_m / 1609.344) AS minimum_distance_to_search_location")
+        .group("course.id, provider.id, provider.provider_name, nearby_courses.distance_m")
     end
 
     def default_ordering_scope

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -359,6 +359,14 @@ module Courses
     # ST_Distance/ST_DWithin take the trailing `false` to force sphere maths, so
     # results match the legacy ST_DistanceSphere path. Distance is returned in
     # miles, preserving the minimum_distance_to_search_location contract.
+    #
+    # The GROUP BY carries the same contract sites_location_scope has always had,
+    # and both of its jobs matter. It collapses the subjects_scope join, which
+    # otherwise repeats a course once per matching subject, and it keeps the
+    # distance column groupable for the orderings that add a GROUP BY of their own
+    # (newest_course, fee_uk_ascending, fee_intl_ascending) - without it those
+    # combinations raise PG::GroupingError. Grouping costs nothing here: the
+    # derived table already yields exactly one row per course.
     def schools_location_scope(latitude:, longitude:, radius_in_meters:)
       point = Course.sanitize_sql_array(
         ["ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography", longitude, latitude],

--- a/spec/services/courses/query/combined_filter_ordering_new_school_model_spec.rb
+++ b/spec/services/courses/query/combined_filter_ordering_new_school_model_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Combined filter + ordering coverage for the canonical course_school -> gias_school
+# location path, gated by :course_publishing_uses_new_school_model. The sibling
+# combined_filter_ordering_spec.rb covers the same combinations over the legacy
+# course_site -> site path.
+#
+# schools_location_scope annotates each course with a distance taken from a derived
+# table while the fee and newest_course orderings add a GROUP BY of their own, and
+# subjects_scope joins a has_many. All three have to agree on the grouping, or
+# Postgres rejects the query and duplicate courses reach the results page.
+RSpec.describe Courses::Query do # rubocop:disable RSpec/SpecFilePathFormat
+  subject(:results) { described_class.call(params:) }
+
+  before { FeatureFlag.activate(:course_publishing_uses_new_school_model) }
+  after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
+
+  let(:alpha_provider) { create(:provider, provider_name: "Alpha University") }
+  let(:beta_provider) { create(:provider, provider_name: "Beta University") }
+  let(:london) { build(:location, :london) }
+  let(:canary_wharf) { build(:location, :canary_wharf) }
+  let(:cambridge) { build(:location, :cambridge) }
+
+  # Teaches an existing course at each location, one gias_school per location.
+  def teach_at(course, *locations)
+    locations.each do |location|
+      create(
+        :course_school,
+        course:,
+        gias_school: create(:gias_school, latitude: location.latitude, longitude: location.longitude),
+      )
+    end
+    course
+  end
+
+  context "when combining location filter with fee_uk_ascending ordering" do
+    let(:params) { { order: "fee_uk_ascending", latitude: london.latitude, longitude: london.longitude, radius: 10 } }
+
+    let!(:nearby_low_fee) do
+      teach_at(
+        create(:course, :published, :fee, name: "Low Fee Nearby", provider: alpha_provider,
+                                          enrichments: [build(:course_enrichment, :published, fee_uk_eu: 5000)]),
+        london,
+      )
+    end
+    let!(:nearby_high_fee) do
+      teach_at(
+        create(:course, :published, :fee, name: "High Fee Nearby", provider: beta_provider,
+                                          enrichments: [build(:course_enrichment, :published, fee_uk_eu: 9000)]),
+        canary_wharf,
+      )
+    end
+    let!(:far_low_fee) do
+      teach_at(
+        create(:course, :published, :fee, name: "Low Fee Far", provider: alpha_provider,
+                                          enrichments: [build(:course_enrichment, :published, fee_uk_eu: 1000)]),
+        cambridge,
+      )
+    end
+
+    it "returns only nearby courses ordered by UK fee ascending" do
+      expect(results).to match_collection([nearby_low_fee, nearby_high_fee], attribute_names: %w[name])
+    end
+  end
+
+  context "when combining location filter with fee_intl_ascending ordering" do
+    let(:params) { { order: "fee_intl_ascending", latitude: london.latitude, longitude: london.longitude, radius: 10 } }
+
+    let!(:nearby_low_fee) do
+      teach_at(
+        create(:course, :published, :fee, name: "Low Intl Fee Nearby", provider: alpha_provider,
+                                          enrichments: [build(:course_enrichment, :published, fee_international: 12_000)]),
+        london,
+      )
+    end
+    let!(:nearby_high_fee) do
+      teach_at(
+        create(:course, :published, :fee, name: "High Intl Fee Nearby", provider: beta_provider,
+                                          enrichments: [build(:course_enrichment, :published, fee_international: 18_000)]),
+        canary_wharf,
+      )
+    end
+    let!(:far_low_fee) do
+      teach_at(
+        create(:course, :published, :fee, name: "Low Intl Fee Far", provider: alpha_provider,
+                                          enrichments: [build(:course_enrichment, :published, fee_international: 5000)]),
+        cambridge,
+      )
+    end
+
+    it "returns only nearby courses ordered by international fee ascending" do
+      expect(results).to match_collection([nearby_low_fee, nearby_high_fee], attribute_names: %w[name])
+    end
+  end
+
+  context "when combining location filter with newest_course ordering" do
+    let(:params) { { order: "newest_course", latitude: london.latitude, longitude: london.longitude, radius: 10 } }
+
+    let!(:nearby_recent) do
+      teach_at(
+        create(:course, :published, name: "Nearby Recent", provider: alpha_provider,
+                                    enrichments: [build(:course_enrichment, :published, last_published_timestamp_utc: 1.day.ago)]),
+        london,
+      )
+    end
+    let!(:nearby_old) do
+      teach_at(
+        create(:course, :published, name: "Nearby Old", provider: beta_provider,
+                                    enrichments: [build(:course_enrichment, :published, last_published_timestamp_utc: 5.days.ago)]),
+        canary_wharf,
+      )
+    end
+    let!(:far_recent) do
+      teach_at(
+        create(:course, :published, name: "Far Recent", provider: alpha_provider,
+                                    enrichments: [build(:course_enrichment, :published, last_published_timestamp_utc: 1.hour.ago)]),
+        cambridge,
+      )
+    end
+
+    it "returns only nearby courses ordered by newest first" do
+      expect(results).to match_collection([nearby_recent, nearby_old], attribute_names: %w[name])
+    end
+  end
+
+  context "when a nearby course is taught at several schools and a fee ordering is applied" do
+    let(:params) { { order: "fee_uk_ascending", latitude: london.latitude, longitude: london.longitude, radius: 10 } }
+
+    let!(:multi_school_course) do
+      teach_at(
+        create(:course, :published, :fee, name: "Multi School", provider: alpha_provider,
+                                          enrichments: [build(:course_enrichment, :published, fee_uk_eu: 5000)]),
+        cambridge,
+        canary_wharf,
+        london,
+      )
+    end
+
+    it "returns the course once, at the distance of its nearest school" do
+      rows = results.to_a
+
+      expect(rows.size).to eq(1)
+      expect(rows.first.minimum_distance_to_search_location.round(2)).to eq(0.0)
+    end
+  end
+end

--- a/spec/services/courses/query/combined_filter_ordering_new_school_model_spec.rb
+++ b/spec/services/courses/query/combined_filter_ordering_new_school_model_spec.rb
@@ -125,6 +125,45 @@ RSpec.describe Courses::Query do # rubocop:disable RSpec/SpecFilePathFormat
     end
   end
 
+  context "when a course matches more than one of the searched subjects" do
+    let(:physics) { find_or_create(:secondary_subject, :physics) }
+    let(:biology) { find_or_create(:secondary_subject, :biology) }
+    let(:params) do
+      {
+        subjects: [physics.subject_code, biology.subject_code],
+        latitude: london.latitude,
+        longitude: london.longitude,
+        radius: 10,
+      }
+    end
+
+    let!(:physics_and_biology) do
+      teach_at(
+        create(:course, :published, :secondary, name: "Physics and Biology", provider: alpha_provider,
+                                                subjects: [physics, biology]),
+        london,
+      )
+    end
+
+    it "returns the course once" do
+      expect(results).to match_collection([physics_and_biology], attribute_names: %w[name])
+    end
+
+    it "returns as many courses as it counts" do
+      query = described_class.new(params: params.dup)
+
+      expect(query.call.to_a.size).to eq(query.count)
+    end
+
+    context "with newest_course ordering" do
+      let(:params) { super().merge(order: "newest_course") }
+
+      it "returns the course once" do
+        expect(results).to match_collection([physics_and_biology], attribute_names: %w[name])
+      end
+    end
+  end
+
   context "when a nearby course is taught at several schools and a fee ordering is applied" do
     let(:params) { { order: "fee_uk_ascending", latitude: london.latitude, longitude: london.longitude, radius: 10 } }
 

--- a/spec/system/find/results/ordering/location_ordering_new_school_model_spec.rb
+++ b/spec/system/find/results/ordering/location_ordering_new_school_model_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "ordering_helper"
+
+# The sibling ordering specs cover these sorts over the legacy course_site -> site
+# path. With :course_publishing_uses_new_school_model on, the distance a location
+# search annotates each course with comes from a derived table instead, while each
+# of these sorts adds a GROUP BY of its own. The two have to agree: when they did
+# not, every one of these searches returned a 500 instead of results, and a course
+# matching two of the chosen subjects was listed twice.
+RSpec.describe "Search results ordering with a location on the new school model", :js, service: :find do
+  include OrderingHelper
+
+  before do
+    FeatureFlag.activate(:course_publishing_uses_new_school_model)
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
+
+  after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
+
+  scenario "ordering courses by lowest UK fee when a location is present" do
+    given_there_are_courses_at_different_locations_with_different_uk_fees
+    when_i_visit_the_find_results_page_with_london_location
+    and_i_sort_by_lowest_uk_fee
+    then_the_courses_are_ordered_by_uk_fee_not_distance
+  end
+
+  scenario "ordering courses by lowest international fee when a location is present" do
+    given_there_are_courses_at_different_locations_with_different_international_fees
+    when_i_visit_the_find_results_page_with_london_location
+    and_i_sort_by_lowest_international_fee
+    then_the_courses_are_ordered_by_international_fee_not_distance
+  end
+
+  scenario "ordering courses by newest course when a location is present" do
+    given_there_are_courses_at_different_locations_published_at_different_times
+    when_i_visit_the_find_results_page_with_london_location
+    and_i_sort_by_newest_course
+    then_the_courses_are_ordered_by_newest_first_not_distance
+  end
+
+  scenario "a course matching several of the chosen subjects is listed once" do
+    given_there_is_a_nearby_course_teaching_physics_and_biology
+    when_i_search_that_location_for_physics_and_biology
+    then_the_course_is_listed_once
+  end
+
+  # Teaches `course` at `location` through the canonical course_school -> gias_school
+  # model, the only location source the flag leaves in play.
+  def teach_at(course, location)
+    create(
+      :course_school,
+      course:,
+      gias_school: create(:gias_school, latitude: location.latitude, longitude: location.longitude),
+    )
+    course
+  end
+
+  def given_there_are_courses_at_different_locations_with_different_uk_fees
+    provider = create(:provider, provider_name: "Test Provider")
+
+    # Closer to London but more expensive
+    teach_at(
+      create(:course, :published, provider:, name: "Expensive Course", course_code: "EXP1",
+                                  enrichments: [build(:course_enrichment, :published, fee_uk_eu: 9000)]),
+      build(:location, :london),
+    )
+
+    # Further from London but cheaper
+    teach_at(
+      create(:course, :published, provider:, name: "Cheap Course", course_code: "CHP1",
+                                  enrichments: [build(:course_enrichment, :published, fee_uk_eu: 1000)]),
+      build(:location, :romford),
+    )
+  end
+
+  def given_there_are_courses_at_different_locations_with_different_international_fees
+    provider = create(:provider, provider_name: "Test Provider")
+
+    teach_at(
+      create(:course, :published, provider:, name: "Expensive Course", course_code: "EXP1",
+                                  enrichments: [build(:course_enrichment, :published, fee_international: 18_000)]),
+      build(:location, :london),
+    )
+
+    teach_at(
+      create(:course, :published, provider:, name: "Cheap Course", course_code: "CHP1",
+                                  enrichments: [build(:course_enrichment, :published, fee_international: 12_000)]),
+      build(:location, :romford),
+    )
+  end
+
+  def given_there_are_courses_at_different_locations_published_at_different_times
+    provider = create(:provider, provider_name: "Test Provider")
+
+    # Closer to London but published longer ago
+    teach_at(
+      create(:course, :published, provider:, name: "Old Course", course_code: "OLD1",
+                                  enrichments: [build(:course_enrichment, :published, last_published_timestamp_utc: 5.days.ago)]),
+      build(:location, :london),
+    )
+
+    teach_at(
+      create(:course, :published, provider:, name: "Recent Course", course_code: "REC1",
+                                  enrichments: [build(:course_enrichment, :published, last_published_timestamp_utc: 1.day.ago)]),
+      build(:location, :romford),
+    )
+  end
+
+  def given_there_is_a_nearby_course_teaching_physics_and_biology
+    @physics = find_or_create(:secondary_subject, :physics)
+    @biology = find_or_create(:secondary_subject, :biology)
+
+    teach_at(
+      create(:course, :published, :secondary,
+             provider: create(:provider, provider_name: "Test Provider"),
+             name: "Physics and Biology", course_code: "PHB1",
+             subjects: [@physics, @biology]),
+      build(:location, :london),
+    )
+  end
+
+  def when_i_search_that_location_for_physics_and_biology
+    stub_london_location_search
+    visit find_results_path(location: "London, UK", subjects: [@physics.subject_code, @biology.subject_code])
+  end
+
+  def then_the_courses_are_ordered_by_uk_fee_not_distance
+    expect(result_titles).to eq([
+      "Test Provider Cheap Course (CHP1)",
+      "Test Provider Expensive Course (EXP1)",
+    ])
+  end
+
+  def then_the_courses_are_ordered_by_international_fee_not_distance
+    expect(result_titles).to eq([
+      "Test Provider Cheap Course (CHP1)",
+      "Test Provider Expensive Course (EXP1)",
+    ])
+  end
+
+  def then_the_courses_are_ordered_by_newest_first_not_distance
+    expect(result_titles).to eq([
+      "Test Provider Recent Course (REC1)",
+      "Test Provider Old Course (OLD1)",
+    ])
+  end
+
+  def then_the_course_is_listed_once
+    expect(result_titles).to eq(["Test Provider Physics and Biology (PHB1)"])
+  end
+
+  def and_i_sort_by_lowest_uk_fee
+    page.find("h3", text: "Sort by", normalize_ws: true).click
+    choose "Lowest fee for UK citizens", visible: :hidden
+    click_link_or_button "Apply filters"
+  end
+
+  def and_i_sort_by_lowest_international_fee
+    page.find("h3", text: "Sort by", normalize_ws: true).click
+    choose "Lowest fee for non-UK citizens", visible: :hidden
+    click_link_or_button "Apply filters"
+  end
+
+  def and_i_sort_by_newest_course
+    page.find("h3", text: "Sort by", normalize_ws: true).click
+    choose "Newest course", visible: :hidden
+    click_link_or_button "Apply filters"
+  end
+end


### PR DESCRIPTION
# Group the course_school location scope

Sorting a location search by fee or by newest course 500s the results page, which is what Sentry is
reporting as `PG::GroupingError: column "nearby_courses.distance_m" must appear in the GROUP BY clause`.
`schools_location_scope` — the location path behind `:course_publishing_uses_new_school_model` — annotates
each course with a distance read straight out of a derived table, as a raw column. Three orderings
(`newest_course`, `fee_uk_ascending`, `fee_intl_ascending`) add a `GROUP BY` of their own, and grouping by
`course.id` covers `course.*` by functional dependency but does not reach into the joined derived table.
So the two disagree and Postgres rejects the query. The legacy `sites_location_scope` never hit this: it
selects `MIN(ST_DistanceSphere(...))` under its own `GROUP BY`, so a second one merges harmlessly.

The same missing `GROUP BY` causes a second, quieter bug: `subjects_scope` joins a `has_many`, so a course
teaching two of the searched subjects comes back twice. The count beside the results is computed separately
with `.distinct.count(:id)`, so it keeps saying one — the page shows "1 course" above two identical cards.
Both bugs arrived together when the location filter moved from `course_site` to `course_school`, and both
are fixed by the same line. Worth noting for whoever picks up the Sentry issue: `EmailAlertMailer` builds
its "see all results" link with `order=newest_course`, and alert subscribers search by location, so those
emails send people straight onto the broken combination.

The fix restores the grouping contract the site-based scope always had:
`GROUP BY course.id, provider.id, provider.provider_name, nearby_courses.distance_m`. It costs nothing in
rows — the derived table already emits exactly one row per course — and it leaves the index work from the
`ST_DWithin` pruning where it was, inside the derived table and ahead of the join. Tests were written
first and each was watched fail with the reported error before the fix landed: service specs for the three
orderings, the duplicate listing, and count-versus-listing agreement, plus a browser spec that searches a
location, picks each sort and reads back the rendered cards. I also checked all seven sort options against
a location, with and without a subject filter, so the orderings that were previously fine stay fine under
the new grouping.

```
                  ┌─ nearby_courses (derived table) ──────┐
                  │ GROUP BY course_school.course_id      │  already one row
                  │ MIN(ST_Distance(...)) AS distance_m   │  per course
                  └───────────────────┬───────────────────┘
                                      │ INNER JOIN
                                      ▼
     subjects ──── JOIN ──────────► course ◄──── JOIN ──── provider
     one row per matching
     subject → duplicate cards ✗ (2)

     SELECT course.*, provider.provider_name,
            nearby_courses.distance_m / 1609.344      ← raw column, not aggregated
     GROUP BY course.id, provider.id, provider.provider_name
              └── added by the newest_course / fee_uk / fee_intl orderings;
                  distance_m is absent → PG::GroupingError ✗ (1)
```
