### PR TITLE
Switch deployed Rails.cache from Redis to Solid Cache

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -14,14 +14,12 @@ data_sources:
     timeout: 30
 
     # Cache results of slow queries. Blazer.cache defaults to Rails.cache,
-    # which is Redis today, so this needs no extra infrastructure.
+    # which uses Solid Cache on the primary database in production.
     #
-    # Revisit when Rails.cache moves to SolidCache on Postgres: this writes
-    # whole result sets (which often contain personal data) into
-    # solid_cache_entries, where they persist unencrypted for expires_in and
-    # appear in backups. Consider encrypt: true on the cache store, a shorter
-    # expires_in, or setting Blazer.cache to a separate store in
-    # config/initializers/blazer.rb.
+    # Cached results can contain personal data. solid_cache_entries is excluded
+    # from analytics and truncated by db/scripts/sanitise.sql before restored
+    # production dumps are used outside production. Production databases and
+    # backups remain subject to the usual controls for personal data.
     cache:
       mode: slow # cache only queries slower than slow_threshold
       expires_in: 60 # minutes

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,6 +1,6 @@
 default: &default
   store_options:
-    # Unused while Redis is the live cache_store. Cap matches Azure Redis C1 (1GB).
+    # Cap matches Azure Redis C1 (1GB) so the store does not grow past the old Redis size.
     max_age: <%= 30.days.to_i %>
     max_size: <%= 1.gigabytes %>
     namespace: <%= Rails.env %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,8 +69,8 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
-  # Redis remains the live store; solid_cache_entries lives on the primary DB for a later cutover.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL", "") }
+  # Solid Cache writes to solid_cache_entries on the primary DB. REDIS_CACHE_URL stays in Terraform until the Redis cache instance is removed.
+  config.cache_store = :solid_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque

--- a/spec/services/geolocation/address_resolver_spec.rb
+++ b/spec/services/geolocation/address_resolver_spec.rb
@@ -114,10 +114,16 @@ RSpec.describe Geolocation::AddressResolver do
 
       before do
         cache.write(address_resolver.cache_key, cached_hash, expires_in: cache_expiration)
+        allow(client).to receive(:geocode)
       end
 
       it "returns address from cached hash" do
         expect(address_resolver.call).to eq(cached_hash)
+      end
+
+      it "does not call the Google client" do
+        address_resolver.call
+        expect(client).not_to have_received(:geocode)
       end
 
       it "logs a cache hit" do

--- a/spec/services/geolocation/suggestions_spec.rb
+++ b/spec/services/geolocation/suggestions_spec.rb
@@ -35,11 +35,17 @@ RSpec.describe Geolocation::Suggestions do
 
       before do
         cache.write(suggestions_query.send(:cache_key), cached_suggestions)
+        allow(client).to receive(:autocomplete)
       end
 
       it "returns the cached suggestions" do
         expect(suggestions).to eq(cached_suggestions)
         expect(cache.read(suggestions_query.send(:cache_key))).to eq(cached_suggestions)
+      end
+
+      it "does not call the Google client" do
+        suggestions
+        expect(client).not_to have_received(:autocomplete)
       end
 
       it "logs a cache hit" do


### PR DESCRIPTION
## Context

Find location search and other `Rails.cache` reads now go to Postgres (`solid_cache_entries` on the primary DB) instead of Redis. First requests after deploy are a cold cache, so Google Places traffic will spike until the table fills. Worker Redis and feature flags are unchanged. Rollback is reverting `production.rb` — the Redis cache instance is still there.

## Changes proposed in this pull request

- Set `config.cache_store = :solid_cache_store` in `production.rb` (qa/review/staging inherit this)
- Stop reading `REDIS_CACHE_URL` in the app (Terraform still injects it)
- Spec that a cache hit does not call Google autocomplete / geocode

## Guidance to review

- `bundle exec rspec spec/services/geolocation/suggestions_spec.rb spec/services/geolocation/address_resolver_spec.rb spec/lib/error_reporting/rate_limiter_spec.rb spec/db/scripts_spec.rb`
- Confirm `production.rb` is `:solid_cache_store` and Terraform still has `REDIS_CACHE_URL`
- Confirm Sidekiq / `REDIS_WORKER_URL` / feature flags were not touched
