### PR TITLE
Upgrade QA DB to General purpose

### DIFF
--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -28,5 +28,5 @@
   "enable_monitoring": true,
   "enable_logit": true,
   "statuscake_contact_groups": [324594],
-  "postgres_flexible_server_sku": "B_Standard_B2s"
+  "postgres_flexible_server_sku": "Standard_D2ds_v5"
 }


### PR DESCRIPTION
## Context

We have reached our burstable limit during our DB rebuild. This has caused our restore to fail. This PR will make the DB non burstable, as discussed with infra

## Changes proposed in this pull request

- Change Postgres qa SKU to d2ds_v5

## Guidance to review

Approve