### PR TITLE
Count the courses rolled over, not the courses attempted

### DIFF
--- a/app/services/data_hub/rollover/provider_processor.rb
+++ b/app/services/data_hub/rollover/provider_processor.rb
@@ -66,6 +66,7 @@ module DataHub
       def provider_details(result)
         {
           courses_count: result[:courses],
+          courses_already_present_count: result[:courses_already_present],
           sites_count: result[:sites],
           sites_already_present_count: result[:sites_already_present],
           study_sites_count: result[:study_sites],

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -2,6 +2,8 @@
 
 module Providers
   class CopyToRecruitmentCycleService
+    COURSE_NOT_ROLLABLE = "Course not rollable"
+
     def initialize(copy_course_to_provider_service:, copy_schools_to_provider_service:, copy_site_to_provider_service:, copy_partnership_to_provider_service:, force:)
       @copy_course_to_provider_service = copy_course_to_provider_service
       @copy_schools_to_provider_service = copy_schools_to_provider_service
@@ -42,7 +44,7 @@ module Providers
                 :copy_partnership_to_provider_service,
                 :force
 
-    # `sites` and `study_sites` count what this run created. `*_already_present`
+    # `courses`, `sites` and `study_sites` count what this run created. `*_already_present`
     # counts what the destination provider already had, which is the normal
     # outcome of a repeat run and not a problem. `*_skipped` is reserved for
     # copies that were attempted and failed — rollover reporting surfaces those
@@ -55,6 +57,7 @@ module Providers
         study_sites: 0,
         study_sites_already_present: 0,
         courses: 0,
+        courses_already_present: 0,
         partnerships: 0,
         courses_failed: [],
         courses_skipped: [],
@@ -142,9 +145,16 @@ module Providers
         raise msg
       end
 
+      existing_course_codes = new_provider.courses.with_discarded.pluck(:course_code).to_set
+
       eligible.each do |course|
-        copy_course_to_provider_service.execute(course: course, new_provider: new_provider)
-        result[:courses] += 1
+        if existing_course_codes.include?(course.course_code)
+          result[:courses_already_present] += 1
+        elsif copy_course_to_provider_service.execute(course: course, new_provider: new_provider)
+          result[:courses] += 1
+        else
+          result[:courses_skipped] << { course_code: course.course_code, reason: COURSE_NOT_ROLLABLE }
+        end
       rescue StandardError => e
         result[:courses_failed] << { course_code: course.course_code, error_message: e.message }
       end

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -100,6 +100,22 @@ describe Providers::CopyToRecruitmentCycleService do
       end
     end
 
+    # Courses::CopyToProviderService returns nil when it declines to copy a
+    # course, so a count taken without reading the return value counts courses
+    # that were never written.
+    context "the course copier declines to copy the course" do
+      it "reports it as skipped rather than copied" do
+        allow(mocked_copy_course_service).to receive(:execute).and_return(nil)
+
+        result = service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
+
+        expect(result[:courses]).to eq(0)
+        expect(result[:courses_skipped]).to contain_exactly(
+          { course_code: course.course_code, reason: "Course not rollable" },
+        )
+      end
+    end
+
     context "the provider already exists in the new recruitment cycle" do
       let(:old_recruitment_cycle) { create(:recruitment_cycle, :previous) }
       let(:new_provider) do
@@ -235,6 +251,7 @@ describe Providers::CopyToRecruitmentCycleService do
         study_sites: 1,
         study_sites_already_present: 0,
         courses: 1,
+        courses_already_present: 0,
         partnerships: 1,
         courses_failed: [],
         courses_skipped: [],

--- a/spec/services/rollover_provider_service_idempotency_spec.rb
+++ b/spec/services/rollover_provider_service_idempotency_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe RolloverProviderService do
     it "copies every course" do
       expect(new_provider.courses.pluck(:course_code)).to match_array(courses.map(&:course_code))
     end
+
+    # Rolling the same course over twice is the shape of a stale rollover page,
+    # and of a provider whose bulk rollover has already run. The second run must
+    # not report the course as copied again.
+    it "reports a course that is already in the next cycle as already present" do
+      expect(roll_over(courses.first)).to include(
+        courses: 0,
+        courses_already_present: 1,
+        courses_failed: [],
+        courses_skipped: [],
+      )
+    end
   end
 
   # The guard this fix replaces matched on code alone and read school and study


### PR DESCRIPTION
## Context

### The rollover summary counted courses it tried to copy, not courses it copied

`Providers::CopyToRecruitmentCycleService#copy_courses` added 1 to `courses` after every call to `Courses::CopyToProviderService#execute` that did not raise, without reading what the call returned. That service returns nil when it declines to copy, so a course the destination provider already had counted as a fresh copy. `courses_skipped` was declared in the result hash and never written to.

`RolloverProcessSummary#update_counters` sums `courses_count` into `total_courses_rolled_over`. That is the number the support user reads after running a rollover, and it grew every time a provider was processed again. Per-course rollover in Publish runs the whole provider pipeline once per course, so repeat runs are normal rather than rare, and the total drifted further from the truth the more of them there were.

The new `courses_already_present` follows the shape already set by `sites_already_present` and `study_sites_already_present`: a course the destination already had is the ordinary outcome of a repeat run, not a problem, so it does not belong in `courses_skipped`. That key is reserved for copies that were attempted and refused, which is now only a course that is not rollable when `force` is off.

Rejected: reporting the skip from inside `Courses::CopyToProviderService`. It already tracks `courses_copied` and `courses_not_copied` for `Support::Providers::CopyCoursesController`, and giving it a second reporting channel for one caller is worse than having the caller read the return value it was already given.

## Changes proposed in this pull request

- `courses` counts copies that happened.
- Courses already in the destination cycle count in a new `courses_already_present`, passed through to the rollover summary as `courses_already_present_count`.
- A course the copier declines counts in `courses_skipped`, with a reason.

No UI change.

## Guidance to review

```
bundle exec rspec spec/services/providers/copy_to_recruitment_cycle_service_spec.rb spec/services/rollover_provider_service_idempotency_spec.rb spec/services/data_hub/rollover/provider_processor_spec.rb
```

The idempotency spec runs the real collaborators, so it pins the behaviour end to end: rolling the same course over twice now reports `courses: 0, courses_already_present: 1`, where it used to report `courses: 1`.

The support user who runs the rollover is the one who reads these counts, so the part worth checking is whether the split tells them what they need. `total_courses_rolled_over` will now report a smaller number than the same run would have reported before, and `courses_already_present_count` carries the difference.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
