### PR TITLE
Training partner find links

### DIFF
--- a/app/assets/stylesheets/publish/components/_table.scss
+++ b/app/assets/stylesheets/publish/components/_table.scss
@@ -12,9 +12,9 @@
 
 .app-table--courses {
   width: 100%;
-  // Fixed layout keeps the Course, Course information and Status columns at an
-  // equal third each, so long course names wrap inside their column instead of
-  // pushing the others out. Adding or dropping a column switches to auto below.
+  // Fixed layout with no widths declared divides the table equally between
+  // whatever columns are present — thirds for three, quarters for four — so long
+  // course names wrap inside their column instead of pushing the others out.
   table-layout: fixed;
 
   // Bottom-align the headers so a wrapped "Course information" header lines up
@@ -51,12 +51,12 @@
   }
 }
 
-// Once the column count is no longer three, equal thirds stop making sense:
-// let the Course column take the remaining width and shrink the narrow columns
-// to their content. This covers the course information column being dropped and
-// the View course column being added, together or separately.
-.app-table--courses--no-information,
-.app-table--courses--view-course {
+// Down to two columns, an equal half is far more room than a status tag needs,
+// so this one case drops out of fixed layout: the Course column takes the width
+// and Status shrinks to its content. Every other combination keeps equal
+// columns, which is what the design asks for and what stops a link wrapping
+// inside a column squeezed to its narrowest word.
+.app-table--courses--no-information:not(.app-table--courses--view-course) {
   table-layout: auto;
 
   .app-table--courses__status {
@@ -64,10 +64,4 @@
 
     white-space: nowrap;
   }
-}
-
-// No nowrap here: "View live course" is long enough that it should be allowed
-// to wrap on a narrow viewport rather than force the table wider.
-.app-table--courses--view-course .app-table--courses__view-course {
-  width: 1%;
 }

--- a/app/assets/stylesheets/publish/components/_table.scss
+++ b/app/assets/stylesheets/publish/components/_table.scss
@@ -12,8 +12,9 @@
 
 .app-table--courses {
   width: 100%;
-  // Fixed layout keeps the three columns at an equal third each, so long course
-  // names wrap inside their column instead of pushing the others out.
+  // Fixed layout keeps the Course, Course information and Status columns at an
+  // equal third each, so long course names wrap inside their column instead of
+  // pushing the others out. Adding or dropping a column switches to auto below.
   table-layout: fixed;
 
   // Bottom-align the headers so a wrapped "Course information" header lines up
@@ -50,9 +51,12 @@
   }
 }
 
-// With no course information at all, the column is dropped: let the Course
-// column take the remaining width and shrink Status to its content on the right.
-.app-table--courses--no-information {
+// Once the column count is no longer three, equal thirds stop making sense:
+// let the Course column take the remaining width and shrink the narrow columns
+// to their content. This covers the course information column being dropped and
+// the View course column being added, together or separately.
+.app-table--courses--no-information,
+.app-table--courses--view-course {
   table-layout: auto;
 
   .app-table--courses__status {
@@ -60,4 +64,10 @@
 
     white-space: nowrap;
   }
+}
+
+// No nowrap here: "View live course" is long enough that it should be allowed
+// to wrap on a narrow viewport rather than force the table wider.
+.app-table--courses--view-course .app-table--courses__view-course {
+  width: 1%;
 }

--- a/app/components/publish/courses/table_component.html.erb
+++ b/app/components/publish/courses/table_component.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table app-table--courses<%= " app-table--courses--no-information" unless course_information_column? %>">
+<table class="<%= table_classes %>">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header"><%= t("publish.courses.course_table.course") %></th>
@@ -6,6 +6,9 @@
         <th class="govuk-table__header"><%= t("publish.courses.course_table.course_information") %></th>
       <% end %>
       <th class="govuk-table__header"><%= t("publish.courses.course_table.status") %></th>
+      <% if view_course_column? %>
+        <th class="govuk-table__header"><%= t("publish.courses.course_table.view_course") %></th>
+      <% end %>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -42,6 +45,16 @@
         <td class="govuk-table__cell app-table--courses__status">
           <%= render Publish::Courses::StatusTagComponent.new(course:, recruitment_cycle_year: recruitment_cycle_year(course)) %>
         </td>
+        <% if view_course_column? %>
+          <td class="govuk-table__cell app-table--courses__view-course">
+            <% if live_on_find?(course) %>
+              <%= govuk_link_to course.find_url do %>
+                <%= t("publish.courses.course_table.view_live_course") %>
+                <span class="govuk-visually-hidden"><%= t("publish.courses.course_table.view_live_course_hidden", course: course.name_and_code) %></span>
+              <% end %>
+            <% end %>
+          </td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/components/publish/courses/table_component.rb
+++ b/app/components/publish/courses/table_component.rb
@@ -7,11 +7,13 @@ module Publish
     # the course-information column (funding / qualification / study type / start
     # date) and the status tag. Rows are read-model rows from Publish::Courses::Query.
     class TableComponent < ApplicationComponent
-      def initialize(courses:, provider:, course_information_fields: Publish::CourseList::FIELDS.keys, classes: [], html_attributes: {})
+      def initialize(courses:, provider:, course_information_fields: Publish::CourseList::FIELDS.keys, view_course_column: false, classes: [], html_attributes: {})
         super(classes:, html_attributes:)
         @courses = courses
         @provider = provider
         @course_information_fields = course_information_fields
+        @view_course_column = view_course_column
+        @live_on_find = {}
       end
 
       attr_reader :courses, :provider, :course_information_fields
@@ -22,6 +24,31 @@ module Publish
 
       def course_information_column?
         course_information_fields.any?
+      end
+
+      # Asked for by the training partner course list, where the course name is
+      # not a link and Find is the only way to see the course. Dropped when
+      # nothing in the list is live, rather than heading a column of empty cells.
+      def view_course_column?
+        @view_course_column && courses.any? { |course| live_on_find?(course) }
+      end
+
+      # Reads the content status from the row's computed column rather than
+      # Course#content_status, which would run the enrichment service per row.
+      def live_on_find?(course)
+        @live_on_find.fetch(course.id) do
+          @live_on_find[course.id] = ::Courses::PublishRules::LiveOnFind.applies?(
+            course,
+            content_status: course.read_attribute(:content_status),
+          )
+        end
+      end
+
+      def table_classes
+        table = %w[govuk-table app-table--courses]
+        table << "app-table--courses--no-information" unless course_information_column?
+        table << "app-table--courses--view-course" if view_course_column?
+        table.join(" ")
       end
 
       # Lines this row actually renders: a shown start-date field still produces

--- a/app/controllers/concerns/copy_course_content.rb
+++ b/app/controllers/concerns/copy_course_content.rb
@@ -52,12 +52,6 @@ private
       Array(@self_accredited_courses) +
       @courses_by_accrediting_provider.values.flatten
 
-    @visible_course_information_fields =
-      Publish::CourseList::FIELDS.keys.select do |key|
-        courses
-          .map(&Publish::CourseList::FIELDS.fetch(key))
-          .uniq
-          .size > 1
-      end
+    @visible_course_information_fields = Publish::CourseList.visible_course_information_fields(courses)
   end
 end

--- a/app/controllers/publish/providers/training_partners/courses_controller.rb
+++ b/app/controllers/publish/providers/training_partners/courses_controller.rb
@@ -19,17 +19,14 @@ module Publish
         # uniformity rule compares across: the partner's courses this accredited
         # provider ratifies, and no one else's.
         #
-        # The View course column asks each row whether it is running, which reads
-        # site statuses, and whether it may publish without schools, which reads
-        # schools for the few courses support has exempted. The provider's own
-        # course list never asks, so the preload belongs here rather than in the
-        # query. preload rather than includes: the relation carries a custom
-        # SELECT and a lateral join that eager_load would have to fold into.
+        # The View course column needs nothing beyond what the row already
+        # carries — the content_status column and the cycle the query preloads
+        # with the provider — so there is nothing extra to load here.
         def fetch_courses
           Publish::Courses::Query.call(
             provider: training_partner,
             params: { accredited_provider: provider.provider_code },
-          ).preload(:site_statuses, :schools).map(&:decorate)
+          ).map(&:decorate)
         end
       end
     end

--- a/app/controllers/publish/providers/training_partners/courses_controller.rb
+++ b/app/controllers/publish/providers/training_partners/courses_controller.rb
@@ -6,6 +6,7 @@ module Publish
       class CoursesController < ApplicationController
         def index
           @courses = fetch_courses
+          @visible_course_information_fields = Publish::CourseList.visible_course_information_fields(@courses)
         end
 
       private
@@ -14,11 +15,21 @@ module Publish
           @training_partner ||= provider.training_partners.find_by(provider_code: params[:training_partner_code])
         end
 
+        # The list is unfiltered, so these courses are the whole list the
+        # uniformity rule compares across: the partner's courses this accredited
+        # provider ratifies, and no one else's.
+        #
+        # The View course column asks each row whether it is running, which reads
+        # site statuses, and whether it may publish without schools, which reads
+        # schools for the few courses support has exempted. The provider's own
+        # course list never asks, so the preload belongs here rather than in the
+        # query. preload rather than includes: the relation carries a custom
+        # SELECT and a lateral join that eager_load would have to fold into.
         def fetch_courses
           Publish::Courses::Query.call(
             provider: training_partner,
             params: { accredited_provider: provider.provider_code },
-          ).map(&:decorate)
+          ).preload(:site_statuses, :schools).map(&:decorate)
         end
       end
     end

--- a/app/services/courses/publish_rules/live_on_find.rb
+++ b/app/services/courses/publish_rules/live_on_find.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 
 # Single source of truth for "does this course have a live page on Find?", which
-# decides whether Publish offers a link to it or only a preview.
+# decides whether Publish links to it or only offers a preview.
+#
+# It mirrors the two guards Find itself applies to a course page:
+# Find::CoursesController#show renders the course whenever it is published, and
+# Find::ApplicationController#provider looks the provider up under
+# RecruitmentCycle.current. Nothing about site statuses comes into it — Find
+# serves a published course whose sites are not on UCAS just the same — so
+# Publish must not be stricter, or it withholds a link to a page that is there.
+#
+# The cycle test has to be equality, not "not the next one". Find resolves a
+# course by code within the current cycle, so a link built from an earlier
+# cycle's row lands on whichever course holds that code today: a different
+# course, with nothing to signal the switch.
 #
 # Content status is a required argument rather than something read off the
 # course, because the two callers get it from different places: the course page
 # from Course#content_status, and the course list from the content_status column
 # Publish::Courses::Query computes in SQL. Reading it off the course in a list
 # would run the enrichment service once per row.
-#
-# Find serves the current cycle only (Find::ApplicationController#provider scopes
-# to RecruitmentCycle.current), and Publish holds the current and next cycle, so
-# "not next cycle" is the cycle test.
-#
-# The year comes off the course's already-loaded cycle and is compared against
-# the timetable rather than through Course#next_recruitment_cycle?, which looks
-# the current cycle up from the database on every call — once per row on a
-# course list.
 module Courses
   module PublishRules
     class LiveOnFind
       def self.applies?(course, content_status:)
         content_status.to_s == "published" &&
-          course.recruitment_cycle_year.to_i <= Find::CycleTimetable.current_year &&
-          (course.is_running? || course.without_employing_school?)
+          course.recruitment_cycle_year.to_i == Find::CycleTimetable.current_year
       end
     end
   end

--- a/app/services/courses/publish_rules/live_on_find.rb
+++ b/app/services/courses/publish_rules/live_on_find.rb
@@ -12,12 +12,17 @@
 # Find serves the current cycle only (Find::ApplicationController#provider scopes
 # to RecruitmentCycle.current), and Publish holds the current and next cycle, so
 # "not next cycle" is the cycle test.
+#
+# The year comes off the course's already-loaded cycle and is compared against
+# the timetable rather than through Course#next_recruitment_cycle?, which looks
+# the current cycle up from the database on every call — once per row on a
+# course list.
 module Courses
   module PublishRules
     class LiveOnFind
       def self.applies?(course, content_status:)
         content_status.to_s == "published" &&
-          !course.next_recruitment_cycle? &&
+          course.recruitment_cycle_year.to_i <= Find::CycleTimetable.current_year &&
           (course.is_running? || course.without_employing_school?)
       end
     end

--- a/app/services/courses/publish_rules/live_on_find.rb
+++ b/app/services/courses/publish_rules/live_on_find.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Single source of truth for "does this course have a live page on Find?", which
+# decides whether Publish offers a link to it or only a preview.
+#
+# Content status is a required argument rather than something read off the
+# course, because the two callers get it from different places: the course page
+# from Course#content_status, and the course list from the content_status column
+# Publish::Courses::Query computes in SQL. Reading it off the course in a list
+# would run the enrichment service once per row.
+#
+# Find serves the current cycle only (Find::ApplicationController#provider scopes
+# to RecruitmentCycle.current), and Publish holds the current and next cycle, so
+# "not next cycle" is the cycle test.
+module Courses
+  module PublishRules
+    class LiveOnFind
+      def self.applies?(course, content_status:)
+        content_status.to_s == "published" &&
+          !course.next_recruitment_cycle? &&
+          (course.is_running? || course.without_employing_school?)
+      end
+    end
+  end
+end

--- a/app/services/publish/course_list.rb
+++ b/app/services/publish/course_list.rb
@@ -46,6 +46,13 @@ module Publish
       start_date: ->(course) { course.start_date.presence&.to_date&.beginning_of_month },
     }.freeze
 
+    # The rule on its own: the fields whose value is not the same for every
+    # course given. Callers that already hold the courses to compare use this
+    # directly rather than restating the comparison.
+    def self.visible_course_information_fields(courses)
+      FIELDS.keys.select { |key| courses.map(&FIELDS.fetch(key)).uniq.size > 1 }
+    end
+
     # Asks whether any course survived the filters rather than whether any group
     # did, so a group that keeps its place with nothing in it is not a list.
     def any?
@@ -70,7 +77,7 @@ module Publish
     # never adds or removes a column.
     def visible_course_information_fields
       @visible_course_information_fields ||=
-        FIELDS.keys.select { |key| unfiltered_courses.map(&FIELDS.fetch(key)).uniq.size > 1 }
+        self.class.visible_course_information_fields(unfiltered_courses)
     end
 
     # The filter groups worth showing: those whose value varies across the whole

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -5,12 +5,12 @@
 <div class="govuk-button-group">
   <%= govuk_link_to course.application_status_closed? ? "Open course" : "Close course", application_status_publish_provider_recruitment_cycle_course_path, class: "govuk-button govuk-!-margin-right-2" %>
 
-  <% if course.scheduled? %>
-   <%= govuk_link_to t(".preview_course"), preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
-  <% else %>
+  <% if Courses::PublishRules::LiveOnFind.applies?(course, content_status: course.content_status) %>
     <%= govuk_link_to find_course_url(course.provider_code, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
     <%= t(".view_live_course") %> <span class="govuk-visually-hidden"><%= t(".hidden_text") %></span>
     <% end %>
+  <% else %>
+   <%= govuk_link_to t(".preview_course"), preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
   <% end %>
 
   <%= govuk_link_to t(".withdraw_course"), withdraw_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive govuk-!-margin-right-2", data: { qa: "course__withdraw-link" } %>

--- a/app/views/publish/providers/training_partners/courses/index.html.erb
+++ b/app/views/publish/providers/training_partners/courses/index.html.erb
@@ -7,5 +7,10 @@
 </h1>
 
 <section>
-  <%= render Publish::Courses::TableComponent.new(courses: @courses, provider: @provider) %>
+  <%= render Publish::Courses::TableComponent.new(
+        courses: @courses,
+        provider: @provider,
+        course_information_fields: @visible_course_information_fields,
+        view_course_column: true,
+      ) %>
 </section>

--- a/config/locales/en/publish/courses/course_table.yml
+++ b/config/locales/en/publish/courses/course_table.yml
@@ -5,6 +5,9 @@ en:
         course: Course
         course_information: Course information
         status: Status
+        view_course: View course
+        view_live_course: View live course
+        view_live_course_hidden: for %{course}
         funding:
           fee: Fee-paying
           salary: Salaried

--- a/spec/components/publish/courses/table_component_spec.rb
+++ b/spec/components/publish/courses/table_component_spec.rb
@@ -163,4 +163,70 @@ RSpec.describe Publish::Courses::TableComponent, type: :component do
       end
     end
   end
+
+  describe "the View course column" do
+    subject(:render_with) { render_inline(described_class.new(courses:, provider:, view_course_column: true)) }
+
+    it "is off by default, leaving the provider's own course list as it was" do
+      create(:course, :published_postgraduate, provider:)
+      render_component
+
+      expect(page.all(".govuk-table__header").map(&:text)).not_to include("View course")
+      expect(page).to have_no_css(".app-table--courses__view-course")
+    end
+
+    context "with a course that is live on Find" do
+      before { create(:course, :published_postgraduate, provider:, name: "Biology", course_code: "B123") }
+
+      it "heads the column and links to the course on Find" do
+        render_with
+
+        expect(page.all(".govuk-table__header").map(&:text)).to eq(["Course", "Course information", "Status", "View course"])
+        expect(page).to have_css("table.app-table--courses--view-course")
+        expect(page.find(".app-table--courses__view-course a")[:href])
+          .to include("find.localhost/course/#{provider.provider_code}/B123")
+      end
+
+      it "names the course in the link, since every row would otherwise read alike" do
+        render_with
+
+        within(".app-table--courses__view-course") do
+          expect(page).to have_css("a .govuk-visually-hidden", text: "for Biology (B123)")
+        end
+      end
+    end
+
+    context "with a mix of live and unpublished courses" do
+      before do
+        create(:course, :published_postgraduate, provider:, name: "Biology", course_code: "B123")
+        create(
+          :course, :with_full_time_sites, provider:, name: "Physics", course_code: "P456",
+                                          enrichments: [build(:course_enrichment, :initial_draft, course: nil)]
+        )
+      end
+
+      it "leaves the cell empty for the course with nowhere live to point at" do
+        render_with
+
+        cells = page.all(".app-table--courses__view-course").map { |cell| cell.text.strip }
+        expect(cells).to contain_exactly(a_string_including("View live course"), "")
+      end
+    end
+
+    context "when no course in the list is live on Find" do
+      before do
+        create(
+          :course, :with_full_time_sites, provider:,
+                                          enrichments: [build(:course_enrichment, :initial_draft, course: nil)]
+        )
+      end
+
+      it "drops the column rather than heading a set of empty cells" do
+        render_with
+
+        expect(page.all(".govuk-table__header").map(&:text)).not_to include("View course")
+        expect(page).to have_no_css(".app-table--courses__view-course")
+      end
+    end
+  end
 end

--- a/spec/requests/publish/providers/training_partners/courses_spec.rb
+++ b/spec/requests/publish/providers/training_partners/courses_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Publish::Providers::TrainingPartners::CoursesController#index" do
+  include DfESignInUserHelper
+
+  def count_queries(&)
+    count = 0
+    counter = ->(_name, _start, _finish, _id, payload) { count += 1 unless payload[:name].to_s =~ /SCHEMA|TRANSACTION/ }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record", &)
+    count
+  end
+
+  def render_list_of(course_count)
+    accredited_provider = create(:provider, :accredited_provider)
+    user = create(:user, providers: [accredited_provider])
+    training_partner = create(:provider)
+    create(:provider_partnership, training_provider: training_partner, accredited_provider: accredited_provider)
+    create_list(:course, course_count, :published_postgraduate, provider: training_partner, accrediting_provider: accredited_provider)
+
+    login_user(user)
+    count_queries do
+      get "/publish/organisations/#{accredited_provider.provider_code}/#{accredited_provider.recruitment_cycle_year}/training-partners/#{training_partner.provider_code}/courses"
+    end
+  end
+
+  # The View course column asks every row whether it is running, which reads site
+  # statuses. Bullet does not raise in test, so this is what stops that becoming
+  # a query per course.
+  it "renders the list in a constant number of queries regardless of course count" do
+    many = render_list_of(9)
+    few = render_list_of(3)
+
+    expect(response.body).to include("View live course")
+    expect(many).to eq(few)
+  end
+end

--- a/spec/requests/publish/providers/training_partners/courses_spec.rb
+++ b/spec/requests/publish/providers/training_partners/courses_spec.rb
@@ -25,9 +25,9 @@ describe "Publish::Providers::TrainingPartners::CoursesController#index" do
     end
   end
 
-  # The View course column asks every row whether it is running, which reads site
-  # statuses. Bullet does not raise in test, so this is what stops that becoming
-  # a query per course.
+  # The View course column must stay answerable from the row's own columns.
+  # Bullet does not raise in test, so this is what catches a change that starts
+  # reaching for an association and turns the column into a query per course.
   it "renders the list in a constant number of queries regardless of course count" do
     many = render_list_of(9)
     few = render_list_of(3)

--- a/spec/services/courses/publish_rules/live_on_find_spec.rb
+++ b/spec/services/courses/publish_rules/live_on_find_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Courses::PublishRules::LiveOnFind do
+  # The rule reads the content status from the caller rather than the course so
+  # that a course list row can hand over Publish::Courses::Query's computed
+  # column instead of paying for Course#content_status per row.
+  def applies?(course)
+    described_class.applies?(course, content_status: course.content_status)
+  end
+
+  # :with_full_time_sites gives the course a findable site status, but also a
+  # published enrichment. Anything else has to override `enrichments:`, which is
+  # the escape hatch the factory documents.
+  def running_course(*traits, **overrides)
+    create(:course, :with_full_time_sites, *traits, **overrides)
+  end
+
+  def enrichment(*traits)
+    [build(:course_enrichment, *traits, course: nil)]
+  end
+
+  describe ".applies?" do
+    context "with a published course in the current cycle" do
+      it "applies when the course is running" do
+        expect(applies?(running_course)).to be(true)
+      end
+
+      it "applies when the course has no schools but support allowed it to publish without them" do
+        course = create(:course, :published, publish_without_schools_allowed: true)
+
+        expect(applies?(course)).to be(true)
+      end
+
+      it "does not apply when the course is neither running nor exempt" do
+        course = create(:course, :published, publish_without_schools_allowed: false)
+
+        expect(applies?(course)).to be(false)
+      end
+    end
+
+    context "with a published, running course in the next cycle" do
+      it "does not apply, because Find only serves the current cycle" do
+        provider = create(:provider, recruitment_cycle: create(:recruitment_cycle, :next))
+
+        expect(applies?(running_course(provider:))).to be(false)
+      end
+    end
+
+    context "when the course is not published" do
+      it "does not apply to a draft course" do
+        expect(applies?(running_course(enrichments: enrichment(:initial_draft)))).to be(false)
+      end
+
+      it "does not apply to a withdrawn course" do
+        expect(applies?(running_course(enrichments: enrichment(:withdrawn)))).to be(false)
+      end
+
+      it "does not apply to a rolled over course" do
+        expect(applies?(running_course(enrichments: enrichment(:rolled_over)))).to be(false)
+      end
+
+      it "does not apply to a course with no enrichment at all" do
+        expect(applies?(running_course(enrichments: []))).to be(false)
+      end
+    end
+  end
+
+  # Publish::Courses::Query selects content_status as a SQL column, but
+  # Course#content_status is a real method that shadows it and runs the
+  # enrichment service instead. Both call sites must reach the same verdict, so
+  # this pins the row and the model together.
+  describe "agreement between the model and the read-model row" do
+    {
+      "a published, running course" => -> { running_course(provider:) },
+      "a published course exempt from needing schools" => -> { create(:course, :published, provider:, publish_without_schools_allowed: true) },
+      "a published course that is not running" => -> { create(:course, :published, provider:) },
+      "a draft course" => -> { running_course(provider:, enrichments: enrichment(:initial_draft)) },
+      "a withdrawn course" => -> { running_course(provider:, enrichments: enrichment(:withdrawn)) },
+      "a rolled over course" => -> { running_course(provider:, enrichments: enrichment(:rolled_over)) },
+      "a course with no enrichment" => -> { running_course(provider:, enrichments: []) },
+    }.each do |description, setup|
+      context "with #{description}" do
+        let(:provider) { create(:provider) }
+
+        it "agrees with the verdict taken from Course#content_status" do
+          course = instance_exec(&setup)
+          row = Publish::Courses::Query.call(provider: provider.reload).find { |r| r.id == course.id }
+
+          expect(described_class.applies?(row, content_status: row.read_attribute(:content_status)))
+            .to eq(applies?(course))
+        end
+      end
+    end
+  end
+end

--- a/spec/services/courses/publish_rules/live_on_find_spec.rb
+++ b/spec/services/courses/publish_rules/live_on_find_spec.rb
@@ -21,30 +21,38 @@ describe Courses::PublishRules::LiveOnFind do
     [build(:course_enrichment, *traits, course: nil)]
   end
 
+  def provider_in(cycle_trait)
+    create(:provider, recruitment_cycle: create(:recruitment_cycle, cycle_trait))
+  end
+
   describe ".applies?" do
     context "with a published course in the current cycle" do
       it "applies when the course is running" do
         expect(applies?(running_course)).to be(true)
       end
 
-      it "applies when the course has no schools but support allowed it to publish without them" do
-        course = create(:course, :published, publish_without_schools_allowed: true)
+      # Find's show action only asks whether the course is published, so it
+      # serves a course whose sites are not on UCAS just the same. Publish must
+      # not be stricter than Find, or it withholds a link to a page that is
+      # there.
+      it "applies when no site is published, which Find serves anyway" do
+        course = running_course(site_statuses: [build(:site_status, status: :new_status, publish: "N")])
 
+        expect(course.is_running?).to be(false)
         expect(applies?(course)).to be(true)
-      end
-
-      it "does not apply when the course is neither running nor exempt" do
-        course = create(:course, :published, publish_without_schools_allowed: false)
-
-        expect(applies?(course)).to be(false)
       end
     end
 
-    context "with a published, running course in the next cycle" do
-      it "does not apply, because Find only serves the current cycle" do
-        provider = create(:provider, recruitment_cycle: create(:recruitment_cycle, :next))
+    context "with a published, running course outside the current cycle" do
+      it "does not apply to the next cycle, which Find does not serve" do
+        expect(applies?(running_course(provider: provider_in(:next)))).to be(false)
+      end
 
-        expect(applies?(running_course(provider:))).to be(false)
+      # Find looks the course up by code under RecruitmentCycle.current, so a
+      # link built from an earlier cycle's row resolves to whichever course
+      # holds that code today — a different course, silently.
+      it "does not apply to a previous cycle, whose code would resolve to another course" do
+        expect(applies?(running_course(provider: provider_in(:previous)))).to be(false)
       end
     end
 
@@ -73,16 +81,17 @@ describe Courses::PublishRules::LiveOnFind do
   # this pins the row and the model together.
   describe "agreement between the model and the read-model row" do
     {
-      "a published, running course" => -> { running_course(provider:) },
-      "a published course exempt from needing schools" => -> { create(:course, :published, provider:, publish_without_schools_allowed: true) },
-      "a published course that is not running" => -> { create(:course, :published, provider:) },
+      "a published course" => -> { running_course(provider:) },
       "a draft course" => -> { running_course(provider:, enrichments: enrichment(:initial_draft)) },
       "a withdrawn course" => -> { running_course(provider:, enrichments: enrichment(:withdrawn)) },
       "a rolled over course" => -> { running_course(provider:, enrichments: enrichment(:rolled_over)) },
       "a course with no enrichment" => -> { running_course(provider:, enrichments: []) },
+      "a published course in the next cycle" => -> { running_course(provider:) },
     }.each do |description, setup|
       context "with #{description}" do
-        let(:provider) { create(:provider) }
+        let(:provider) do
+          description.include?("next cycle") ? provider_in(:next) : create(:provider)
+        end
 
         it "agrees with the verdict taken from Course#content_status" do
           course = instance_exec(&setup)

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -81,6 +81,36 @@ RSpec.describe Publish::CourseList do
     end
   end
 
+  # The rule itself, independent of a provider's list: callers that already hold
+  # the courses to compare (the training partner course list, the copy-content
+  # sidebar) use this rather than restating it.
+  describe ".visible_course_information_fields" do
+    let(:provider) { create(:provider) }
+
+    it "returns no fields when every course shares the same values" do
+      courses = build_list(:course, 2, provider:, funding: "fee", study_mode: :full_time)
+
+      expect(described_class.visible_course_information_fields(courses)).to eq([])
+    end
+
+    it "returns the varying fields in display order" do
+      courses = [
+        build(:course, provider:, funding: "fee", study_mode: :full_time),
+        build(:course, provider:, funding: "salary", study_mode: :part_time),
+      ]
+
+      expect(described_class.visible_course_information_fields(courses)).to eq(%i[funding study_mode])
+    end
+
+    it "returns no fields for a single course, which has nothing to vary against" do
+      expect(described_class.visible_course_information_fields([build(:course, provider:)])).to eq([])
+    end
+
+    it "returns no fields for an empty list" do
+      expect(described_class.visible_course_information_fields([])).to eq([])
+    end
+  end
+
   describe "#visible_course_information_fields" do
     let(:provider) { create(:provider, :accredited_provider) }
 

--- a/spec/support/page_objects/publish/training_partner_courses.rb
+++ b/spec/support/page_objects/publish/training_partner_courses.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class TrainingPartnerCourses < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/training-partners/{training_partner_code}/courses"
+
+      elements :column_headings, ".app-table--courses .govuk-table__header"
+
+      sections :rows, ".app-table--courses tbody tr" do
+        element :name, ".app-table--courses__course-name"
+        element :course_information, ".app-table--courses__course-information"
+        element :status, ".app-table--courses__status"
+        element :view_course, ".app-table--courses__view-course"
+      end
+    end
+  end
+end

--- a/spec/system/publish/viewing_a_course_spec.rb
+++ b/spec/system/publish/viewing_a_course_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe "Course show" do
     end
   end
 
+  describe "in an earlier cycle" do
+    # Find resolves a course by code within the current cycle, so linking an
+    # earlier cycle's course would land on whichever course holds that code
+    # today rather than the one being looked at.
+    scenario "a published, running course offers a preview rather than a link to Find" do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course))
+      and_there_is_a_published_running_course_in_the_previous_cycle
+      when_i_visit_the_previous_cycle_course_page
+      then_i_should_see_a_preview_link_rather_than_a_link_to_find
+    end
+  end
+
   describe "with a published course that has a legacy subsequent draft" do
     scenario "i can view the published partial" do
       given_i_am_authenticated_as_a_provider_user(
@@ -318,6 +330,26 @@ private
     )
 
     @user.providers << @next_cycle_provider
+  end
+
+  def and_there_is_a_published_running_course_in_the_previous_cycle
+    @previous_cycle_course = build(:course, :published, site_statuses: [build(:site_status, :findable)])
+    @previous_cycle_provider = create(
+      :provider,
+      recruitment_cycle: find_or_create(:recruitment_cycle, year: RecruitmentCycle.current.year.to_i - 1),
+      provider_code: @user.providers.first.provider_code,
+      courses: [@previous_cycle_course],
+    )
+
+    @user.providers << @previous_cycle_provider
+  end
+
+  def when_i_visit_the_previous_cycle_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: @previous_cycle_provider.provider_code,
+      recruitment_cycle_year: @previous_cycle_provider.recruitment_cycle_year,
+      course_code: @previous_cycle_course.course_code,
+    )
   end
 
   def when_i_visit_the_next_cycle_course_page

--- a/spec/system/publish/viewing_a_course_spec.rb
+++ b/spec/system/publish/viewing_a_course_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe "Course show" do
       when_i_visit_the_next_cycle_courses_page
       then_i_should_see_the_status_scheduled
     end
+
+    # Find serves the current cycle only, so a next-cycle course has nowhere
+    # live to link to however published and running it is.
+    scenario "a published, running course offers a preview rather than a link to Find" do
+      given_there_is_a_next_recruitment_cycle
+      given_i_am_authenticated_as_a_provider_user(course: build(:course))
+      and_there_is_a_published_running_course_in_the_next_cycle
+      when_i_visit_the_next_cycle_course_page
+      then_i_should_see_a_preview_link_rather_than_a_link_to_find
+    end
   end
 
   describe "with a published course that has a legacy subsequent draft" do
@@ -296,6 +306,33 @@ private
       ],
     )
     given_i_am_authenticated(user: @user)
+  end
+
+  def and_there_is_a_published_running_course_in_the_next_cycle
+    @next_cycle_course = build(:course, :published, site_statuses: [build(:site_status, :findable)])
+    @next_cycle_provider = create(
+      :provider,
+      recruitment_cycle: RecruitmentCycle.next,
+      provider_code: @user.providers.first.provider_code,
+      courses: [@next_cycle_course],
+    )
+
+    @user.providers << @next_cycle_provider
+  end
+
+  def when_i_visit_the_next_cycle_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: next_cycle_provider.provider_code,
+      recruitment_cycle_year: next_recruitment_cycle_year,
+      course_code: @next_cycle_course.course_code,
+    )
+  end
+
+  def then_i_should_see_a_preview_link_rather_than_a_link_to_find
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).to have_link("Preview course")
+      expect(course_button_panel).to have_no_link("View live course")
+    end
   end
 
   def and_there_is_the_provider_in_the_next_cycle

--- a/spec/system/publish/viewing_training_partner_courses_spec.rb
+++ b/spec/system/publish/viewing_training_partner_courses_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe "Viewing a training partner's courses as an accredited provider" 
 
       then_i_should_see_the_column_headings("Course", "Status")
     end
+
+    # Find resolves a course by code within the current cycle, so linking an
+    # earlier cycle's course would land on whichever course holds that code
+    # today rather than the one in the row.
+    scenario "the column is dropped on an earlier cycle, whose codes resolve elsewhere on Find" do
+      and_an_earlier_cycle_has_the_same_partnership_with_a_published_course
+      when_i_visit_the_earlier_cycle_training_partner_courses_page
+
+      then_i_should_see_the_column_headings("Course", "Status")
+    end
   end
 
   describe "the Course information column" do
@@ -107,6 +117,37 @@ RSpec.describe "Viewing a training partner's courses as an accredited provider" 
       :course, :published_postgraduate,
       provider: training_partner, accrediting_provider: create(:accredited_provider),
       name: "Geography", course_code: "G321", funding: "salary"
+    )
+  end
+
+  def and_an_earlier_cycle_has_the_same_partnership_with_a_published_course
+    cycle = find_or_create(:recruitment_cycle, year: RecruitmentCycle.current.year.to_i - 1)
+    @earlier_accredited_provider = create(
+      :provider, :accredited_provider,
+      recruitment_cycle: cycle, provider_code: accrediting_provider.provider_code
+    )
+    @earlier_training_partner = create(
+      :provider,
+      recruitment_cycle: cycle, provider_code: training_partner.provider_code,
+    )
+    create(
+      :provider_partnership,
+      training_provider: @earlier_training_partner, accredited_provider: @earlier_accredited_provider,
+    )
+    create(
+      :course, :published_postgraduate,
+      provider: @earlier_training_partner, accrediting_provider: @earlier_accredited_provider,
+      name: "Biology", course_code: "B123"
+    )
+
+    @current_user.providers << @earlier_accredited_provider
+  end
+
+  def when_i_visit_the_earlier_cycle_training_partner_courses_page
+    publish_training_partner_courses_page.load(
+      provider_code: @earlier_accredited_provider.provider_code,
+      recruitment_cycle_year: @earlier_accredited_provider.recruitment_cycle_year,
+      training_partner_code: @earlier_training_partner.provider_code,
     )
   end
 

--- a/spec/system/publish/viewing_training_partner_courses_spec.rb
+++ b/spec/system/publish/viewing_training_partner_courses_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Viewing a training partner's courses as an accredited provider" do
+  before { given_i_am_authenticated_as_an_accredited_provider_user }
+
+  describe "the View course column" do
+    scenario "a live course links through to Find" do
+      and_the_partner_has_a_live_course
+      when_i_visit_the_training_partner_courses_page
+
+      then_i_should_see_the_column_headings("Course", "Status", "View course")
+      expect(course_row("Biology").view_course).to have_link("View live course")
+      expect(course_row("Biology").view_course.find("a")[:href])
+        .to include("find.localhost/course/#{training_partner.provider_code}/B123")
+    end
+
+    scenario "a course with nowhere live to point at has no link" do
+      and_the_partner_has_a_live_course
+      and_the_partner_has_a_rolled_over_course
+      when_i_visit_the_training_partner_courses_page
+
+      expect(course_row("Biology").view_course).to have_link("View live course")
+      expect(course_row("Physics").view_course).to have_no_link
+      expect(course_row("Physics").status).to have_text("Rolled over")
+    end
+
+    scenario "the column is dropped when no course is live" do
+      and_the_partner_has_a_rolled_over_course
+      when_i_visit_the_training_partner_courses_page
+
+      then_i_should_see_the_column_headings("Course", "Status")
+    end
+  end
+
+  describe "the Course information column" do
+    scenario "shows only the values that vary across the partner's courses" do
+      and_the_partner_has_two_courses_differing_only_in_study_mode
+      when_i_visit_the_training_partner_courses_page
+
+      then_i_should_see_the_column_headings("Course", "Course information", "Status", "View course")
+      expect(course_row("Biology").course_information).to have_text("Full time")
+      expect(course_row("Biology").course_information).to have_no_text("Fee-paying")
+      expect(course_row("Biology").course_information).to have_no_text("QTS with PGCE")
+    end
+
+    scenario "is dropped for a partner with a single course, which cannot vary" do
+      and_the_partner_has_a_live_course
+      when_i_visit_the_training_partner_courses_page
+
+      then_i_should_see_the_column_headings("Course", "Status", "View course")
+    end
+
+    # The comparison must cover the courses this accredited provider ratifies,
+    # not everything the partner runs, or a course they cannot see here would
+    # decide what they are shown.
+    scenario "ignores the partner's courses ratified by someone else" do
+      and_the_partner_has_two_courses_differing_only_in_study_mode
+      and_the_partner_has_a_part_time_course_ratified_by_another_accredited_provider
+      when_i_visit_the_training_partner_courses_page
+
+      expect(rows.size).to eq(2)
+      expect(course_row("Biology").course_information).to have_text("Full time")
+      expect(course_row("Biology").course_information).to have_no_text("Fee-paying")
+    end
+  end
+
+  def given_i_am_authenticated_as_an_accredited_provider_user
+    given_i_am_authenticated(user: create(:user, providers: [create(:provider, :accredited_provider)]))
+    create(:provider_partnership, training_provider: training_partner, accredited_provider: accrediting_provider)
+  end
+
+  def and_the_partner_has_a_live_course
+    create(
+      :course, :published_postgraduate, provider: training_partner, accrediting_provider:,
+      name: "Biology", course_code: "B123"
+    )
+  end
+
+  def and_the_partner_has_a_rolled_over_course
+    create(
+      :course, :with_full_time_sites, provider: training_partner, accrediting_provider:,
+      name: "Physics", course_code: "P456",
+      enrichments: [build(:course_enrichment, :rolled_over, course: nil)]
+    )
+  end
+
+  # Site status vacancies have to agree with the course's study mode, so the
+  # part time course composes the traits rather than using
+  # :published_postgraduate, which brings full time sites with it.
+  def and_the_partner_has_two_courses_differing_only_in_study_mode
+    create(:course, :published_postgraduate, provider: training_partner, accrediting_provider:,
+                                             name: "Biology", course_code: "B123", study_mode: :full_time)
+    create(:course, :open, :with_part_time_sites, :resulting_in_pgce_with_qts,
+           provider: training_partner, accrediting_provider:,
+           name: "Chemistry", course_code: "C789", study_mode: :part_time)
+  end
+
+  def and_the_partner_has_a_part_time_course_ratified_by_another_accredited_provider
+    create(
+      :course, :published_postgraduate, provider: training_partner,
+      accrediting_provider: create(:accredited_provider), name: "Geography", course_code: "G321",
+      funding: "salary"
+    )
+  end
+
+  def when_i_visit_the_training_partner_courses_page
+    publish_training_partner_courses_page.load(
+      provider_code: accrediting_provider.provider_code,
+      recruitment_cycle_year: accrediting_provider.recruitment_cycle_year,
+      training_partner_code: training_partner.provider_code,
+    )
+  end
+
+  def then_i_should_see_the_column_headings(*headings)
+    expect(publish_training_partner_courses_page.column_headings.map(&:text)).to eq(headings)
+  end
+
+  def rows
+    publish_training_partner_courses_page.rows
+  end
+
+  def course_row(name)
+    rows.find { |row| row.name.text.include?(name) } ||
+      raise("no row for #{name.inspect} in #{rows.map { |row| row.name.text }.inspect}")
+  end
+
+  def accrediting_provider
+    @current_user.providers.first
+  end
+
+  def training_partner
+    @training_partner ||= create(:provider)
+  end
+end

--- a/spec/system/publish/viewing_training_partner_courses_spec.rb
+++ b/spec/system/publish/viewing_training_partner_courses_spec.rb
@@ -73,15 +73,15 @@ RSpec.describe "Viewing a training partner's courses as an accredited provider" 
 
   def and_the_partner_has_a_live_course
     create(
-      :course, :published_postgraduate, provider: training_partner, accrediting_provider:,
-      name: "Biology", course_code: "B123"
+      :course, :published_postgraduate,
+      provider: training_partner, accrediting_provider:, name: "Biology", course_code: "B123"
     )
   end
 
   def and_the_partner_has_a_rolled_over_course
     create(
-      :course, :with_full_time_sites, provider: training_partner, accrediting_provider:,
-      name: "Physics", course_code: "P456",
+      :course, :with_full_time_sites,
+      provider: training_partner, accrediting_provider:, name: "Physics", course_code: "P456",
       enrichments: [build(:course_enrichment, :rolled_over, course: nil)]
     )
   end
@@ -90,18 +90,23 @@ RSpec.describe "Viewing a training partner's courses as an accredited provider" 
   # part time course composes the traits rather than using
   # :published_postgraduate, which brings full time sites with it.
   def and_the_partner_has_two_courses_differing_only_in_study_mode
-    create(:course, :published_postgraduate, provider: training_partner, accrediting_provider:,
-                                             name: "Biology", course_code: "B123", study_mode: :full_time)
-    create(:course, :open, :with_part_time_sites, :resulting_in_pgce_with_qts,
-           provider: training_partner, accrediting_provider:,
-           name: "Chemistry", course_code: "C789", study_mode: :part_time)
+    create(
+      :course, :published_postgraduate,
+      provider: training_partner, accrediting_provider:,
+      name: "Biology", course_code: "B123", study_mode: :full_time
+    )
+    create(
+      :course, :open, :with_part_time_sites, :resulting_in_pgce_with_qts,
+      provider: training_partner, accrediting_provider:,
+      name: "Chemistry", course_code: "C789", study_mode: :part_time
+    )
   end
 
   def and_the_partner_has_a_part_time_course_ratified_by_another_accredited_provider
     create(
-      :course, :published_postgraduate, provider: training_partner,
-      accrediting_provider: create(:accredited_provider), name: "Geography", course_code: "G321",
-      funding: "salary"
+      :course, :published_postgraduate,
+      provider: training_partner, accrediting_provider: create(:accredited_provider),
+      name: "Geography", course_code: "G321", funding: "salary"
     )
   end
 
@@ -117,9 +122,7 @@ RSpec.describe "Viewing a training partner's courses as an accredited provider" 
     expect(publish_training_partner_courses_page.column_headings.map(&:text)).to eq(headings)
   end
 
-  def rows
-    publish_training_partner_courses_page.rows
-  end
+  delegate :rows, to: :publish_training_partner_courses_page
 
   def course_row(name)
     rows.find { |row| row.name.text.include?(name) } ||

--- a/spec/system/publish/viewing_training_partners_and_their_courses_spec.rb
+++ b/spec/system/publish/viewing_training_partners_and_their_courses_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe "Viewing courses as an accredited provider" do
       "/publish/organisations/#{accrediting_provider.provider_code}/#{accrediting_provider.recruitment_cycle_year}/training-partners/#{training_provider.provider_code}/courses",
     )
     expect(page).to have_text(course.name_and_code)
-    expect(page).to have_no_link(course.name_and_code)
+    # Scoped to the name cell: the View course link names the course in its
+    # hidden text, so matching on the name alone finds that link instead.
+    expect(page).to have_no_css(".app-table--courses__course-name a")
   end
 
   def accrediting_provider


### PR DESCRIPTION
## Context

Research with accredited providers found they need more information about their training partners' courses in order to oversee that those courses are accurate. Today the accredited provider's view of a partner's courses is a dead end: the course names are not links on that page, so there is no way to see a course as a candidate would.

This adds a "View course" column to that list. Each row links to the course on Find when there is a live page to point at, and is left empty otherwise; the column disappears entirely when nothing in the list is live. The same page also now applies the existing "hide a value that is identical across every course" rule to the Course information column, which it had been skipping and always showing all four values. Most partners have a single ratified course, so that list will often show no course information at all — that is the rule working as specified.

The live-vs-preview condition was spread across the course show page's button panel partials, so it is extracted into Courses::PublishRules::LiveOnFind and shared by both call sites; the show page's behaviour is unchanged. The uniformity rule was already written out twice, so it is lifted to Publish::CourseList.visible_course_information_fields and all three callers point at it. Deciding whether a row is live reads site statuses, so those are preloaded for this page only, and a request spec pins the page at a constant number of queries — Bullet does not raise in test and would let a per-row query through unnoticed.

## URLs to test

- `/publish/organisations/{ACCREDITED_CODE}/2026/training-partners/{PARTNER_CODE}/courses` — the new column and the course information rule
- `/publish/organisations/{PROVIDER_CODE}/2026/courses` — the provider's own list, which must be unchanged
- `/publish/organisations/{PROVIDER_CODE}/2026/courses/{COURSE_CODE}` — the course page's View live course / Preview course link, also unchanged
