### PR TITLE
Link and label ids in Blazer results

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -1,4 +1,10 @@
 override_csp: true
+
+# Blazer renders a query's creator as `creator.try(Blazer.user_name)`. Its
+# default is :name, which User does not respond to, so the whole column read
+# blank for everyone except the person looking at it.
+user_name: full_name
+
 data_sources:
   main:
     url: <%= Rails.configuration.x.read_only_database_url %>
@@ -20,3 +26,43 @@ data_sources:
       mode: slow # cache only queries slower than slow_threshold
       expires_in: 60 # minutes
       slow_threshold: 15 # seconds
+
+    # Turn values in results into links. Only {value} is interpolated, so a
+    # column can be linked only when its own value identifies the resource.
+    # That rules out provider_id: the publish route is keyed by provider_code,
+    # and the id-keyed support route also needs a recruitment cycle year.
+    linked_columns:
+      provider_code: "/publish/organisations/{value}"
+      accredited_provider_code: "/publish/organisations/{value}"
+      urn: "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/{value}"
+
+    # Show a name next to a value, so queries stop joining purely to make their
+    # own output readable. Blazer adds the name as a second line in the cell and
+    # leaves the raw value in place, and runs these once per result set with
+    # {value} bound to the distinct values in that column.
+    #
+    # provider_code repeats per recruitment cycle, so the accredited lookup takes
+    # the name from the most recent cycle the code appears in.
+    smart_columns:
+      provider_id: "SELECT id, provider_name FROM provider WHERE id IN {value}"
+      accredited_provider_code: "SELECT DISTINCT ON (provider_code) provider_code, provider_name FROM provider WHERE provider_code IN {value} ORDER BY provider_code, recruitment_cycle_id DESC"
+      course_id: "SELECT id, name || ' (' || course_code || ')' FROM course WHERE id IN {value}"
+
+    # Back these variables with dropdowns. Inert until a query uses one, which
+    # none do yet: 89 of the 164 saved queries hardcode a cycle year instead,
+    # which is why the query list grows by about thirty every rollover.
+    smart_variables:
+      recruitment_cycle_year: "SELECT year, year FROM recruitment_cycle ORDER BY year DESC"
+      provider_code: "SELECT DISTINCT provider_code, provider_name FROM provider ORDER BY provider_name"
+
+    # Without a default Blazer refuses to run a parameterised query until you
+    # pick from the dropdown, which is a worse first experience than the
+    # hardcoded years these variables replace.
+    #
+    # This is the cycle the app is running, not the newest row in
+    # recruitment_cycle: that is next year's, and mostly empty. It has to be a
+    # literal, because Blazer reads this file once at boot and a query here
+    # would run during assets:precompile, which has no database. Update it at
+    # rollover; spec/config/blazer_spec.rb fails until you do.
+    variable_defaults:
+      recruitment_cycle_year: "2026"

--- a/spec/config/blazer_spec.rb
+++ b/spec/config/blazer_spec.rb
@@ -3,15 +3,63 @@
 require "rails_helper"
 
 RSpec.describe "Blazer" do
+  let(:data_source) { Blazer.data_sources["main"] }
+
   it "can reach the database its data source points at" do
     # A URL Blazer cannot connect to breaks the whole suite rather than just
     # Blazer: it registers the pool, and setup_transactional_fixtures then pins
     # every registered pool in every later example. Blazer stays quiet about it,
     # rescuing the failure and rendering its query page anyway, so assert on the
     # connection here.
-    result = Blazer.data_sources["main"].run_statement("SELECT 1 AS one")
+    result = data_source.run_statement("SELECT 1 AS one")
 
     expect(result.error).to be_nil
     expect(result.rows).to eq([[1]])
+  end
+
+  it "can run every smart column and smart variable lookup" do
+    # These name tables and columns in config/blazer.yml, where nothing checks
+    # them. A typo surfaces as an empty dropdown or an unresolved id, months
+    # later, to whoever is mid-investigation.
+    lookups = data_source.smart_columns.values.map { |sql| sql.sub("{value}", "(NULL)") } +
+      data_source.smart_variables.values
+
+    expect(lookups).not_to be_empty
+
+    lookups.each do |sql|
+      expect(data_source.run_statement(sql).error).to be_nil, "#{sql.inspect} failed"
+    end
+  end
+
+  it "names query creators with a method User actually has" do
+    # Blazer renders creators as `creator.try(Blazer.user_name)`, so a name it
+    # does not respond to fails silently and the column is blank for everyone
+    # but you. Blazer's own default, :name, is one of those.
+    expect(User.new).to respond_to(Blazer.user_name)
+  end
+
+  it "defaults the recruitment cycle to the one the app is running" do
+    # variable_defaults is a static hash read once at boot, so it cannot follow
+    # the cycle on its own. This fails at the next rollover, which is the point:
+    # the build tells you to change the one line rather than everyone quietly
+    # querying last year.
+    expect(data_source.variable_defaults["recruitment_cycle_year"])
+      .to eq(Find::CycleTimetable.current_year.to_s)
+  end
+
+  it "links columns to paths the app serves" do
+    # Blazer only interpolates {value}, so a linked column has to name a route
+    # keyed on that column alone. Blazer is mounted on the publish host, so
+    # recognise the paths against it.
+    host = Settings.publish_hosts.first
+    paths = data_source.linked_columns.values.grep_v(%r{\Ahttps?://})
+
+    expect(paths).not_to be_empty
+
+    paths.each do |path|
+      recognised = Rails.application.routes.recognize_path("http://#{host}#{path.sub('{value}', 'ABC')}", method: :get)
+
+      expect(recognised).to be_present, "#{path.inspect} is not a route"
+    end
   end
 end


### PR DESCRIPTION
## Context

  Blazer results are full of ids that people copy out and paste into the address bar, and several queries join to `provider` or `course` purely so their own output is readable. Blazer does both jobs from config,
  so this turns them on.

  The catch is that `linked_columns` interpolates only `{value}`, and url-escapes it. A column can be linked only when its own value identifies the resource, which rules out `provider_id` entirely: the Publish
  route is keyed by provider code, and the id-keyed Support route also needs a recruitment cycle year. `provider_id` is handled as a smart column instead, which is the better answer anyway, since it removes the
  join rather than just shortening the copy and paste.

  Two things were rejected. A `recruitment_cycle_id` smart column, because no query actually selects that column. And computing the cycle default instead of hardcoding it, because `Blazer.settings` loads at boot
  and `Dockerfile:69` precompiles assets with no database; a spec pins the literal to `Find::CycleTimetable.current_year` so it fails at rollover rather than drifting.

  `user_name` is a bug fix riding along. Blazer defaults it to `:name`, which `User` does not respond to, so the creator column read blank for everyone except the person looking at it. That was invisible until the
  attribution fix started recording creators.

  ## Changes proposed in this pull request

  - Provider codes, accredited provider codes and URNs are links, to Publish and to GIAS.
  - Provider ids, accredited provider codes and course ids show a name under the raw value. The value stays put, and CSV exports are unchanged.
  - Queries can take a cycle from a dropdown with `{recruitment_cycle_year}`, defaulting to the current cycle so a parameterised query still runs on open.
  - Query creators render their names.
  - Specs run every lookup and recognise every internal link, so a mistake in the YAML fails the build instead of surfacing as an empty dropdown months later.

  ## Guidance to review

  `bundle exec rspec spec/config/blazer_spec.rb`. To see it, visit `/blazer` and open query 408, which selects `provider_id` and `provider_code`: the code should link to the provider in Publish and the id should
  carry the provider name beneath it. The Docs link on any query page lists everything configured.

  Two things I would like an opinion on. The `provider_code` dropdown holds around 2,854 entries, which select2 searches fine but is large. And whether `urn` earns its linked column: only three of the 45 queries
  marked keep output one, though they are the site duplication queries that get re-run most.
## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
