### PR TITLE
Canonical schools distance queries

### DIFF
--- a/app/components/courses/query_debug_header_component.html.erb
+++ b/app/components/courses/query_debug_header_component.html.erb
@@ -28,7 +28,7 @@
           <tr class="govuk-table__row">
             <th class="govuk-table__header">Course</th>
             <th class="govuk-table__header">Provider</th>
-            <th class="govuk-table__header">Nearest Site</th>
+            <th class="govuk-table__header">Nearest School</th>
             <th class="govuk-table__header">Latitude</th>
             <th class="govuk-table__header">Longitude</th>
             <th class="govuk-table__header">Distance (miles)</th>

--- a/app/components/courses/query_debug_header_component.rb
+++ b/app/components/courses/query_debug_header_component.rb
@@ -33,10 +33,6 @@ module Courses
       ).call
     end
 
-    def unique_nearest_school_for_each_result
-      nearest_school_for_each_result.uniq { |site| [site.latitude, site.longitude] }
-    end
-
     GOOGLE_MAPS_BASE_URL = "https://www.google.com/maps/dir/"
 
     def google_maps_directions_path
@@ -49,12 +45,10 @@ module Courses
       "#{google_maps_directions_path}/#{result.latitude},#{result.longitude}"
     end
 
+    # Publish resolves this route against Provider::School#uuid, so that is the
+    # only uuid worth linking - a legacy site uuid 404s there.
     def school_uuid(result)
-      if result.provider.recruitment_cycle.after?(Settings.schools_remodel_cycle_year)
-        result.provider_school_uuid
-      else
-        result.site_uuid
-      end
+      result.provider_school_uuid
     end
   end
 end

--- a/app/components/courses/school_distances_debug_component.rb
+++ b/app/components/courses/school_distances_debug_component.rb
@@ -22,7 +22,7 @@ module Courses
     end
 
     def schools
-      ::Courses::SchoolDistancesQuery.new(courses: [course], latitude:, longitude:).call
+      @schools ||= ::Courses::SchoolDistancesQuery.new(courses: [course], latitude:, longitude:).call
     end
 
     GOOGLE_MAPS_BASE_URL = "https://www.google.com/maps/dir/"

--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -45,7 +45,7 @@ module Find
 
         def guaranteed_text
           return if no_employing_schools?
-          return unless address
+          return unless address && distance_from_location.present?
 
           I18n.t(".find.courses.training_locations.view.guaranteed") if course.fee? || course.salary?
         end

--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -36,7 +36,7 @@ module Find
         def potential_placements_text
           if no_employing_schools?
             I18n.t(".find.courses.training_locations.view.no_employing_schools")
-          elsif address
+          elsif address && distance_from_location.present?
             distance_text
           else
             content_tag(:span, I18n.t(".find.courses.training_locations.view.search_help_#{course.funding}"), class: "govuk-hint govuk-!-font-size-16")

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -40,11 +40,14 @@ module Find
       @address = Geolocation::Address.query(location_params)
       return unless @address.coordinates?
 
+      # A course can have no school to measure from: none attached, or none of
+      # them geocoded. That is not an error - the page falls back to the funding
+      # hint instead of a distance.
       @distance_from_location ||= ::Courses::NearestSchoolQuery.new(
         courses: [@course],
         latitude: @address.latitude,
         longitude: @address.longitude,
-      ).call.first.distance_to_search_location.ceil
+      ).call.first&.distance_to_search_location&.ceil
     end
 
   private
@@ -63,8 +66,18 @@ module Find
       @course = provider.courses.includes(
         :enrichments,
         subjects: [:financial_incentive],
-        site_statuses: [:site],
+        **school_preloads,
       ).find_by!(course_code: params[:course_code]&.upcase).decorate
+    end
+
+    # Study sites still have no canonical model, so study_site_placements keeps
+    # its own legacy preload elsewhere - only the placement schools move.
+    def school_preloads
+      if FeatureFlag.active?(:course_publishing_uses_new_school_model)
+        { schools: %i[gias_school provider_school] }
+      else
+        { site_statuses: [:site] }
+      end
     end
 
     def show_interview_process?

--- a/app/services/courses/canonical_school_distance.rb
+++ b/app/services/courses/canonical_school_distance.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Courses
+  # Shared SQL for the two canonical course_school -> gias_school distance queries.
+  #
+  # NearestSchoolQuery and SchoolDistancesQuery differ only in how many rows they
+  # keep per course, so the distance maths and the school columns live here. If the
+  # two drifted apart, the course page and the ?debug panel would quietly disagree
+  # about how far away the same school is.
+  module CanonicalSchoolDistance
+    # geo_location is a stored generated column, so it is NULL whenever either
+    # coordinate is missing - one guard covers both, and the partial GiST index
+    # index_gias_school_on_geo_location covers the guard.
+    GEOCODED_SCHOOL = "gias_school.geo_location IS NOT NULL"
+
+  private
+
+    # ST_Distance takes the trailing `false` to force sphere maths, matching the
+    # legacy ST_DistanceSphere path and Courses::Query#schools_location_scope;
+    # metres are converted with the same 1609.344 the results page uses, so a
+    # course's distance reads the same on the results card and on its own page.
+    #
+    # The CASE reproduces Provider::School#location_name in SQL.
+    def school_columns_sql
+      <<~SQL.squish
+        course.id AS course_id,
+        course.*,
+        provider_school.uuid AS provider_school_uuid,
+        CASE
+          WHEN provider_school.site_code = #{Course.connection.quote(Provider::School::MAIN_SITE_CODE)}
+          THEN gias_school.name || ' (Main Site)'
+          ELSE gias_school.name
+        END AS location_name,
+        gias_school.latitude,
+        gias_school.longitude,
+        ST_Distance(gias_school.geo_location, #{search_point}, false) / 1609.344 AS distance_to_search_location
+      SQL
+    end
+
+    def search_point
+      Course.sanitize_sql_array(
+        ["ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography", Float(@longitude), Float(@latitude)],
+      )
+    end
+  end
+end

--- a/app/services/courses/canonical_school_distance.rb
+++ b/app/services/courses/canonical_school_distance.rb
@@ -27,8 +27,8 @@ module Courses
     #
     # ST_Distance takes the trailing `false` to force sphere maths, matching the
     # legacy ST_DistanceSphere path and Courses::Query#schools_location_scope;
-    # metres are converted with the same 1609.344 the results page uses, so a
-    # course's distance reads the same on the results card and on its own page.
+    # metres are converted with the same Geolocation::METRES_PER_MILE the results
+    # page uses, so a course's distance reads the same on the card and its own page.
     #
     # The CASE reproduces Provider::School#location_name in SQL.
     def school_columns_sql(distinct_on)
@@ -49,11 +49,12 @@ module Courses
               gias_school.geo_location,
               ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography,
               false
-            ) / 1609.344 AS distance_to_search_location
+            ) / ? AS distance_to_search_location
           SQL
           Provider::School::MAIN_SITE_CODE,
           Float(@longitude),
           Float(@latitude),
+          Geolocation::METRES_PER_MILE,
         ],
       )
     end

--- a/app/services/courses/canonical_school_distance.rb
+++ b/app/services/courses/canonical_school_distance.rb
@@ -13,33 +13,48 @@ module Courses
     # index_gias_school_on_geo_location covers the guard.
     GEOCODED_SCHOOL = "gias_school.geo_location IS NOT NULL"
 
+    # The two DISTINCT ON keys the callers choose between. Constants rather than
+    # caller-built strings so nothing reaches the SELECT that is not written here.
+    NEAREST_PER_COURSE = "course.id"
+    EACH_SCHOOL_PER_COURSE = "course.id, gias_school.id"
+
   private
 
+    # The whole SELECT goes through sanitize_sql_array: the only values that come
+    # from outside are the search coordinates, bound as parameters rather than
+    # interpolated (and coerced with Float first, so a non-numeric raises here
+    # rather than reaching the database).
+    #
     # ST_Distance takes the trailing `false` to force sphere maths, matching the
     # legacy ST_DistanceSphere path and Courses::Query#schools_location_scope;
     # metres are converted with the same 1609.344 the results page uses, so a
     # course's distance reads the same on the results card and on its own page.
     #
     # The CASE reproduces Provider::School#location_name in SQL.
-    def school_columns_sql
-      <<~SQL.squish
-        course.id AS course_id,
-        course.*,
-        provider_school.uuid AS provider_school_uuid,
-        CASE
-          WHEN provider_school.site_code = #{Course.connection.quote(Provider::School::MAIN_SITE_CODE)}
-          THEN gias_school.name || ' (Main Site)'
-          ELSE gias_school.name
-        END AS location_name,
-        gias_school.latitude,
-        gias_school.longitude,
-        ST_Distance(gias_school.geo_location, #{search_point}, false) / 1609.344 AS distance_to_search_location
-      SQL
-    end
-
-    def search_point
+    def school_columns_sql(distinct_on)
       Course.sanitize_sql_array(
-        ["ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography", Float(@longitude), Float(@latitude)],
+        [
+          <<~SQL.squish,
+            DISTINCT ON (#{distinct_on}) course.id AS course_id,
+            course.*,
+            provider_school.uuid AS provider_school_uuid,
+            CASE
+              WHEN provider_school.site_code = ?
+              THEN gias_school.name || ' (Main Site)'
+              ELSE gias_school.name
+            END AS location_name,
+            gias_school.latitude,
+            gias_school.longitude,
+            ST_Distance(
+              gias_school.geo_location,
+              ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography,
+              false
+            ) / 1609.344 AS distance_to_search_location
+          SQL
+          Provider::School::MAIN_SITE_CODE,
+          Float(@longitude),
+          Float(@latitude),
+        ],
       )
     end
   end

--- a/app/services/courses/nearest_school_query.rb
+++ b/app/services/courses/nearest_school_query.rb
@@ -4,6 +4,8 @@ module Courses
   # Finds only nearest school per course
   #
   class NearestSchoolQuery
+    include CanonicalSchoolDistance
+
     def initialize(courses:, latitude:, longitude:)
       @courses = courses
       @latitude = latitude
@@ -37,8 +39,8 @@ module Courses
       Course
         .joins(schools: %i[gias_school provider_school])
         .where(id: @courses.map(&:id))
-        .where("gias_school.geo_location IS NOT NULL")
-        .select(schools_select_sql)
+        .where(GEOCODED_SCHOOL)
+        .select("DISTINCT ON (course.id) #{school_columns_sql}")
         .order("course.id, distance_to_search_location ASC, gias_school.id ASC")
     end
 
@@ -50,35 +52,6 @@ module Courses
         .where("site.longitude IS NOT NULL AND site.latitude IS NOT NULL")
         .select(select_sql)
         .order("course.id, distance_to_search_location ASC")
-    end
-
-    # geo_location is a stored generated column, so it is NULL whenever either
-    # coordinate is missing - one guard covers both. ST_Distance takes the
-    # trailing `false` to force sphere maths, matching the legacy
-    # ST_DistanceSphere path and Courses::Query#schools_location_scope, and
-    # metres are converted with the same 1609.344 the results page uses.
-    #
-    # The CASE reproduces Provider::School#location_name in SQL.
-    def schools_select_sql
-      <<~SQL.squish
-        DISTINCT ON (course.id) course.id AS course_id,
-        course.*,
-        provider_school.uuid AS provider_school_uuid,
-        CASE
-          WHEN provider_school.site_code = #{Course.connection.quote(Provider::School::MAIN_SITE_CODE)}
-          THEN gias_school.name || ' (Main Site)'
-          ELSE gias_school.name
-        END AS location_name,
-        gias_school.latitude,
-        gias_school.longitude,
-        ST_Distance(gias_school.geo_location, #{search_point}, false) / 1609.344 AS distance_to_search_location
-      SQL
-    end
-
-    def search_point
-      Course.sanitize_sql_array(
-        ["ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography", Float(@longitude), Float(@latitude)],
-      )
     end
 
     def select_sql

--- a/app/services/courses/nearest_school_query.rb
+++ b/app/services/courses/nearest_school_query.rb
@@ -70,7 +70,7 @@ module Courses
         ST_DistanceSphere(
           ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
           ST_SetSRID(ST_MakePoint(#{Float(@longitude)}, #{Float(@latitude)}), 4326)
-        ) / 1609.34 AS distance_to_search_location
+        ) / #{Geolocation::METRES_PER_MILE} AS distance_to_search_location
       SQL
     end
 

--- a/app/services/courses/nearest_school_query.rb
+++ b/app/services/courses/nearest_school_query.rb
@@ -11,13 +11,12 @@ module Courses
     end
 
     def call
-      subquery = Course
-                 .joins(site_statuses: :site)
-                 .joins(school_identity_joins)
-                 .where(id: @courses.map(&:id))
-                 .where("site.longitude IS NOT NULL AND site.latitude IS NOT NULL")
-                 .select(select_sql)
-                 .order("course.id, distance_to_search_location ASC")
+      subquery =
+        if FeatureFlag.active?(:course_publishing_uses_new_school_model)
+          schools_subquery
+        else
+          sites_subquery
+        end
 
       Course
         .from(subquery, :course)
@@ -25,6 +24,62 @@ module Courses
     end
 
   private
+
+    # Nearest school over the canonical course_school -> gias_school model, used
+    # while the :course_publishing_uses_new_school_model flag is on.
+    #
+    # DISTINCT ON (course.id) does double duty: it reduces a course's schools to
+    # the nearest one, and it absorbs the duplicates a course picks up when two of
+    # its Provider::Schools share a GiasSchool - legal, because course_school is
+    # unique on (course_id, provider_school_id), not on gias_school_id.
+    # The gias_school.id tiebreaker keeps that pick stable between runs.
+    def schools_subquery
+      Course
+        .joins(schools: %i[gias_school provider_school])
+        .where(id: @courses.map(&:id))
+        .where("gias_school.geo_location IS NOT NULL")
+        .select(schools_select_sql)
+        .order("course.id, distance_to_search_location ASC, gias_school.id ASC")
+    end
+
+    def sites_subquery
+      Course
+        .joins(site_statuses: :site)
+        .joins(school_identity_joins)
+        .where(id: @courses.map(&:id))
+        .where("site.longitude IS NOT NULL AND site.latitude IS NOT NULL")
+        .select(select_sql)
+        .order("course.id, distance_to_search_location ASC")
+    end
+
+    # geo_location is a stored generated column, so it is NULL whenever either
+    # coordinate is missing - one guard covers both. ST_Distance takes the
+    # trailing `false` to force sphere maths, matching the legacy
+    # ST_DistanceSphere path and Courses::Query#schools_location_scope, and
+    # metres are converted with the same 1609.344 the results page uses.
+    #
+    # The CASE reproduces Provider::School#location_name in SQL.
+    def schools_select_sql
+      <<~SQL.squish
+        DISTINCT ON (course.id) course.id AS course_id,
+        course.*,
+        provider_school.uuid AS provider_school_uuid,
+        CASE
+          WHEN provider_school.site_code = #{Course.connection.quote(Provider::School::MAIN_SITE_CODE)}
+          THEN gias_school.name || ' (Main Site)'
+          ELSE gias_school.name
+        END AS location_name,
+        gias_school.latitude,
+        gias_school.longitude,
+        ST_Distance(gias_school.geo_location, #{search_point}, false) / 1609.344 AS distance_to_search_location
+      SQL
+    end
+
+    def search_point
+      Course.sanitize_sql_array(
+        ["ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography", Float(@longitude), Float(@latitude)],
+      )
+    end
 
     def select_sql
       <<~SQL.squish

--- a/app/services/courses/nearest_school_query.rb
+++ b/app/services/courses/nearest_school_query.rb
@@ -43,7 +43,7 @@ module Courses
         .joins(schools: %i[gias_school provider_school])
         .where(id: @courses.map(&:id))
         .where(GEOCODED_SCHOOL)
-        .select("DISTINCT ON (course.id) #{school_columns_sql}")
+        .select(school_columns_sql(NEAREST_PER_COURSE))
         .order("course.id, distance_to_search_location ASC, gias_school.id ASC, provider_school.site_code ASC")
     end
 

--- a/app/services/courses/nearest_school_query.rb
+++ b/app/services/courses/nearest_school_query.rb
@@ -34,14 +34,17 @@ module Courses
     # the nearest one, and it absorbs the duplicates a course picks up when two of
     # its Provider::Schools share a GiasSchool - legal, because course_school is
     # unique on (course_id, provider_school_id), not on gias_school_id.
-    # The gias_school.id tiebreaker keeps that pick stable between runs.
+    #
+    # Those duplicates tie on distance and on gias_school.id, so site_code breaks
+    # the tie: without it Postgres could return either provider school, and the
+    # ?debug panel's link and "(Main Site)" label would flip between page loads.
     def schools_subquery
       Course
         .joins(schools: %i[gias_school provider_school])
         .where(id: @courses.map(&:id))
         .where(GEOCODED_SCHOOL)
         .select("DISTINCT ON (course.id) #{school_columns_sql}")
-        .order("course.id, distance_to_search_location ASC, gias_school.id ASC")
+        .order("course.id, distance_to_search_location ASC, gias_school.id ASC, provider_school.site_code ASC")
     end
 
     def sites_subquery

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -286,7 +286,7 @@ module Courses
     def location_scope
       return @scope if params[:latitude].blank? || params[:longitude].blank?
 
-      radius_in_meters = radius_in_miles * 1609.34
+      radius_in_meters = radius_in_miles * Geolocation::METRES_PER_MILE
       latitude = Float(params[:latitude])
       longitude = Float(params[:longitude])
 
@@ -337,10 +337,11 @@ module Courses
                 MIN(ST_DistanceSphere(
                   ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
                   ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
-                ) / 1609.344) AS minimum_distance_to_search_location
+                ) / ?) AS minimum_distance_to_search_location
               SQL
               longitude,
               latitude,
+              Geolocation::METRES_PER_MILE,
             ],
           ),
         )
@@ -386,7 +387,14 @@ module Courses
 
       @scope
         .joins(nearby_courses)
-        .select("course.*, provider.provider_name, (nearby_courses.distance_m / 1609.344) AS minimum_distance_to_search_location")
+        .select(
+          Course.sanitize_sql_array(
+            [
+              "course.*, provider.provider_name, (nearby_courses.distance_m / ?) AS minimum_distance_to_search_location",
+              Geolocation::METRES_PER_MILE,
+            ],
+          ),
+        )
         .group("course.id, provider.id, provider.provider_name, nearby_courses.distance_m")
     end
 

--- a/app/services/courses/school_distances_query.rb
+++ b/app/services/courses/school_distances_query.rb
@@ -80,7 +80,7 @@ module Courses
         ST_DistanceSphere(
           ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
           ST_SetSRID(ST_MakePoint(#{Float(@longitude)}, #{Float(@latitude)}), 4326)
-        ) / 1609.34 AS distance_to_search_location
+        ) / #{Geolocation::METRES_PER_MILE} AS distance_to_search_location
       SQL
     end
   end

--- a/app/services/courses/school_distances_query.rb
+++ b/app/services/courses/school_distances_query.rb
@@ -51,7 +51,7 @@ module Courses
                  .joins(schools: %i[gias_school provider_school])
                  .where(id: @courses.map(&:id))
                  .where(GEOCODED_SCHOOL)
-                 .select("DISTINCT ON (course.id, gias_school.id) #{school_columns_sql}")
+                 .select(school_columns_sql(EACH_SCHOOL_PER_COURSE))
                  .order("course.id, gias_school.id, provider_school.site_code ASC")
 
       Course

--- a/app/services/courses/school_distances_query.rb
+++ b/app/services/courses/school_distances_query.rb
@@ -20,6 +20,8 @@ module Courses
   # Then you can access the distance through #distance_to_search_location
   #
   class SchoolDistancesQuery
+    include CanonicalSchoolDistance
+
     def initialize(courses:, latitude:, longitude:)
       @courses = courses
       @latitude = latitude
@@ -48,8 +50,8 @@ module Courses
       subquery = Course
                  .joins(schools: %i[gias_school provider_school])
                  .where(id: @courses.map(&:id))
-                 .where("gias_school.geo_location IS NOT NULL")
-                 .select(schools_select_sql)
+                 .where(GEOCODED_SCHOOL)
+                 .select("DISTINCT ON (course.id, gias_school.id) #{school_columns_sql}")
                  .order("course.id, gias_school.id, provider_school.site_code ASC")
 
       Course
@@ -65,35 +67,6 @@ module Courses
         .select(select_sql)
         .order("course.id, distance_to_search_location ASC")
         .group("course.id, site.id")
-    end
-
-    # geo_location is a stored generated column, so it is NULL whenever either
-    # coordinate is missing - one guard covers both. ST_Distance takes the
-    # trailing `false` to force sphere maths, matching the legacy
-    # ST_DistanceSphere path and Courses::Query#schools_location_scope, and
-    # metres are converted with the same 1609.344 the results page uses.
-    #
-    # The CASE reproduces Provider::School#location_name in SQL.
-    def schools_select_sql
-      <<~SQL.squish
-        DISTINCT ON (course.id, gias_school.id) course.id AS course_id,
-        course.*,
-        provider_school.uuid AS provider_school_uuid,
-        CASE
-          WHEN provider_school.site_code = #{Course.connection.quote(Provider::School::MAIN_SITE_CODE)}
-          THEN gias_school.name || ' (Main Site)'
-          ELSE gias_school.name
-        END AS location_name,
-        gias_school.latitude,
-        gias_school.longitude,
-        ST_Distance(gias_school.geo_location, #{search_point}, false) / 1609.344 AS distance_to_search_location
-      SQL
-    end
-
-    def search_point
-      Course.sanitize_sql_array(
-        ["ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography", Float(@longitude), Float(@latitude)],
-      )
     end
 
     def select_sql

--- a/app/services/courses/school_distances_query.rb
+++ b/app/services/courses/school_distances_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Courses
-  # This query class fetches distances between given courses' sites and a specified location.
+  # This query class fetches distances between given courses' schools and a specified location.
   #
   # This is more an utility class that can help understand the school locations
   #
@@ -27,6 +27,37 @@ module Courses
     end
 
     def call
+      if FeatureFlag.active?(:course_publishing_uses_new_school_model)
+        schools_query
+      else
+        sites_query
+      end
+    end
+
+  private
+
+    # Every school of every course over the canonical course_school -> gias_school
+    # model, used while the :course_publishing_uses_new_school_model flag is on.
+    #
+    # DISTINCT ON (course.id, gias_school.id) is the counterpart of the legacy
+    # GROUP BY (course.id, site.id): it lists a school once per course however many
+    # of the course's Provider::Schools point at it, without having to aggregate the
+    # provider_school columns the SELECT needs. The subquery is re-wrapped so the
+    # rows can be ordered by distance rather than by the DISTINCT ON key.
+    def schools_query
+      subquery = Course
+                 .joins(schools: %i[gias_school provider_school])
+                 .where(id: @courses.map(&:id))
+                 .where("gias_school.geo_location IS NOT NULL")
+                 .select(schools_select_sql)
+                 .order("course.id, gias_school.id, provider_school.site_code ASC")
+
+      Course
+        .from(subquery, :course)
+        .order("course_id ASC, distance_to_search_location ASC")
+    end
+
+    def sites_query
       Course
         .joins(site_statuses: :site)
         .where(id: @courses.map(&:id))
@@ -36,7 +67,34 @@ module Courses
         .group("course.id, site.id")
     end
 
-  private
+    # geo_location is a stored generated column, so it is NULL whenever either
+    # coordinate is missing - one guard covers both. ST_Distance takes the
+    # trailing `false` to force sphere maths, matching the legacy
+    # ST_DistanceSphere path and Courses::Query#schools_location_scope, and
+    # metres are converted with the same 1609.344 the results page uses.
+    #
+    # The CASE reproduces Provider::School#location_name in SQL.
+    def schools_select_sql
+      <<~SQL.squish
+        DISTINCT ON (course.id, gias_school.id) course.id AS course_id,
+        course.*,
+        provider_school.uuid AS provider_school_uuid,
+        CASE
+          WHEN provider_school.site_code = #{Course.connection.quote(Provider::School::MAIN_SITE_CODE)}
+          THEN gias_school.name || ' (Main Site)'
+          ELSE gias_school.name
+        END AS location_name,
+        gias_school.latitude,
+        gias_school.longitude,
+        ST_Distance(gias_school.geo_location, #{search_point}, false) / 1609.344 AS distance_to_search_location
+      SQL
+    end
+
+    def search_point
+      Course.sanitize_sql_array(
+        ["ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)::geography", Float(@longitude), Float(@latitude)],
+      )
+    end
 
     def select_sql
       <<~SQL.squish

--- a/app/services/geolocation.rb
+++ b/app/services/geolocation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Geolocation
+  # The international mile, exactly. PostGIS returns distances in metres and every
+  # caller reports miles, so this is the one place that conversion lives.
+  #
+  # It was previously spelled out at each call site in two precisions - 1609.344
+  # and a truncated 1609.34 - which left the course page and the results card
+  # dividing the same distance by different numbers.
+  METRES_PER_MILE = 1609.344
+end

--- a/app/services/saved_courses/query.rb
+++ b/app/services/saved_courses/query.rb
@@ -71,10 +71,11 @@ module SavedCourses
                 MIN(ST_DistanceSphere(
                   ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
                   ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
-                ) / 1609.344) AS minimum_distance_to_search_location
+                ) / ?) AS minimum_distance_to_search_location
               SQL
               longitude,
               latitude,
+              Geolocation::METRES_PER_MILE,
             ],
           ),
         )
@@ -105,10 +106,11 @@ module SavedCourses
                 MIN(ST_DistanceSphere(
                   ST_SetSRID(ST_MakePoint(gias_school.longitude::float, gias_school.latitude::float), 4326),
                   ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
-                ) / 1609.344) AS minimum_distance_to_search_location
+                ) / ?) AS minimum_distance_to_search_location
               SQL
               longitude,
               latitude,
+              Geolocation::METRES_PER_MILE,
             ],
           ),
         )

--- a/spec/components/courses/query_debug_header_component_spec.rb
+++ b/spec/components/courses/query_debug_header_component_spec.rb
@@ -143,6 +143,11 @@ RSpec.describe Courses::QueryDebugHeaderComponent, type: :component do
       expect(page).to have_content("Debug School")
       expect(page).not_to have_link("Debug School", visible: :all)
     end
+
+    it "labels the column as a school rather than a site" do
+      expect(query_debug_header_component_content).to include("Nearest School")
+      expect(query_debug_header_component_content).not_to include("Nearest Site")
+    end
   end
 
   context "when the results only have canonical schools" do

--- a/spec/components/courses/query_debug_header_component_spec.rb
+++ b/spec/components/courses/query_debug_header_component_spec.rb
@@ -103,6 +103,8 @@ RSpec.describe Courses::QueryDebugHeaderComponent, type: :component do
 
   context "when rendering nearest school links" do
     let(:debug) { true }
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: 2026) }
+    let(:provider) { create(:provider, recruitment_cycle:) }
     let(:environment_name) { "qa" }
     let(:latitude) { 51.5 }
     let(:longitude) { -0.1 }
@@ -126,34 +128,51 @@ RSpec.describe Courses::QueryDebugHeaderComponent, type: :component do
       create(:site_status, :findable, course:, site:)
     end
 
-    context "in the schools remodel cycle" do
-      let(:recruitment_cycle) { create(:recruitment_cycle, year: 2026) }
-      let(:provider) { create(:provider, recruitment_cycle:) }
+    # The link resolves against Provider::School#uuid in Publish, so that is the
+    # only uuid worth rendering - a legacy site uuid would 404 there.
+    it "links to the school using the provider school uuid" do
+      provider_school = create(:provider_school, provider:, gias_school:, site_code:)
+      render_inline(component)
 
-      it "links to the school using the legacy site uuid" do
-        render_inline(component)
-
-        expect(page.find_link("Debug School", visible: :all)[:href]).to include("/schools/#{site.uuid}")
-      end
+      expect(page.find_link("Debug School", visible: :all)[:href]).to include("/schools/#{provider_school.uuid}")
     end
 
-    context "after the schools remodel cycle" do
-      let(:recruitment_cycle) { create(:recruitment_cycle, year: 2027) }
-      let(:provider) { create(:provider, recruitment_cycle:) }
+    it "renders the school name without a school link when the provider school uuid is missing" do
+      render_inline(component)
 
-      it "links to the school using the provider school uuid" do
-        provider_school = create(:provider_school, provider:, gias_school:, site_code:)
-        render_inline(component)
+      expect(page).to have_content("Debug School")
+      expect(page).not_to have_link("Debug School", visible: :all)
+    end
+  end
 
-        expect(page.find_link("Debug School", visible: :all)[:href]).to include("/schools/#{provider_school.uuid}")
-      end
+  context "when the results only have canonical schools" do
+    before { FeatureFlag.activate(:course_publishing_uses_new_school_model) }
+    after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
 
-      it "renders the school name without a school link when the provider school uuid is missing" do
-        render_inline(component)
+    let(:debug) { true }
+    let(:environment_name) { "qa" }
+    let(:latitude) { 51.5 }
+    let(:longitude) { -0.1 }
+    let(:results) { [course] }
+    let(:provider) { create(:provider) }
+    let(:course) { create(:course, provider:) }
+    let(:gias_school) { create(:gias_school, name: "Canonical School", latitude: 51.5045, longitude: -0.0243) }
+    let!(:course_school) { create(:course_school, course:, gias_school:) }
 
-        expect(page).to have_content("Debug School")
-        expect(page).not_to have_link("Debug School", visible: :all)
-      end
+    it "lists the nearest GIAS school with no Site or SiteStatus in play" do
+      render_inline(component)
+
+      expect(course.site_statuses).to be_empty
+      expect(page).to have_content("Canonical School")
+      expect(page.find_link("Canonical School", visible: :all)[:href]).to include(
+        "/schools/#{course_school.provider_school.uuid}",
+      )
+    end
+
+    it "renders the school's coordinates and distance" do
+      expect(query_debug_header_component_content).to include("51.5045")
+      expect(query_debug_header_component_content).to include("-0.0243")
+      expect(query_debug_header_component_content).to include("3.27 miles")
     end
   end
 end

--- a/spec/components/courses/school_distances_debug_component_spec.rb
+++ b/spec/components/courses/school_distances_debug_component_spec.rb
@@ -130,4 +130,44 @@ RSpec.describe Courses::SchoolDistancesDebugComponent do
       end
     end
   end
+
+  context "when the course only has canonical schools" do
+    before { FeatureFlag.activate(:course_publishing_uses_new_school_model) }
+    after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
+
+    let(:environment_name) { "qa" }
+    let(:debug) { true }
+    let(:manchester) { build(:location, :manchester) }
+    let(:bristol) { build(:location, :bristol) }
+
+    it "lists every GIAS school with no Site or SiteStatus in play" do
+      schools = [manchester, bristol].map do |location|
+        create(
+          :course_school,
+          course:,
+          gias_school: create(:gias_school, latitude: location.latitude, longitude: location.longitude),
+        ).gias_school
+      end
+
+      expect(course.site_statuses).to be_empty
+      expect(school_distances_debug_component_content).to include("School distances for Test Provider (TP123) - Maths (M123)")
+
+      schools.each do |school|
+        expect(school_distances_debug_component_content).to have_text(school.name)
+        expect(school_distances_debug_component_content).to have_text(school.latitude.to_s)
+        expect(school_distances_debug_component_content).to have_text(school.longitude.to_s)
+        expect(rendered_component.css("a").map { |a| a[:href] }).to include(
+          "https://www.google.com/maps/dir/#{latitude},#{longitude}/#{school.latitude},#{school.longitude}",
+        )
+      end
+    end
+
+    it "runs the query once however many times the template asks for the schools" do
+      create(:course_school, course:, gias_school: create(:gias_school, latitude: manchester.latitude, longitude: manchester.longitude))
+
+      expect(Courses::SchoolDistancesQuery).to receive(:new).once.and_call_original
+
+      3.times { component.schools }
+    end
+  end
 end

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -140,6 +140,23 @@ describe Find::Courses::TrainingLocations::View, type: :component do
         expect(component.potential_placements_text).to eq('<span class="govuk-!-font-weight-bold">10 miles</span> from <span class="govuk-!-font-weight-bold">Some Address</span>')
       end
     end
+
+    # A located search can resolve an address but still find no school to measure
+    # from - a course with no schools attached, or none of them geocoded.
+    context "when there is no distance to report" do
+      let(:course) { create(:course, :with_full_time_sites, funding: "fee", study_sites: [build(:site, :study_site)]) }
+      let(:distance_from_location) { nil }
+
+      it "prompts the candidate to search instead of claiming a zero-mile distance" do
+        expect(component.potential_placements_text).to eq(
+          '<span class="govuk-hint govuk-!-font-size-16">Search by city, town or postcode to find the nearest potential placement school</span>',
+        )
+      end
+
+      it "does not render a distance" do
+        expect(subject).to have_no_text("from Some Address")
+      end
+    end
   end
 
   describe "#potential_study_sites_text" do

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -156,6 +156,13 @@ describe Find::Courses::TrainingLocations::View, type: :component do
       it "does not render a distance" do
         expect(subject).to have_no_text("from Some Address")
       end
+
+      # Without a distance there is no school on show, so hedging about schools
+      # changing has nothing to attach to - the no-address case omits it too.
+      it "does not hedge about schools it is not showing" do
+        expect(component.guaranteed_text).to be_nil
+        expect(subject).to have_no_text("Schools can change and are not guaranteed")
+      end
     end
   end
 

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -98,6 +98,57 @@ module Find
           }.not_to raise_error
         end
       end
+
+      context "when the course only has canonical schools" do
+        render_views
+
+        let(:london) { build(:location, :london) }
+        let(:canary_wharf) { build(:location, :canary_wharf) }
+
+        let(:published_course) do
+          create(:course, enrichments: [build(:course_enrichment, :published)], provider:)
+        end
+
+        before do
+          FeatureFlag.activate(:course_publishing_uses_new_school_model)
+          allow(Geolocation::Address).to receive(:query).and_return(
+            Geolocation::Address.new(latitude: london.latitude, longitude: london.longitude, formatted_address: "London"),
+          )
+        end
+
+        after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
+
+        def get_show_from_london
+          get :show, params: {
+            provider_code: provider.provider_code,
+            course_code: published_course.course_code,
+            location: "London",
+          }
+        end
+
+        it "measures the distance from the nearest GIAS school, with no Site or SiteStatus in play" do
+          create(
+            :course_school,
+            course: published_course,
+            gias_school: create(:gias_school, latitude: canary_wharf.latitude, longitude: canary_wharf.longitude),
+          )
+
+          get_show_from_london
+
+          expect(published_course.site_statuses).to be_empty
+          expect(response).to have_http_status(:ok)
+          expect(controller.view_assigns["distance_from_location"]).to eq(5)
+        end
+
+        it "renders without a distance when the course has no geocoded school" do
+          create(:course_school, course: published_course, gias_school: create(:gias_school))
+
+          get_show_from_london
+
+          expect(response).to have_http_status(:ok)
+          expect(controller.view_assigns["distance_from_location"]).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/services/courses/nearest_school_query_new_school_model_spec.rb
+++ b/spec/services/courses/nearest_school_query_new_school_model_spec.rb
@@ -114,5 +114,20 @@ RSpec.describe Courses::NearestSchoolQuery do
       expect(results.first.distance_to_search_location).to be_within(0.01).of(4.46)
     end
 
+    # Both rows tie on distance and on gias_school.id, so without a further
+    # tiebreaker Postgres is free to return either provider school - and the
+    # ?debug panel's link and "(Main Site)" label would flip between page loads.
+    it "always picks the same provider school of the two" do
+      gias_school = create(:gias_school, latitude: canary_wharf.latitude, longitude: canary_wharf.longitude)
+      main_site = create(:course_school, :main_site, course:, gias_school:).provider_school
+      create(:course_school, course:, gias_school:, site_code: "A")
+
+      5.times do
+        result = described_class.new(courses: [course], latitude: london.latitude, longitude: london.longitude).call.first
+
+        expect(result.provider_school_uuid).to eq(main_site.uuid)
+        expect(result.location_name).to eq("#{gias_school.name} (Main Site)")
+      end
+    end
   end
 end

--- a/spec/services/courses/nearest_school_query_new_school_model_spec.rb
+++ b/spec/services/courses/nearest_school_query_new_school_model_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The nearest-school lookup over the canonical course_school -> gias_school model,
+# gated by the :course_publishing_uses_new_school_model flag. Distances come from
+# gias_school coordinates instead of course_site -> site, so a course that only has
+# Course::School / Provider::School records - with no legacy Site or SiteStatus -
+# still resolves a distance. The expected miles below are the same values the
+# location search pins in spec/services/courses/query/location_new_school_model_spec.rb.
+RSpec.describe Courses::NearestSchoolQuery do
+  subject(:results) { described_class.new(courses:, latitude: london.latitude, longitude: london.longitude).call }
+
+  before { FeatureFlag.activate(:course_publishing_uses_new_school_model) }
+  after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
+
+  let(:london) { build(:location, :london) }
+  let(:canary_wharf) { build(:location, :canary_wharf) }
+  let(:cambridge) { build(:location, :cambridge) }
+  let(:edinburgh) { build(:location, :edinburgh) }
+
+  let(:courses) { [course] }
+
+  # A course taught at each of `locations`, with no legacy Site or SiteStatus.
+  def course_taught_at(*locations, name: "Mathematics", provider: create(:provider))
+    create(:course, name:, provider:).tap do |course|
+      locations.each { |location| attach_school(course, location) }
+    end
+  end
+
+  def attach_school(course, location, **options)
+    create(
+      :course_school,
+      course:,
+      gias_school: create(:gias_school, latitude: location&.latitude, longitude: location&.longitude),
+      **options,
+    )
+  end
+
+  context "when a course has only canonical schools" do
+    let(:course) { course_taught_at(canary_wharf) }
+
+    it "returns one row per course with the distance to the search location" do
+      expect(course.site_statuses).to be_empty
+      expect(results.size).to eq(1)
+      expect(results.first.distance_to_search_location).to be_within(0.01).of(4.46)
+    end
+
+    it "returns the school's name, coordinates and provider school uuid" do
+      course_school = course.schools.sole
+      result = results.first
+
+      expect(result.location_name).to eq(course_school.gias_school.name)
+      expect(result.latitude).to eq(canary_wharf.latitude)
+      expect(result.longitude).to eq(canary_wharf.longitude)
+      expect(result.provider_school_uuid).to eq(course_school.provider_school.uuid)
+    end
+
+    it "labels a main site school the way Provider::School does" do
+      main_site_course = create(:course).tap { |c| attach_school(c, cambridge, site_code: Provider::School::MAIN_SITE_CODE) }
+      result = described_class.new(courses: [main_site_course], latitude: london.latitude, longitude: london.longitude).call.first
+
+      expect(result.location_name).to eq("#{main_site_course.schools.sole.gias_school.name} (Main Site)")
+    end
+  end
+
+  context "when a course has several schools" do
+    let(:course) { course_taught_at(edinburgh, canary_wharf, cambridge) }
+
+    it "returns only the nearest one" do
+      expect(results.size).to eq(1)
+      expect(results.first.distance_to_search_location).to be_within(0.01).of(4.46)
+      expect(results.first.latitude).to eq(canary_wharf.latitude)
+    end
+  end
+
+  context "when several courses match" do
+    let(:cambridge_course) { course_taught_at(cambridge, name: "Chemistry (Cambridge)") }
+    let(:canary_wharf_course) { course_taught_at(canary_wharf, name: "Science (Canary Wharf)") }
+    let(:edinburgh_course) { course_taught_at(edinburgh, name: "Physics (Edinburgh)") }
+    let(:courses) { [edinburgh_course, cambridge_course, canary_wharf_course] }
+
+    it "orders them by distance from the search location" do
+      expect(results.map(&:id)).to eq([canary_wharf_course.id, cambridge_course.id, edinburgh_course.id])
+    end
+  end
+
+  context "when a school has no coordinates" do
+    let(:course) { course_taught_at(cambridge) }
+
+    it "ignores it in favour of a school that has them" do
+      attach_school(course, nil)
+
+      expect(results.size).to eq(1)
+      expect(results.first.latitude).to eq(cambridge.latitude)
+    end
+
+    it "returns no row when it is the course's only school" do
+      ungeocoded_course = create(:course).tap { |c| attach_school(c, nil) }
+
+      expect(described_class.new(courses: [ungeocoded_course], latitude: london.latitude, longitude: london.longitude).call).to be_empty
+    end
+  end
+
+  context "when a course is linked to the same GIAS school twice" do
+    let(:course) { create(:course) }
+
+    it "returns a single row with the correct distance" do
+      gias_school = create(:gias_school, latitude: canary_wharf.latitude, longitude: canary_wharf.longitude)
+      create(:course_school, course:, gias_school:, site_code: "A")
+      create(:course_school, course:, gias_school:, site_code: "B")
+
+      expect(results.size).to eq(1)
+      expect(results.first.distance_to_search_location).to be_within(0.01).of(4.46)
+    end
+
+  end
+end

--- a/spec/services/courses/school_distances_query_new_school_model_spec.rb
+++ b/spec/services/courses/school_distances_query_new_school_model_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The per-school distance listing behind Find's ?debug panel, over the canonical
+# course_school -> gias_school model and gated by the
+# :course_publishing_uses_new_school_model flag. Unlike the nearest-school lookup
+# this keeps every school a course is taught at, so the panel can show them all -
+# but only once each, however many Provider::Schools point at the same GiasSchool.
+RSpec.describe Courses::SchoolDistancesQuery do
+  subject(:results) { described_class.new(courses:, latitude: london.latitude, longitude: london.longitude).call }
+
+  before { FeatureFlag.activate(:course_publishing_uses_new_school_model) }
+  after { FeatureFlag.deactivate(:course_publishing_uses_new_school_model) }
+
+  let(:london) { build(:location, :london) }
+  let(:canary_wharf) { build(:location, :canary_wharf) }
+  let(:cambridge) { build(:location, :cambridge) }
+  let(:edinburgh) { build(:location, :edinburgh) }
+
+  let(:courses) { [course] }
+
+  def attach_school(course, location, **options)
+    create(
+      :course_school,
+      course:,
+      gias_school: create(:gias_school, latitude: location&.latitude, longitude: location&.longitude),
+      **options,
+    )
+  end
+
+  context "when a course has only canonical schools" do
+    let(:course) { create(:course) }
+
+    it "returns every school, nearest first, with its distance and details" do
+      attach_school(course, cambridge)
+      attach_school(course, canary_wharf)
+
+      expect(course.site_statuses).to be_empty
+      expect(results.map(&:distance_to_search_location)).to match([
+        a_value_within(0.01).of(4.46),
+        a_value_within(0.01).of(49.38),
+      ])
+      expect(results.map(&:latitude)).to eq([canary_wharf.latitude, cambridge.latitude])
+      expect(results.map(&:location_name)).to eq(
+        course.schools.map { |school| school.gias_school.name }.values_at(1, 0),
+      )
+    end
+  end
+
+  context "when several courses are given" do
+    let(:cambridge_course) { create(:course).tap { |c| attach_school(c, cambridge) } }
+    let(:canary_wharf_course) { create(:course).tap { |c| attach_school(c, canary_wharf) } }
+    let(:courses) { [cambridge_course, canary_wharf_course] }
+
+    it "groups the schools by course" do
+      expect(results.map(&:course_id)).to eq([cambridge_course.id, canary_wharf_course.id].sort)
+    end
+  end
+
+  context "when a course is linked to the same GIAS school twice" do
+    let(:course) { create(:course) }
+
+    it "returns the school once" do
+      gias_school = create(:gias_school, latitude: canary_wharf.latitude, longitude: canary_wharf.longitude)
+      create(:course_school, course:, gias_school:, site_code: "A")
+      create(:course_school, course:, gias_school:, site_code: "B")
+
+      expect(results.size).to eq(1)
+      expect(results.first.distance_to_search_location).to be_within(0.01).of(4.46)
+    end
+  end
+
+  context "when a school has no coordinates" do
+    let(:course) { create(:course) }
+
+    it "leaves it out" do
+      attach_school(course, edinburgh)
+      attach_school(course, nil)
+
+      expect(results.map(&:latitude)).to eq([edinburgh.latitude])
+    end
+  end
+end

--- a/spec/services/courses/school_distances_query_spec.rb
+++ b/spec/services/courses/school_distances_query_spec.rb
@@ -33,13 +33,17 @@ RSpec.describe Courses::SchoolDistancesQuery do
     ])
   end
 
+  # Exact rather than rounded, so a change to the distance maths has to be
+  # deliberate. The values are metres from PostGIS divided by
+  # Geolocation::METRES_PER_MILE; they last moved when this path stopped using a
+  # truncated 1609.34.
   it "includes the distance to the search location in miles for each school" do
     expect(query_result.map(&:distance_to_search_location)).to eq(
       [
-        1.3003659425292355,
-        3.2706425036474585,
-        163.8616343199448,
-        49.64250415094387,
+        1.3003627104894913,
+        3.2706343745153306,
+        163.86122704434848,
+        49.64238076525591,
       ],
     )
   end


### PR DESCRIPTION
## Context

Find had two queries left on the legacy `Site` / `SiteStatus` model: `NearestSchoolQuery`, which drives the distance on the course page, and `SchoolDistancesQuery`, which drives the `?debug` panel. Find's search had already moved to the canonical `Course::School -> GiasSchool` chain behind `:course_publishing_uses_new_school_model`, so with the flag on the results card and the course page for the same course were computed from two different data sources — and two different divisors, 1609.344 against 1609.34.

The visible consequence was a 500. Opening a course with a `?location=` param raised `NoMethodError` for any course with `Course::School` rows but no legacy `Site`: the query inner-joined `course_site -> site`, came back empty, and `.first.distance_to_search_location` was called on nil. Both queries now have a canonical path gated on the same flag, mirroring the `sites_`/`schools_` split in `Courses::Query`, and the shared SELECT lives in one module so the two can't drift and quietly disagree about the same school's distance.

The debug tooling moved with them: the school link now uses `Provider::School#uuid` (the old `site_uuid` fallback built a link that 404s in Publish, since that route resolves `provider.schools.find_by!(uuid:)`), and "Nearest Site" became "Nearest School". The course page no longer renders "0 miles from London" when there's no school to measure from. Not addressed: `Find::PlacementsController` is still on `site_statuses`, so a canonical-only course links to an empty placements page — pre-existing, worth a follow-up.

## URLs to test

Flag on (`FeatureFlag.activate(:course_publishing_uses_new_school_model)`), against a 2026 course with `Course::School` rows and no `SiteStatus`:

- `/results?location=London&latitude=51.5074&longitude=-0.1278&radius=10` — card distance
- `/course/:provider_code/:course_code?location=London&latitude=51.5074&longitude=-0.1278` — should render the distance, and match the card above (previously 500)
- `/results?location=London&latitude=51.5074&longitude=-0.1278&radius=10&debug=true` — "Nearest School" column, school link resolves in Publish, per-course distances panel
- Null a `GiasSchool`'s `latitude`, then reload the course page URL — loads with the funding hint instead of "0 miles"
