### PR TITLE
Offer rollover on any course that has not been rolled over

### DIFF
--- a/app/controllers/publish/courses/draft_rollover_controller.rb
+++ b/app/controllers/publish/courses/draft_rollover_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Courses
     class DraftRolloverController < ApplicationController
-      before_action :redirect_to_courses, if: -> { course.is_published? }
+      before_action :redirect_to_courses, unless: -> { course.manually_rollable? }
 
       def edit
         @course_rollover_form = CourseRolloverForm.new(course)

--- a/app/forms/publish/course_rollover_form.rb
+++ b/app/forms/publish/course_rollover_form.rb
@@ -15,7 +15,7 @@ module Publish
   private
 
     def course_is_rollable?
-      return false if %i[draft empty rolled_over].include? course.content_status
+      return if course.manually_rollable?
 
       errors.add(:course_is_rollable)
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -446,9 +446,7 @@ class Course < ApplicationRecord
   end
 
   def manually_rollable?
-    rollover_conditions = !rolled_over? && RecruitmentCycle.upcoming_cycles_open_to_publish? && recruitment_cycle == RecruitmentCycle.current
-
-    rollover_conditions && %i[empty draft rolled_over].include?(content_status)
+    !rolled_over? && RecruitmentCycle.upcoming_cycles_open_to_publish? && recruitment_cycle == RecruitmentCycle.current
   end
 
   def rolled_over?

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -5,12 +5,19 @@
 <div class="govuk-button-group">
   <%= govuk_link_to course.application_status_closed? ? "Open course" : "Close course", application_status_publish_provider_recruitment_cycle_course_path, class: "govuk-button govuk-!-margin-right-2" %>
 
+  <% if course.manually_rollable? %>
+    <%= govuk_button_to("Roll over course", rollover_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                      class: " govuk-button--secondary govuk-!-margin-right-2",
+                      data: { qa: "course__rollover" },
+                      method: :get) %>
+  <% end %>
+
   <% if Courses::PublishRules::LiveOnFind.applies?(course, content_status: course.content_status) %>
     <%= govuk_link_to find_course_url(course.provider_code, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
-    <%= t(".view_live_course") %> <span class="govuk-visually-hidden"><%= t(".hidden_text") %></span>
+      <%= t(".view_live_course") %> <span class="govuk-visually-hidden"><%= t(".hidden_text") %></span>
     <% end %>
   <% else %>
-   <%= govuk_link_to t(".preview_course"), preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
+    <%= govuk_link_to t(".preview_course"), preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
   <% end %>
 
   <%= govuk_link_to t(".withdraw_course"), withdraw_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive govuk-!-margin-right-2", data: { qa: "course__withdraw-link" } %>

--- a/app/views/publish/courses/course_button_panel/_withdrawn.html.erb
+++ b/app/views/publish/courses/course_button_panel/_withdrawn.html.erb
@@ -1,6 +1,12 @@
 <span class="govuk-hint govuk-!-font-size-16" data-qa="course__withdrawn_date">
   Withdrawn on <%= l(course.withdrawn_at.to_time, format: :last_event) %>
 </span>
-<p class="govuk-body">
-<%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__preview-link" } %>
-</p>
+<div class="govuk-button-group">
+  <% if course.manually_rollable? %>
+    <%= govuk_button_to("Roll over course", rollover_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                      class: " govuk-button--secondary govuk-!-margin-right-2",
+                      data: { qa: "course__rollover" },
+                      method: :get) %>
+  <% end %>
+  <%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__preview-link" } %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -988,7 +988,7 @@ en:
         publish/course_rollover_form:
           attributes:
             course_is_rollable:
-              invalid: "Course must have draft, empty or rolled over status."
+              invalid: "This course cannot be rolled over into the next recruitment cycle."
         publish/course_funding_form:
           attributes:
             funding:

--- a/spec/forms/publish/course_rollover_form_spec.rb
+++ b/spec/forms/publish/course_rollover_form_spec.rb
@@ -12,8 +12,12 @@ module Publish
 
     subject { described_class.new(course) }
 
+    before do
+      find_or_create(:recruitment_cycle, :next).update(available_in_publish_from: 1.day.ago)
+    end
+
     describe "draft course" do
-      let(:course) { build(:course, enrichments: [draft_enrichment]) }
+      let(:course) { create(:course, enrichments: [draft_enrichment]) }
 
       it "is valid" do
         expect(subject).to be_valid
@@ -39,25 +43,53 @@ module Publish
     describe "published course" do
       let(:course) { create(:course, enrichments: [published_enrichment]) }
 
-      it "is invalid" do
-        expect(subject).not_to be_valid
+      it "is valid" do
+        expect(subject).to be_valid
       end
     end
 
     describe "legacy subsequent draft course" do
       let(:course) { create(:course, enrichments: [unpublished_changes_enrichment]) }
 
-      it "is invalid" do
-        expect(subject).not_to be_valid
+      it "is valid" do
+        expect(subject).to be_valid
       end
     end
 
     describe "withdrawn course" do
       let(:course) { create(:course, enrichments: [withdrawn_enrichment]) }
 
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    describe "course that has already been rolled over" do
+      let(:course) { create(:course, enrichments: [published_enrichment]) }
+
+      before do
+        create(
+          :course,
+          course_code: course.course_code,
+          provider: create(:provider, recruitment_cycle: RecruitmentCycle.next, provider_code: course.provider.provider_code),
+        )
+      end
+
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors[:course_is_rollable]).to include "Course must have draft, empty or rolled over status."
+        expect(subject.errors[:course_is_rollable]).to include "This course cannot be rolled over into the next recruitment cycle."
+      end
+    end
+
+    describe "course in a cycle that is not open for rollover" do
+      let(:course) { create(:course, enrichments: [published_enrichment]) }
+
+      before do
+        RecruitmentCycle.next.update(available_in_publish_from: 1.day.from_now)
+      end
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -652,6 +652,26 @@ describe Course do
         end
       end
 
+      context "when the course is published" do
+        before do
+          find_or_create(:recruitment_cycle, :next).update(available_in_publish_from: 1.day.ago)
+        end
+
+        it "returns true" do
+          expect(create(:course, enrichments: [build(:course_enrichment, :published)])).to be_manually_rollable
+        end
+      end
+
+      context "when the course is withdrawn" do
+        before do
+          find_or_create(:recruitment_cycle, :next).update(available_in_publish_from: 1.day.ago)
+        end
+
+        it "returns true" do
+          expect(create(:course, enrichments: [build(:course_enrichment, :withdrawn)])).to be_manually_rollable
+        end
+      end
+
       context "when next cycle is available for publish users but course was already rolled over" do
         let(:course) { create(:course) }
 

--- a/spec/system/publish/viewing_a_course_spec.rb
+++ b/spec/system/publish/viewing_a_course_spec.rb
@@ -120,6 +120,36 @@ RSpec.describe "Course show" do
     end
   end
 
+  # A provider that publishes a course after the rollover has already run needs
+  # to be able to roll that course over itself, so the button is offered on
+  # published and withdrawn courses too for as long as they have not been rolled
+  # over already.
+  describe "with a published course and an open next cycle" do
+    scenario "i can roll the course over" do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, :salary, enrichments: [course_enrichment], application_status: "open", site_statuses: [build(:site_status, :findable)]))
+      given_there_is_a_next_recruitment_cycle
+      and_the_cycle_is_rollable
+      when_i_visit_the_course_page
+      and_i_click_the_roll_over_course_button
+      then_i_see_the_rollover_confirmation_page
+      when_i_confirm_the_rollover
+      then_i_should_see_the_course_show_page_with_success_message
+    end
+  end
+
+  describe "with a withdrawn course and an open next cycle" do
+    scenario "i can roll the course over" do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_withdrawn]))
+      given_there_is_a_next_recruitment_cycle
+      and_the_cycle_is_rollable
+      when_i_visit_the_course_page
+      and_i_click_the_roll_over_course_button
+      then_i_see_the_rollover_confirmation_page
+      when_i_confirm_the_rollover
+      then_i_should_see_the_course_show_page_with_success_message
+    end
+  end
+
   describe "rollover with an empty course" do
     scenario "i can see the success message and link" do
       given_i_am_authenticated_as_a_provider_user(course: create(:course, enrichments: [], funding_type: "salary"))
@@ -203,6 +233,18 @@ private
 
   def when_i_click_the_rollover_course_button
     rollover_form_page.rollover_course_button.click
+  end
+
+  def and_i_click_the_roll_over_course_button
+    click_link_or_button "Roll over course"
+  end
+
+  def then_i_see_the_rollover_confirmation_page
+    expect(page).to have_content "Are you sure you want to roll over the course into the next recruitment cycle?"
+  end
+
+  def when_i_confirm_the_rollover
+    click_link_or_button "Roll over course"
   end
 
   def then_i_should_see_the_rollover_form_page


### PR DESCRIPTION
## Context

### Providers cannot roll over a course they publish after their rollover has run

Manual rollover was for courses a provider had not published: draft, empty and already rolled over courses could be rolled over one at a time, and anything published was left to the bulk rollover. A provider who creates and publishes a course after their organisation has been rolled over falls outside that, so the course has no route into the next cycle and support has to move it by hand.

The rule now turns on the destination rather than the course's content status. A course can be rolled over if it is not in the next cycle already, is in the current cycle, and there is an upcoming cycle open to publish. Every content status passes that, so the status lists in the model, the controller and the form no longer exclude anything and all three now call a single `Course#manually_rollable?`.

The controller and the form guard different requests. The redirect keeps the confirmation page from rendering for a course that cannot be rolled over, and the validation refuses the submission however the request reached it.

Nothing below the controller stops a second rollover. The endpoint calls `RolloverProviderService` with `force: true`, which bypasses `Provider#rollable?`, so `manually_rollable?` is the only check standing between a stale page and a duplicate course in the next cycle.

## Changes proposed in this pull request

- The "Roll over course" button appears on published and withdrawn courses that have not been rolled over, alongside the draft and empty courses that already had it.
- `Publish::Courses::DraftRolloverController` redirects to the course list unless the course is manually rollable, rather than only when it is published.
- `Publish::CourseRolloverForm` validates the same condition, so a POST for a course already present in the next cycle is rejected.
- The validation message changes from "Course must have draft, empty or rolled over status." to "This course cannot be rolled over into the next recruitment cycle."
- The withdrawn panel's preview link sits in the button group rather than in a `<p>` inside it, matching the unpublished panel.

## Guidance to review

```
bundle exec rspec spec/models/course_spec.rb spec/forms/publish/course_rollover_form_spec.rb spec/system/publish/viewing_a_course_spec.rb
```

To check it by hand, sign in as a provider persona, make sure the next recruitment cycle exists with `available_in_publish_from` in the past, then open a published course and a withdrawn course from the courses list. Both offer "Roll over course", and the confirmation page ends on "Course rolled over". Open the same course again and the button is gone.

The withdrawn case is the part I am least sure of. A withdrawn course rolls into the next cycle as a copy the provider then has to publish or withdraw again, and I do not know whether that is wanted or whether the ask covered published courses only. The shared `manually_rollable?` is worth a second opinion too: a change to the button's condition now changes what the endpoint accepts.
