### PR TITLE
Add stylelint-order to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "stylelint-config-recess-order": "^6.1.0",
     "stylelint-config-standard": "^40.0.0",
     "stylelint-config-standard-scss": "^17.0.0",
+    "stylelint-order": "^8.1.1",
     "stylelint-selector-bem-pattern": "^5.0.0",
     "vitest": "^4.1.11"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,6 +4467,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-sorting@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "postcss-sorting@npm:10.0.0"
+  peerDependencies:
+    postcss: ^8.4.20
+  checksum: 10c0/2e53560ccfaefb6ccfaa44cd258735f815de7a06ff6c79e6fb0fe789422f10242266044902c716e2eec9680879d7e0872b4ecd5d89e9bd8670f6d9f6c3ce5adc
+  languageName: node
+  linkType: hard
+
 "postcss-sorting@npm:^8.0.2":
   version: 8.0.2
   resolution: "postcss-sorting@npm:8.0.2"
@@ -5385,6 +5394,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stylelint-order@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "stylelint-order@npm:8.1.1"
+  dependencies:
+    postcss: "npm:^8.5.8"
+    postcss-sorting: "npm:^10.0.0"
+  peerDependencies:
+    stylelint: ^16.18.0 || ^17.0.0
+  checksum: 10c0/ef135a414d3ed98a53cc19e52f1cdff25105e34d96430ecc805d831dbdf4f505031d692dba0f2275b6e7b3a4f4b406f352d85a3924e2e3d89931af65a64eb047
+  languageName: node
+  linkType: hard
+
 "stylelint-scss@npm:^6.4.0":
   version: 6.11.1
   resolution: "stylelint-scss@npm:6.11.1"
@@ -5573,6 +5594,7 @@ __metadata:
     stylelint-config-recess-order: "npm:^6.1.0"
     stylelint-config-standard: "npm:^40.0.0"
     stylelint-config-standard-scss: "npm:^17.0.0"
+    stylelint-order: "npm:^8.1.1"
     stylelint-selector-bem-pattern: "npm:^5.0.0"
     vitest: "npm:^4.1.11"
   languageName: unknown


### PR DESCRIPTION
## Context

The stylelint-config-recess-order package requires stylelint-order to be installed as a dependency

https://github.com/stormwarning/stylelint-config-recess-order#usage

## Changes proposed in this pull request

`yarn install stylelint-order`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
