### PR TITLE
Allow us to test blazer by fixing the connection string

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -83,5 +83,27 @@ module ManageCoursesBackend
 
     # Insert the middlware at the end of the stack
     config.middleware.use RequestLoggingTags
+
+    # Blazer opens its own connection pool from this URL, so it has to describe
+    # the database the app is already using. Deriving it from the resolved
+    # config follows database.yml, DATABASE_URL and TEST_ENV_NUMBER without
+    # restating any of them.
+    #
+    # This has to be assigned at config time. Blazer's engine reads
+    # config/blazer.yml while the initializers run, so an initializer is too
+    # late. An unconnectable URL fails far more than Blazer, and silently:
+    # spec/config/blazer_spec.rb guards it.
+    def read_only_database_url
+      db = ActiveRecord::DatabaseConfigurations.new(config.database_configuration)
+        .configs_for(env_name: Rails.env, name: "primary")
+        .configuration_hash
+      userinfo = [db[:username], db[:password]].compact_blank.map { |part| ERB::Util.url_encode(part) }.join(":")
+      authority = [
+        ("#{userinfo}@" if userinfo.present?),
+        db[:host].presence && [db[:host], db[:port].presence].compact.join(":"),
+      ].compact.join
+
+      "postgres://#{authority}/#{db[:database]}"
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
 
   config.authentication_token = ENV.fetch("AUTHENTICATION_TOKEN", "bats")
 
-  config.x.read_only_database_url = "postgres://localhost/#{ENV.fetch('DB_DATABASE', 'manage_courses_backend_development')}"
+  config.x.read_only_database_url = Rails.application.read_only_database_url
 
   config.rails_semantic_logger.semantic   = false
   config.rails_semantic_logger.started    = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -77,5 +77,5 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
-  config.x.read_only_database_url = "postgres://localhost/#{ENV.fetch('DB_DATABASE', 'manage_courses_backend_test')}"
+  config.x.read_only_database_url = Rails.application.read_only_database_url
 end

--- a/spec/config/blazer_spec.rb
+++ b/spec/config/blazer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Blazer" do
+  it "can reach the database its data source points at" do
+    # A URL Blazer cannot connect to breaks the whole suite rather than just
+    # Blazer: it registers the pool, and setup_transactional_fixtures then pins
+    # every registered pool in every later example. Blazer stays quiet about it,
+    # rescuing the failure and rendering its query page anyway, so assert on the
+    # connection here.
+    result = Blazer.data_sources["main"].run_statement("SELECT 1 AS one")
+
+    expect(result.error).to be_nil
+    expect(result.rows).to eq([[1]])
+  end
+end


### PR DESCRIPTION
## Context

Both the test and development environments built Blazer's database URL by hand, and both got it wrong the same three ways: forced TCP to `localhost`, no credentials, no `TEST_ENV_NUMBER`. Blazer could not
connect from a bare metal test run, from CI, or from Docker development.

The surprise is the blast radius. An unreachable Blazer URL does not fail Blazer, it fails the whole suite: Blazer registers a connection pool the first time anything touches the data source,
`setup_transactional_fixtures` pins every registered pool, and every later example then dies with `fe_sendauth: no password supplied`. Nothing warns you, because Blazer's query form wraps the call in a bare
`rescue` and renders anyway. That is what broke CI after the user attribution change.

Standardising on `DATABASE_URL` was rejected: CI's URL deliberately omits the database name, and one variable cannot express a database per parallel process. Letting Blazer inherit `ActiveRecord::Base`'s pool
was rejected too, because its adapter builds an anonymous class that overrides `name`, so Rails cannot resolve a connection spec for a constant that does not exist.

## Changes proposed in this pull request

- The URL is derived once from the config Rails resolved for the current environment, so it follows `database.yml`, `DATABASE_URL` and `TEST_ENV_NUMBER` instead of restating them. Production is untouched.
- Blazer connects in test: bare metal, CI, and each parallel process against its own database.
- Blazer connects in Docker development, where Postgres is on host `db` behind a password. It never could before.
- A spec fails if the data source stops being reachable.

No UI changes.

## Guidance to review

`bundle exec rspec spec/config/blazer_spec.rb spec/models/session_spec.rb` is the pairing that reproduced the suite failure. `RAILS_ENV=test bundle exec rails runner 'puts
Rails.configuration.x.read_only_database_url'` prints the derived URL; repeat it with a CI-style `DATABASE_URL`, with `TEST_ENV_NUMBER=2`, and under `RAILS_ENV=development` with the Docker `DB_*` variables.

Two things I would like opinions on. The guard proves the connection works, not that it points at the right database, so a URL aimed at the server default would still pass it; asserting `SELECT
current_database()` would close that gap and I left it out. And `read_only_database_url` sits on the Application in `config/application.rb`, which holds no other methods, so say if you would rather see the
derivation duplicated per environment file or moved into `lib/`.

## Checklist

- [x] I have moved hard-coded strings to locale files. (No user-facing strings in this change.)
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests. (No HTML in this change.)
