### PR TITLE
Update GiT colours to match the rebrand

### DIFF
--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -27,7 +27,7 @@ body:not(.js-enabled) {
 
 .course-accordion .govuk-accordion__section {
   background-color: govuk-colour("light-grey");
-  border-left: govuk-spacing(1) solid govuk-colour("purple");
+  border-left: govuk-spacing(1) solid $git-non-uk-colour;
 }
 
 .course-accordion .govuk-accordion__section-header {
@@ -52,5 +52,5 @@ body:not(.js-enabled) {
 
 .course-accordion .govuk-accordion__section--orange {
   background-color: govuk-colour("light-grey");
-  border-left: govuk-spacing(1) solid govuk-colour("orange");
+  border-left: govuk-spacing(1) solid $git-brand-colour;
 }

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -27,7 +27,11 @@ body:not(.js-enabled) {
 
 .course-accordion .govuk-accordion__section {
   background-color: govuk-colour("light-grey");
-  border-left: govuk-spacing(1) solid $git-non-uk-colour;
+  border-left: govuk-spacing(1) solid transparent;
+}
+
+.course-accordion .govuk-accordion__section--pink {
+  border-left-color: $git-non-uk-colour;
 }
 
 .course-accordion .govuk-accordion__section-header {
@@ -50,7 +54,6 @@ body:not(.js-enabled) {
   padding-left: govuk-spacing(4);
 }
 
-.course-accordion .govuk-accordion__section--orange {
-  background-color: govuk-colour("light-grey");
-  border-left: govuk-spacing(1) solid $git-brand-colour;
+.course-accordion .govuk-accordion__section--purple {
+  border-left-color: $git-brand-colour;
 }

--- a/app/assets/stylesheets/components/_callout.scss
+++ b/app/assets/stylesheets/components/_callout.scss
@@ -10,8 +10,8 @@
     border-color: $git-support-colour;
   }
 
-  &.app-callout--orange {
-    border-color: govuk-colour("orange");
+  &.app-callout--purple {
+    border-color: $git-brand-colour;
   }
 
   &.app-callout--blue {

--- a/app/assets/stylesheets/components/_callout.scss
+++ b/app/assets/stylesheets/components/_callout.scss
@@ -6,7 +6,7 @@
   background-color: govuk-colour("light-grey");
   border-left-width: govuk-spacing(1);
 
-  &.app-callout--pink {
+  &.app-callout--light-purple {
     border-color: $git-support-colour;
   }
 

--- a/app/assets/stylesheets/components/_callout.scss
+++ b/app/assets/stylesheets/components/_callout.scss
@@ -7,7 +7,7 @@
   border-left-width: govuk-spacing(1);
 
   &.app-callout--pink {
-    border-color: govuk-colour("pink");
+    border-color: $git-support-colour;
   }
 
   &.app-callout--orange {

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -12,8 +12,8 @@
   }
 }
 
-.app-card--inset {
-  border-left: govuk-spacing(1) solid govuk-colour("orange");
+.app-card--purple {
+  border-left: govuk-spacing(1) solid $git-brand-colour;
 }
 
 .app-card--blue {

--- a/app/assets/stylesheets/find/components/_accordion.scss
+++ b/app/assets/stylesheets/find/components/_accordion.scss
@@ -17,7 +17,7 @@ body:not(.js-enabled) {
     padding-bottom: govuk-spacing(1);
 
     background-color: govuk-colour("light-grey");
-    border-left: 5px solid govuk-colour("orange");
+    border-left: 5px solid $git-brand-colour;
   }
 
   .govuk-accordion__section-heading {

--- a/app/assets/stylesheets/govuk_style_setup.scss
+++ b/app/assets/stylesheets/govuk_style_setup.scss
@@ -8,4 +8,7 @@ $mobile-small-start: 400px;
 $mobile-small-end: 401px;
 $mobile-big-start: 500px;
 $mobile-big-end: 501px;
-$git-brand-colour: govuk-colour("orange");
+// Get Into Teaching rebrand colours
+$git-brand-colour: #54319f;
+$git-non-uk-colour: #ca357c;
+$git-support-colour: #aa98cf;

--- a/app/assets/stylesheets/publish/components/_dynamic_preview.scss
+++ b/app/assets/stylesheets/publish/components/_dynamic_preview.scss
@@ -18,7 +18,7 @@
   border-top: 0;
   border-right: 0;
   border-bottom: 0;
-  border-left: 5px solid #f47738;
+  border-left: 5px solid $git-brand-colour;
 }
 
 .app-notification-banner--non-uk {
@@ -27,7 +27,7 @@
   border-top: 0;
   border-right: 0;
    border-bottom: 0;
-  border-left: 5px solid #4c2c92;
+  border-left: 5px solid $git-non-uk-colour;
 }
 
 .app-notification-banner--flight-check {

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -93,7 +93,7 @@
     <% end %>
 
     <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-      <%= accordion.with_section(heading_text: content_tag(:h3, t("find.get_into_teaching.qualifications_outside_uk"), class: "govuk-heading-m")) do %>
+      <%= accordion.with_section(heading_text: content_tag(:h3, t("find.get_into_teaching.qualifications_outside_uk"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--pink" }) do %>
         <p class="govuk-body"><%= t("find.get_into_teaching.qualifications_outside_uk_body") %> </p>
 
         <p class="govuk-body">

--- a/app/components/shared/advice_component/view.html.erb
+++ b/app/components/shared/advice_component/view.html.erb
@@ -1,4 +1,4 @@
-<aside class="app-callout app-callout--orange">
+<aside class="app-callout app-callout--purple">
   <h3 class="app-callout__title"><%= title %></h3>
 
   <%= content %>

--- a/app/components/shared/courses/financial_support/bursary_component/view.html.erb
+++ b/app/components/shared/courses/financial_support/bursary_component/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--orange" }) do %>
+  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--purple" }) do %>
     <div>
       <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
         <h4 class="govuk-heading-s"><%= t("find.financial_support.bursaries") %></h4>
@@ -17,7 +17,7 @@
 <% end %>
 
 <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.non_uk_citizens.title"), class: "govuk-heading-m")) do %>
+  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.non_uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--pink" }) do %>
     <div>
 
       <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>

--- a/app/components/shared/courses/financial_support/scholarship_and_bursary_component/view.html.erb
+++ b/app/components/shared/courses/financial_support/scholarship_and_bursary_component/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--orange" }) do %>
+  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--purple" }) do %>
     <div>
       <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
         <h4 class="govuk-heading-s"><%= t("find.financial_support.bursary_and_scholarships") %></h4>
@@ -17,7 +17,7 @@
 <% end %>
 
 <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.non_uk_citizens.title"), class: "govuk-heading-m")) do %>
+  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.non_uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--pink" }) do %>
     <div>
 
       <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>

--- a/app/views/find/courses/_advice.html.erb
+++ b/app/views/find/courses/_advice.html.erb
@@ -1,4 +1,4 @@
-<div id="section-advice-and-support" class="app-callout app-callout--border app-callout--pink">
+<div id="section-advice-and-support" class="app-callout app-callout--border app-callout--light-purple">
   <h2 id="section-advice" class="app-callout__title"><%= t(".heading") %></h2>
 
   <span class="govuk-body">

--- a/app/views/find/courses/_tda_advice.html.erb
+++ b/app/views/find/courses/_tda_advice.html.erb
@@ -1,4 +1,4 @@
-<div class="app-callout app-callout--border app-callout--pink">
+<div class="app-callout app-callout--border app-callout--light-purple">
   <h2 id="section-advice" class="app-callout__title"><%= t(".heading") %></h2>
 
   <div class="govuk-body">

--- a/app/views/find/courses/school_experience_interstitial.html.erb
+++ b/app/views/find/courses/school_experience_interstitial.html.erb
@@ -51,7 +51,7 @@
       </p>
     </div>
 
-    <%= govuk_inset_text classes: "app-callout app-callout--orange govuk-!-margin-top-0" do %>
+    <%= govuk_inset_text classes: "app-callout app-callout--purple govuk-!-margin-top-0" do %>
       <h2 class="govuk-heading-m"><%= t("find.courses.confirm_apply.school_experience_interruption.salaried_callout_heading") %></h2>
       <p class="govuk-body"><%= t("find.courses.confirm_apply.school_experience_interruption.salaried_callout_body_one") %></p>
       <p class="govuk-body">
@@ -78,7 +78,7 @@
       </p>
     <% end %>
 
-    <%= govuk_inset_text classes: "app-callout app-callout--orange govuk-!-margin-top-4" do %>
+    <%= govuk_inset_text classes: "app-callout app-callout--purple govuk-!-margin-top-4" do %>
       <h2 class="govuk-heading-m"><%= t("find.courses.confirm_apply.school_experience_interruption.adviser_callout_heading") %></h2>
       <p class="govuk-body govuk-!-margin-bottom-0">
         <%= t(

--- a/app/views/find/courses/training_with_disabilities/show.html.erb
+++ b/app/views/find/courses/training_with_disabilities/show.html.erb
@@ -23,7 +23,7 @@
       ) %>
     </p>
 
-    <%= govuk_inset_text classes: "app-callout app-callout--orange app-callout--min-height govuk-!-margin-top-0" do %>
+    <%= govuk_inset_text classes: "app-callout app-callout--purple app-callout--min-height govuk-!-margin-top-0" do %>
       <h3><%= t(".funding_and_support") %></h3>
 
       <p><%= t(".neurodivergent_html", link: govuk_link_to(t(".neurodivergent_link_text"), find_track_click_path(utm_content: "training_disabilities_neurodivergent", url: t(".neurodivergent_link")))) %>.</p>

--- a/app/views/find/homepage/index.html.erb
+++ b/app/views/find/homepage/index.html.erb
@@ -150,14 +150,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
-    <%= govuk_inset_text classes: "app-callout app-callout--pink app-callout--min-height govuk-!-margin-top-0" do %>
+    <%= govuk_inset_text classes: "app-callout app-callout--light-purple app-callout--min-height govuk-!-margin-top-0" do %>
       <h3><%= t("find.search.become_a_teacher") %></h3>
       <%= t("find.search.become_a_teacher_html", link: govuk_link_to(t("find.search.become_a_teacher_link_text"), find_track_click_path(utm_content: "become_a_teacher", url: t("get_into_teaching.url_become_a_teacher")))) %>
     <% end %>
   </div>
 
   <div class="govuk-grid-column-one-half">
-    <%= govuk_inset_text classes: "app-callout app-callout--pink app-callout--min-height govuk-!-margin-top-0" do %>
+    <%= govuk_inset_text classes: "app-callout app-callout--light-purple app-callout--min-height govuk-!-margin-top-0" do %>
       <h3><%= t("find.search.get_help_and_support") %></h3>
       <%= t("find.search.get_help_and_support_html", link: govuk_link_to(t("find.search.get_help_and_support_link_text"), find_track_click_path(utm_content: "get_help_and_support", url: t("get_into_teaching.url_help_and_support")))) %>
     <% end %>

--- a/app/views/find/results/courses_guidance/_show.html.erb
+++ b/app/views/find/results/courses_guidance/_show.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-inset-text app-card app-card--inset">
+<div class="govuk-inset-text app-card app-card--inset app-card--purple">
   <p class="govuk-body">
     <%= govuk_link_to t(".links.choose_course"), find_track_click_path(url: t("find.get_into_teaching.url_choose_course")) %>
   </p>

--- a/app/views/shared/courses/financial_support/_loan.html.erb
+++ b/app/views/shared/courses/financial_support/_loan.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--orange" }) do %>
+  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--purple" }) do %>
     <div>
       <h4 class="govuk-heading-s"><%= t("find.financial_support.student_loans") %></h4>
 
@@ -10,7 +10,7 @@
 <% end %>
 
 <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.non_uk_citizens.title"), class: "govuk-heading-m")) do %>
+  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.non_uk_citizens.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--pink" }) do %>
     <div>
       <p class="govuk-body"><%= t("find.financial_support.non_uk_citizens.unlikely_to_get_help") %></p>
       <p class="govuk-body"><%= govuk_link_to(t("find.financial_support.non_uk_citizens.what_support"), find_track_click_path(utm_content: "non_uk_citizens_loans_non_uk_trainees", url: t("find.get_into_teaching.url_non_uk_trainees"))) %></p>

--- a/app/views/shared/courses/financial_support/_salaried.html.erb
+++ b/app/views/shared/courses/financial_support/_salaried.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.uk_citizens.salaried_courses.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--orange" }) do %>
+  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.uk_citizens.salaried_courses.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--purple" }) do %>
     <div class="course-salary-details">
       <p class="govuk-body"><%= t("find.financial_support.uk_citizens.salaried_courses.competitive") %></p>
       <h4 class="govuk-heading-s"><%= t("find.financial_support.uk_citizens.salaried_courses.salary_heading") %></h4>
@@ -17,7 +17,7 @@
   <% end %>
 <% end %>
 <%= govuk_accordion(html_attributes: { class: "accordion-without-controls course-accordion" }) do |accordion| %>
-  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.non_uk_citizens.salaried_courses.title"), class: "govuk-heading-m")) do %>
+  <%= accordion.with_section(heading_text: content_tag(:h3, t("find.financial_support.non_uk_citizens.salaried_courses.title"), class: "govuk-heading-m"), html_attributes: { class: "govuk-accordion__section--pink" }) do %>
     <div class="course-salary-details-non-uk">
       <p class="govuk-body"><%= t("find.financial_support.non_uk_citizens.salaried_courses.competitive") %></p>
       <p class="govuk-body"><%= t("find.financial_support.non_uk_citizens.salaried_courses.entry_requirements") %></p>

--- a/spec/system/publish/providers/schools/add_school_spec.rb
+++ b/spec/system/publish/providers/schools/add_school_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
   def given_i_see_the_schools_guidance_text
     expect(page).to have_text("You can only add schools that are on Get Information About Schools (GIAS).", normalize_ws: true)
     expect(page).to have_link("Get Information About Schools (GIAS)", href: "https://get-information-schools.service.gov.uk/Search?SelectedTab=Establishments")
-    within(".app-callout.app-callout--orange") do
+    within(".app-callout.app-callout--purple") do
       expect(page).to have_css(
         ".app-callout__title",
         text: "Attaching schools to courses",


### PR DESCRIPTION
## Context

Get Into Teaching have rebranded. The colours we use on Find (and in the Publish course preview) for content that sends people to GiT no longer match the GiT website.

## Changes proposed in this pull request

Update GiT brand colours:

- Non-UK expander left border: `#ca357c`
- GiT callout left border (Financial support for UK citizens): `#54319f`
- Support callout border (course pages and homepage): `#aa98cf`

The colours are defined as Sass variables in `govuk_style_setup.scss` and used by the course accordion, support callout, and Publish preview banners.

## Guidance to review

On Find, check:

- a course page: Non-UK qualifications expander, UK financial support expander, and Support and advice box
- the homepage: Become a teacher / Get help and support boxes

On Publish, check a course preview for the GiT and non-UK notification banners.

The CSS class names (`app-callout--pink`, `govuk-accordion__section--orange`) are unchanged. Only the colours they apply have changed.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.