### PR TITLE
Update information displayed and styling on Schools show page in Publish

### DIFF
--- a/app/components/publish/courses/table_component.html.erb
+++ b/app/components/publish/courses/table_component.html.erb
@@ -12,7 +12,13 @@
     <% courses.each do |course| %>
       <tr class="<%= row_classes(course) %>">
         <td class="govuk-table__cell app-table--courses__course-name">
-          <%= govuk_link_to course.name_and_code, course_path(course), class: "govuk-heading-s govuk-!-margin-bottom-0" %>
+          <% if link_to_course?(course) %>
+            <%= govuk_link_to course.name_and_code, course_path(course), class: "govuk-heading-s govuk-!-margin-bottom-0" %>
+          <% else %>
+            <span class="govuk-heading-s govuk-!-margin-0">
+              <%= course.name_and_code %><br>
+            </span>
+          <% end %>
           <% if age_range(course) %>
             <div class="govuk-hint govuk-!-margin-0"><%= age_range(course) %></div>
           <% end %>

--- a/app/components/publish/courses/table_component.html.erb
+++ b/app/components/publish/courses/table_component.html.erb
@@ -12,13 +12,7 @@
     <% courses.each do |course| %>
       <tr class="<%= row_classes(course) %>">
         <td class="govuk-table__cell app-table--courses__course-name">
-          <% if on_courses_index_page?(course) %>
-            <%= govuk_link_to course.name_and_code, course_path(course), class: "govuk-heading-s govuk-!-margin-bottom-0" %>
-          <% else %>
-            <span class="govuk-heading-s govuk-!-margin-0">
-              <%= course.name_and_code %><br>
-            </span>
-          <% end %>
+          <%= govuk_link_to course.name_and_code, course_path(course), class: "govuk-heading-s govuk-!-margin-bottom-0" %>
           <% if age_range(course) %>
             <div class="govuk-hint govuk-!-margin-0"><%= age_range(course) %></div>
           <% end %>

--- a/app/components/publish/courses/table_component.rb
+++ b/app/components/publish/courses/table_component.rb
@@ -53,6 +53,15 @@ module Publish
         )
       end
 
+      # The path is built from this table's provider, which Publish looks up
+      # with provider.courses.find_by!(course_code:). Linking when that
+      # provider does not own the course 404s, or opens a different course
+      # that happens to share the code — as on the training-partners list,
+      # where @provider is the accredited provider.
+      def link_to_course?(course)
+        course.provider_id == provider.id
+      end
+
       def age_range(course)
         return if course.secondary_course?
         return if course.age_range_in_years.blank?

--- a/app/components/publish/courses/table_component.rb
+++ b/app/components/publish/courses/table_component.rb
@@ -53,15 +53,6 @@ module Publish
         )
       end
 
-      def on_courses_index_page?(course)
-        helpers.current_page?(
-          helpers.publish_provider_recruitment_cycle_courses_path(
-            provider.provider_code,
-            course.recruitment_cycle.year,
-          ),
-        )
-      end
-
       def age_range(course)
         return if course.secondary_course?
         return if course.age_range_in_years.blank?

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -16,7 +16,9 @@ module Publish
         )
       end
 
-      def show; end
+      def show
+        @school_courses = Publish::Courses::Query.call(provider:, school:).map(&:decorate)
+      end
 
       def create
         @site = provider.sites.build

--- a/app/services/publish/courses/query.rb
+++ b/app/services/publish/courses/query.rb
@@ -54,9 +54,10 @@ module Publish
 
       attr_reader :applied_scopes, :scope, :params
 
-      def initialize(provider:, params: {})
+      def initialize(provider:, params: {}, school: nil)
         @provider = provider
         @params = params
+        @school = school
         @applied_scopes = {}
         # Preload provider + cycle for the course link path and status cycle
         # branch; status/display fields come from columns (no enrichment/site loads).
@@ -64,6 +65,7 @@ module Publish
       end
 
       def call
+        @scope = school_scope
         @scope = accredited_provider_scope
         @scope = enrichment_join_scope
         @scope = level_scope
@@ -83,7 +85,16 @@ module Publish
 
     private
 
-      attr_reader :provider
+      attr_reader :provider, :school
+
+      # Restrict to kept courses attached to this provider school (the school
+      # show page). A subquery rather than a join so a course cannot appear twice.
+      def school_scope
+        return @scope if school.blank?
+
+        @applied_scopes[:school] = school.id
+        @scope.where(id: ::Course::School.where(provider_school_id: school.id).select(:course_id))
+      end
 
       # Filter: restrict to courses ratified by a given accredited provider
       # (used by the training-partners course list).

--- a/app/views/publish/providers/schools/delete.html.erb
+++ b/app/views/publish/providers/schools/delete.html.erb
@@ -10,7 +10,7 @@
       <% if school_removal.removable? %>
         <%= t("components.page_titles.publish.providers.schools.delete") %>
         </h1>
-        <%= govuk_button_to "Remove school",
+        <%= govuk_button_to t(".remove", school_name: school.location_name),
           school_delete_path_with_return,
           method: :delete,
           class: "govuk-button--warning" %>

--- a/app/views/publish/providers/schools/show.html.erb
+++ b/app/views/publish/providers/schools/show.html.erb
@@ -5,30 +5,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= school.location_name %></h1>
-      </legend>
-      <%= render GovukComponent::SummaryListComponent.new do |component|
-            component.with_row do |row|
-              row.with_key { t(".code") }
-              row.with_value(text: school.code)
-              row.with_action
-            end
+    <h1 class="govuk-heading-l"><%= school.location_name %></h1>
+    <p class="govuk-body govuk-hint govuk-!-margin-bottom-0"><%= school.full_address %></p>
+    <p class="govuk-body govuk-hint"><%= t(".urn", urn: school.urn) %></p>
 
-            component.with_row do |row|
-              row.with_key { t(".urn") }
-              row.with_value(text: value_provided?(school.urn))
-            end
+    <% if @school_courses.any? %>
+      <div class="govuk-!-margin-top-6">
+        <%= render Publish::Courses::TableComponent.new(courses: @school_courses, provider: @provider) %>
+      </div>
+    <% else %>
+      <p class="govuk-body govuk-!-margin-top-6"><%= t(".no_courses") %></p>
+    <% end %>
 
-            component.with_row do |row|
-              row.with_key { t(".address") }
-              row.with_value(text: simple_format(school.full_address_on_seperate_lines, {}, wrapper_tag: :div))
-            end
-          end %>
-      <p class="govuk-body">
-        <%= govuk_link_to t(".remove", resource: "location"), delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid), class: "app-link--destructive" %>
-      </p>
-    </fieldset>
+    <p class="govuk-body">
+      <%= govuk_link_to t(".remove", school_name: school.location_name), delete_publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.uuid), class: "app-link--destructive" %>
+    </p>
   </div>
 </div>

--- a/config/locales/en/publish/providers/schools.yml
+++ b/config/locales/en/publish/providers/schools.yml
@@ -13,10 +13,11 @@ en:
             other: "%{count} courses"
           remove: Remove school
         show:
-          code: School code
-          urn: URN
-          address: Address
-          remove: Remove school
+          urn: "URN: %{urn}"
+          no_courses: This school is not attached to any courses.
+          remove: "Remove %{school_name} from your account"
+        delete:
+          remove: "Remove %{school_name} from your account"
         destroy:
           cannot_remove_school: This school could not be removed because it is used by a course
           cannot_remove_only_school: This school could not be removed because it is your only school

--- a/spec/components/publish/courses/table_component_spec.rb
+++ b/spec/components/publish/courses/table_component_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe Publish::Courses::TableComponent, type: :component do
       end
     end
 
+    context "when the table's provider does not own the course" do
+      subject(:render_component) { render_inline(described_class.new(courses:, provider: accredited_provider)) }
+
+      let(:accredited_provider) { create(:provider, :accredited_provider) }
+
+      it "renders the course name as text, not a link" do
+        render_component
+
+        within(".app-table--courses__course-name") do
+          expect(page).to have_text("Biology (B123)")
+          expect(page).to have_no_link("Biology (B123)")
+        end
+      end
+    end
+
     context "when the course is secondary" do
       before do
         create(:course, :secondary, :published_postgraduate, provider:, name: "Physics", course_code: "P456")

--- a/spec/components/publish/courses/table_component_spec.rb
+++ b/spec/components/publish/courses/table_component_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Publish::Courses::TableComponent, type: :component do
       create(:course, :published_postgraduate, provider:, name: "Biology", course_code: "B123", start_date: Time.zone.local(2026, 9, 1))
     end
 
-    it "renders the course name and the age range hint" do
+    it "renders the course name as a link and the age range hint" do
       render_component
 
       within(".app-table--courses__course-name") do
-        expect(page).to have_text("Biology (B123)")
+        expect(page).to have_link("Biology (B123)")
         expect(page).to have_css(".govuk-hint", text: "Ages 3 to 7")
       end
     end

--- a/spec/requests/publish/providers/schools_spec.rb
+++ b/spec/requests/publish/providers/schools_spec.rb
@@ -108,10 +108,13 @@ RSpec.describe "Publish provider school show page", service: :publish do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("St Joseph")
         expect(response.body).to include("Catholic Primary School")
-        expect(response.body).to include("School code")
-        expect(response.body).to include("A")
-        expect(response.body).to include("112992")
-        expect(response.body).to include("1 School Lane")
+        expect(response.body).to include("1 School Lane, Building A, Quarter B, Leeds, West Yorkshire, LS1 1AA")
+        expect(response.body).to include("URN: 112992")
+        expect(response.body).to include("This school is not attached to any courses.")
+        expect(response.body).to include("Remove #{provider_school.decorate.location_name} from your account")
+        expect(response.body).not_to include("School code")
+        expect(response.body).not_to include("govuk-summary-list")
+        expect(response.body).not_to include("govuk-table")
       end
 
       it "returns not found when the provider school does not exist" do
@@ -144,7 +147,59 @@ RSpec.describe "Publish provider school show page", service: :publish do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("St Joseph")
         expect(response.body).to include("Catholic Primary School")
-        expect(response.body).to include("B")
+        expect(response.body).to include("1 School Lane, Building A, Quarter B, Leeds, West Yorkshire, LS1 1AA")
+        expect(response.body).to include("URN: 112992")
+        expect(response.body).to include("This school is not attached to any courses.")
+        expect(response.body).to include("Remove #{provider_school.decorate.location_name} from your account")
+        expect(response.body).not_to include("School code")
+        expect(response.body).not_to include("govuk-table")
+      end
+
+      it "lists attached courses in the courses table" do
+        course = create(
+          :course,
+          :published_postgraduate,
+          provider:,
+          name: "Biology",
+          course_code: "B123",
+          start_date: Time.zone.local(2026, 9, 1),
+        )
+        create(:course_school, course:, provider_school:, gias_school:)
+        create(
+          :course,
+          :published_postgraduate,
+          provider:,
+          name: "History",
+          course_code: "H100",
+        )
+
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Biology (B123)")
+        expect(response.body).to include("Course information")
+        expect(response.body).to include("Fee-paying")
+        expect(response.body).to include("QTS with PGCE")
+        expect(response.body).to include("Full time")
+        expect(response.body).to include("September 2026")
+        expect(response.parsed_body.at_css(".govuk-tag")).to be_present
+        expect(response.body).to include(
+          publish_provider_recruitment_cycle_course_path(provider.provider_code, recruitment_cycle.year, "B123"),
+        )
+        expect(response.body).not_to include("History (H100)")
+        expect(response.body).not_to include("This school is not attached to any courses.")
+      end
+
+      it "does not list discarded courses attached to the school" do
+        course = create(:course, provider:, name: "Biology", course_code: "B123")
+        create(:course_school, course:, provider_school:, gias_school:)
+        course.discard
+
+        get publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid)
+
+        expect(response.body).to include("This school is not attached to any courses.")
+        expect(response.body).not_to include("Biology (B123)")
+        expect(response.body).not_to include("govuk-table")
       end
 
       it "returns not found for a school in another recruitment cycle" do
@@ -181,7 +236,7 @@ RSpec.describe "Publish provider school show page", service: :publish do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("(Main Site)")
-        expect(response.body).to include("-")
+        expect(response.body).not_to include("School code")
       end
     end
   end
@@ -198,7 +253,7 @@ RSpec.describe "Publish provider school show page", service: :publish do
       get delete_publish_provider_recruitment_cycle_school_path(provider.provider_code, recruitment_cycle.year, provider_school.uuid)
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Remove school")
+      expect(response.body).to include("Remove #{provider_school.decorate.location_name} from your account")
       expect(response.body).to include("St Joseph")
       expect(response.body).to include("Catholic Primary School")
     end

--- a/spec/services/publish/courses/query_spec.rb
+++ b/spec/services/publish/courses/query_spec.rb
@@ -90,6 +90,39 @@ RSpec.describe Publish::Courses::Query do
     end
   end
 
+  describe "school filter" do
+    subject(:rows) { described_class.call(provider: provider.reload, school:) }
+
+    let(:provider) { create(:provider) }
+    let(:school) { create(:provider_school, provider:) }
+    let!(:attached) { create(:course, provider:, name: "Biology", course_code: "B123") }
+    let!(:unattached) { create(:course, provider:, name: "History", course_code: "H100") }
+
+    before { create(:course_school, course: attached, provider_school: school, gias_school: school.gias_school) }
+
+    it "returns only courses attached to that school" do
+      expect(rows.map(&:course_code)).to eq(%w[B123])
+    end
+
+    context "when the school has no attached courses" do
+      subject(:rows) { described_class.call(provider: provider.reload, school: empty_school) }
+
+      let(:empty_school) { create(:provider_school, provider:) }
+
+      it "returns no courses" do
+        expect(rows).to be_empty
+      end
+    end
+
+    context "when an attached course has been discarded" do
+      before { attached.discard }
+
+      it "does not return it" do
+        expect(rows).to be_empty
+      end
+    end
+  end
+
   describe "accredited_provider filter" do
     subject(:rows) { described_class.call(provider: provider.reload, params: { accredited_provider: wanted.provider_code }) }
 

--- a/spec/support/page_objects/publish/school_delete.rb
+++ b/spec/support/page_objects/publish/school_delete.rb
@@ -7,7 +7,7 @@ module PageObjects
 
       element :heading, "h1"
       element :cancel_link, ".govuk-link", text: "Cancel"
-      element :remove_school_button, ".govuk-button", text: "Remove school"
+      element :remove_school_button, ".govuk-button--warning"
     end
   end
 end

--- a/spec/support/page_objects/publish/school_show.rb
+++ b/spec/support/page_objects/publish/school_show.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Publish
     class SchoolShow < PageObjects::Base
       set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/schools/{school_id}"
-      element :remove_school_link, ".govuk-link", text: "Remove school"
+      element :remove_school_link, "a.app-link--destructive"
     end
   end
 end

--- a/spec/system/publish/providers/schools/delete_school_spec.rb
+++ b/spec/system/publish/providers/schools/delete_school_spec.rb
@@ -174,9 +174,11 @@ RSpec.describe "Delete a provider's schools" do
   def then_i_see_the_provider_school_details
     expect(publish_school_show_page).to be_displayed
     expect(page).to have_content("Future School (Main Site)")
-    expect(page).to have_content("School code-", normalize_ws: true)
-    expect(page).to have_content("URN654321", normalize_ws: true)
-    expect(page).to have_content("Address 1 Future Road Future Building Future Quarter Future Town Future County FT1 1AA", normalize_ws: true)
+    expect(page).to have_content("1 Future Road, Future Building, Future Quarter, Future Town, Future County, FT1 1AA")
+    expect(page).to have_content("URN: 654321")
+    expect(page).to have_content("This school is not attached to any courses.")
+    expect(page).to have_link("Remove Future School (Main Site) from your account")
+    expect(page).not_to have_content("School code")
   end
 
   def when_i_remove_the_provider_school
@@ -223,7 +225,7 @@ RSpec.describe "Delete a provider's schools" do
   end
 
   def and_i_click_remove_school_link
-    click_link_or_button "Remove school"
+    click_link "from your account"
   end
 
   def and_i_click_remove_school_from_the_index
@@ -243,7 +245,7 @@ RSpec.describe "Delete a provider's schools" do
   end
 
   def and_i_click_remove_school_button
-    click_link_or_button "Remove school"
+    click_button "from your account"
   end
   alias_method :when_i_click_remove_school_button, :and_i_click_remove_school_button
 
@@ -293,7 +295,7 @@ RSpec.describe "Delete a provider's schools" do
   end
 
   def and_i_am_able_to_remove_the_school
-    expect(page).to have_content("Remove school")
+    expect(page).to have_button("Remove #{provider_school.decorate.location_name} from your account")
   end
 
   def then_i_see_the_school_could_not_be_removed

--- a/spec/system/publish/viewing_training_partners_and_their_courses_spec.rb
+++ b/spec/system/publish/viewing_training_partners_and_their_courses_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "Viewing courses as an accredited provider" do
       "/publish/organisations/#{accrediting_provider.provider_code}/#{accrediting_provider.recruitment_cycle_year}/training-partners/#{training_provider.provider_code}/courses",
     )
     expect(page).to have_text(course.name_and_code)
+    expect(page).to have_no_link(course.name_and_code)
   end
 
   def accrediting_provider


### PR DESCRIPTION
## Context

Providers opening a school in Publish were shown a summary list with school code, URN and address. That extra structure made identity hard to scan, and there was no way to see which courses used the school without leaving the page.

## Changes proposed in this pull request

- Replace the school identity summary list with the school name as the heading, then address and URN as hint text. School code is no longer shown.
- List attached courses in the same table as the main Courses page (name and code, funding / qualification / study mode / start date, status tag). Schools with none attached see “This school is not attached to any courses.”
- Change the remove link and confirm button to “Remove [school name] from your account”.
- Always link course names in the courses table, including from the school page.

## Guidance to review

- Open a school with no attached courses and one with several, for example `/publish/organisations/:provider_code/:year/schools/:uuid`.
- Check the address and URN sit on consecutive hint lines under the heading, with no school code and no summary list.
- Check the attached-courses table matches the main Courses list, including status tags and links through to each course. Discarded courses should not appear.
- Follow the remove link and confirm the warning button uses the same “from your account” wording.
- The courses table now always links the course name, including on the Courses index.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.