### PR TITLE
Report rollover failures instead of claiming success

### DIFF
--- a/app/controllers/publish/courses/draft_rollover_controller.rb
+++ b/app/controllers/publish/courses/draft_rollover_controller.rb
@@ -11,16 +11,23 @@ module Publish
 
       def update
         @course_rollover_form = CourseRolloverForm.new(course)
-        if @course_rollover_form.valid?
-          RolloverProviderService.call(provider_code: params[:provider_code], course_codes: params[:code]&.split, force: true)
+        return render :edit unless @course_rollover_form.valid?
+
+        result = RolloverProviderService.call(provider_code: params[:provider_code], course_codes: params[:code]&.split, force: true)
+
+        # The service collects a failed course copy into `courses_failed` and
+        # commits the rest of the transaction, so the provider and its sites can
+        # be in the next cycle without the course.
+        if result[:courses_failed].any?
+          @course_rollover_form.errors.add(:base, :rollover_failed)
+          render :edit
+        else
           flash[:success] = "Course rolled over"
           redirect_to publish_provider_recruitment_cycle_course_path(
             @provider.provider_code,
             @course.recruitment_cycle_year,
             @course.course_code,
           )
-        else
-          render :edit
         end
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -987,6 +987,8 @@ en:
               too_long: "Reduce the word count for degree subject requirements"
         publish/course_rollover_form:
           attributes:
+            base:
+              rollover_failed: "This course could not be rolled over. Try again, or contact becomingateacher@digital.education.gov.uk for help."
             course_is_rollable:
               invalid: "This course cannot be rolled over into the next recruitment cycle."
         publish/course_funding_form:

--- a/spec/system/publish/courses/rolling_over_a_course_that_fails_spec.rb
+++ b/spec/system/publish/courses/rolling_over_a_course_that_fails_spec.rb
@@ -10,7 +10,7 @@ require "rails_helper"
 # A course row with no start date makes the copy fail for real:
 # Courses::CopyToProviderService adds a year to `start_date` before it saves the
 # new course, so the failure lands before any course row is written.
-RSpec.describe "Rolling over a course that fails to copy", travel: mid_cycle(2025) do
+RSpec.describe "Rolling over a course that fails to copy", travel: mid_cycle do
   scenario "the provider is told the course was not rolled over" do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_rollable_next_recruitment_cycle

--- a/spec/system/publish/courses/rolling_over_a_course_that_fails_spec.rb
+++ b/spec/system/publish/courses/rolling_over_a_course_that_fails_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Providers::CopyToRecruitmentCycleService collects per-course failures into
+# `courses_failed` and lets the surrounding transaction commit, so a failed
+# rollover can still copy the provider and its sites. The page must not report
+# success when the course itself did not make it into the next cycle.
+#
+# A course row with no start date makes the copy fail for real:
+# Courses::CopyToProviderService adds a year to `start_date` before it saves the
+# new course, so the failure lands before any course row is written.
+RSpec.describe "Rolling over a course that fails to copy", travel: mid_cycle(2025) do
+  scenario "the provider is told the course was not rolled over" do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_rollable_next_recruitment_cycle
+    and_the_course_has_no_start_date
+    when_i_visit_the_rollover_page
+    and_i_confirm_the_rollover
+    then_i_see_that_the_course_was_not_rolled_over
+    and_i_am_not_told_it_was_rolled_over
+    and_the_course_is_not_in_the_next_recruitment_cycle
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    @course = build(:course, enrichments: [build(:course_enrichment)], funding_type: "salary")
+    @provider = create(:provider, courses: [@course])
+    given_i_am_authenticated(user: create(:user, providers: [@provider]))
+  end
+
+  def and_there_is_a_rollable_next_recruitment_cycle
+    find_or_create(:recruitment_cycle, :next).update(available_in_publish_from: 1.hour.ago)
+  end
+
+  def and_the_course_has_no_start_date
+    @course.update_columns(start_date: nil)
+  end
+
+  def when_i_visit_the_rollover_page
+    visit rollover_publish_provider_recruitment_cycle_course_path(
+      @provider.provider_code,
+      @provider.recruitment_cycle_year,
+      @course.course_code,
+    )
+  end
+
+  def and_i_confirm_the_rollover
+    click_link_or_button "Roll over course"
+  end
+
+  def then_i_see_that_the_course_was_not_rolled_over
+    expect(page).to have_content "This course could not be rolled over. Try again, or contact becomingateacher@digital.education.gov.uk for help."
+  end
+
+  def and_i_am_not_told_it_was_rolled_over
+    expect(page).to have_no_content "Course rolled over"
+  end
+
+  def and_the_course_is_not_in_the_next_recruitment_cycle
+    next_cycle_provider = RecruitmentCycle.next.providers.find_by(provider_code: @provider.provider_code)
+
+    expect(next_cycle_provider).to be_present
+    expect(next_cycle_provider.courses).to be_empty
+  end
+end


### PR DESCRIPTION
## Context

### The page said "Course rolled over" when the course did not roll over

A provider rolls over one course. `Providers::CopyToRecruitmentCycleService` copies the provider, its schools and its study sites first. Then it copies the course.

If the course copy fails, the service writes the failure into `courses_failed`. It does not stop, and it does not raise. The database saves the rest of the work. So the provider is in the next cycle, and the course is not.

`Publish::Courses::DraftRolloverController` threw the result away. It always showed "Course rolled over". The provider saw success, and support moved the course by hand later.

The page now shows an error instead. The provider can try again, because a course that did not copy still passes `Course#manually_rollable?`.

`Support::Providers::ManualRolloverController` reads the same way, and this PR leaves it alone. `copy_courses` selects no courses when `force` is true and the caller gives no course codes. That is how the support controller calls the service. No course copy runs there, so no course copy can fail. That controller copies no courses at all and still reports success. That is a different problem, and it needs its own card.

I rejected one other option: roll the whole transaction back when a course fails. The bulk rollover must continue through the other courses. So the failure stays with the course, and the caller reports it.

## Changes proposed in this pull request
<img width="1267" height="845" alt="image" src="https://github.com/user-attachments/assets/791fdc01-3b0e-4132-9961-fff6c35cc81a" />

- The rollover page shows an error when the course does not copy. The success message does not appear.
- The provider can start the rollover again after the error.

## Guidance to review

```
bundle exec rspec spec/system/publish/courses/rolling_over_a_course_that_fails_spec.rb
```

The test makes the copy fail for real. It clears `start_date` on the course row, because `Courses::CopyToProviderService` adds a year to that date. The test mocks nothing. Tell me if you know a better real trigger.

I checked the test fails without the new guard. Without it, the page says "Course rolled over" for a course that is not in the next cycle.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
