### PR TITLE
Blocking bots on our feedback form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,9 @@ gem "http"
 # For configuring domains and assets
 gem "rack-cors"
 
+# Honeypot spam protection for unauthenticated forms
+gem "invisible_captcha"
+
 # Rails console colours
 gem "colorize"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,6 +362,8 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
+    invisible_captcha (2.3.0)
+      rails (>= 5.2)
     io-console (0.9.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -860,6 +862,7 @@ DEPENDENCIES
   govuk_notify_rails
   http
   httparty
+  invisible_captcha
   jsbundling-rails (~> 1.3)
   jsonapi-rails!
   jsonapi-rb

--- a/app/controllers/find/feedbacks_controller.rb
+++ b/app/controllers/find/feedbacks_controller.rb
@@ -1,5 +1,10 @@
 module Find
   class FeedbacksController < ApplicationController
+    invisible_captcha only: :create,
+                      honeypot: :subject,
+                      scope: :feedback,
+                      on_spam: :discard_spam
+
     def new
       @feedback = Feedback.new
     end
@@ -18,6 +23,10 @@ module Find
     end
 
   private
+
+    def discard_spam
+      redirect_to find_root_path, flash: { success: t("find.feedbacks.create.success") }
+    end
 
     def feedback_form_params
       params.require(:feedback).permit(:ease_of_use, :experience)

--- a/app/views/find/feedbacks/new.html.erb
+++ b/app/views/find/feedbacks/new.html.erb
@@ -22,6 +22,7 @@
             hint: { text: t(".experience_hint") },
             rows: 5,
             max_chars: Feedback::MAX_EXPERIENCE_LENGTH %>
+      <%= invisible_captcha :subject, :feedback, nonce: true %>
       <%= f.govuk_submit t(".submit_feedback_button") %>
     <% end %>
   </div>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,5 +25,5 @@ Rails.application.configure do
   end
 
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w[script-src]
+  config.content_security_policy_nonce_directives = %w[script-src style-src]
 end

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+InvisibleCaptcha.setup do |config|
+  config.spinner_enabled = false
+  config.timestamp_enabled = false
+end

--- a/spec/requests/find/feedbacks_spec.rb
+++ b/spec/requests/find/feedbacks_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Find feedback form", service: :find, type: :request do
+  let(:valid_feedback) { { ease_of_use: "very_easy", experience: "Great experience!" } }
+
+  describe "POST /feedback" do
+    it "saves feedback when the honeypot is empty" do
+      get new_find_feedback_path
+
+      expect {
+        post find_feedback_path, params: { feedback: valid_feedback.merge(subject: "") }
+      }.to change(Feedback, :count).by(1)
+
+      expect(response).to redirect_to(find_root_path)
+    end
+
+    it "discards feedback when the honeypot is filled" do
+      get new_find_feedback_path
+
+      expect {
+        post find_feedback_path, params: { feedback: valid_feedback.merge(subject: "http://spam.example") }
+      }.not_to change(Feedback, :count)
+
+      expect(response).to redirect_to(find_root_path)
+      expect(flash[:success]).to eq(I18n.t("find.feedbacks.create.success"))
+    end
+
+    it "saves feedback corrected straight after a validation error" do
+      get new_find_feedback_path
+      post find_feedback_path, params: { feedback: valid_feedback.merge(ease_of_use: "") }
+
+      expect {
+        post find_feedback_path, params: { feedback: valid_feedback }
+      }.to change(Feedback, :count).by(1)
+    end
+
+    it "saves a second submission made without reloading the form" do
+      get new_find_feedback_path
+      post find_feedback_path, params: { feedback: valid_feedback }
+
+      expect {
+        post find_feedback_path, params: { feedback: valid_feedback.merge(experience: "More thoughts") }
+      }.to change(Feedback, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Bots are polluting feedback data which needs a monthly manual clean-up. 

https://trello.com/c/NSBD9dAD/1931-blocking-bots-on-our-feedback-form

## Changes proposed in this pull request

Add honeypot input field which is invisible to users but blocks bots if submitted.

Detected bots get the ordinary success page, so they can't tell they were blocked. 

## Guidance to review

Check http://find.localhost:3001/feedback/new and confirm the honeypot is invisible and the console clean.

<img width="1144" height="111" alt="Screenshot 2026-09-07 at 14 41 58" src="https://github.com/user-attachments/assets/ae168212-54d4-46b2-b069-ce9180680cb5" />


## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
