### PR TITLE
Get GovukTechDocs from RubyGems instead of GitHub

### DIFF
--- a/docs/.tool-versions
+++ b/docs/.tool-versions
@@ -1,3 +1,2 @@
 nodejs  24.13.0
-bundler 2.7.2
-ruby    3.4.8
+ruby    3.4.10

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -4,7 +4,7 @@
 # the following line to use "http://"
 source "https://rubygems.org"
 
-ruby "~> 3.4.8"
+ruby "~> 3.4.10"
 
 # Include the tech docs gem
 gem "govuk_tech_docs", git: "https://github.com/alphagov/tech-docs-gem"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -6,8 +6,7 @@ source "https://rubygems.org"
 
 ruby "~> 3.4.10"
 
-# Include the tech docs gem
-gem "govuk_tech_docs", git: "https://github.com/alphagov/tech-docs-gem"
+gem "govuk_tech_docs", "~> 6.3"
 
 group :test do
   gem "capybara"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,28 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/tech-docs-gem
-  revision: e1cb2c86fbd1ef50de08953a41804c0e070d0d94
-  specs:
-    govuk_tech_docs (6.3.0)
-      autoprefixer-rails
-      chronic
-      concurrent-ruby
-      csv
-      haml (>= 6, < 8)
-      middleman
-      middleman-autoprefixer
-      middleman-compass
-      middleman-livereload
-      middleman-search-gds
-      middleman-sprockets (= 4.0.0)
-      middleman-syntax
-      mutex_m
-      nokogiri
-      openapi3_parser
-      redcarpet
-      sassc-embedded
-      schmooze (~> 0.2.0)
-      terser (~> 1.2.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,13 +35,15 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (2.9.0-aarch64-linux)
-    commonmarker (2.9.0-aarch64-linux-musl)
-    commonmarker (2.9.0-arm-linux)
-    commonmarker (2.9.0-arm64-darwin)
-    commonmarker (2.9.0-x86_64-darwin)
-    commonmarker (2.9.0-x86_64-linux)
-    commonmarker (2.9.0-x86_64-linux-musl)
+    commonmarker (2.10.0)
+      rb_sys (~> 0.9)
+    commonmarker (2.10.0-aarch64-linux)
+    commonmarker (2.10.0-aarch64-linux-musl)
+    commonmarker (2.10.0-arm-linux-gnu)
+    commonmarker (2.10.0-arm64-darwin)
+    commonmarker (2.10.0-x86_64-darwin)
+    commonmarker (2.10.0-x86_64-linux)
+    commonmarker (2.10.0-x86_64-linux-musl)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -91,7 +68,8 @@ GEM
       http_parser.rb (~> 0)
     erubi (1.13.1)
     eventmachine (1.2.7)
-    execjs (2.10.1)
+    execjs (2.10.2)
+      json (>= 2)
     fast_blank (1.0.1)
     fastimage (2.4.1)
     ffi (1.17.4-aarch64-linux-gnu)
@@ -102,27 +80,47 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
-    google-protobuf (4.35.1)
+    google-protobuf (4.36.1)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-aarch64-linux-gnu)
+    google-protobuf (4.36.1-aarch64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-aarch64-linux-musl)
+    google-protobuf (4.36.1-aarch64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-arm64-darwin)
+    google-protobuf (4.36.1-arm64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-darwin)
+    google-protobuf (4.36.1-x86_64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-linux-gnu)
+    google-protobuf (4.36.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-linux-musl)
+    google-protobuf (4.36.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    govuk_tech_docs (6.3.0)
+      autoprefixer-rails
+      chronic
+      concurrent-ruby
+      csv
+      haml (>= 6, < 8)
+      middleman
+      middleman-autoprefixer
+      middleman-compass
+      middleman-livereload
+      middleman-search-gds
+      middleman-sprockets (= 4.0.0)
+      middleman-syntax
+      mutex_m
+      nokogiri
+      openapi3_parser
+      redcarpet
+      sassc-embedded
+      schmooze (~> 0.2.0)
+      terser (~> 1.2.3)
     haml (6.4.0)
       temple (>= 0.8.2)
       thor
@@ -134,7 +132,7 @@ GEM
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.21.2)
+    json (3.0.0)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     listen (3.10.0)
@@ -194,9 +192,9 @@ GEM
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
-    middleman-syntax (3.6.1)
+    middleman-syntax (3.6.2)
       middleman-core (>= 3.2)
-      rouge (~> 3.2)
+      rouge (>= 3.2, < 5)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -226,12 +224,12 @@ GEM
       padrino-support (= 0.16.1)
       tilt (>= 2.1, < 3)
     padrino-support (0.16.1)
-    parallel (2.1.0)
+    parallel (2.2.0)
     parslet (2.0.0)
     prism (1.9.0)
     public_suffix (7.0.5)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-livereload (0.3.17)
       rack
     rack-test (2.2.0)
@@ -239,13 +237,16 @@ GEM
     rackup (2.3.1)
       rack (>= 3)
     rake (13.4.2)
+    rake-compiler-dock (1.12.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rb_sys (0.9.130)
+      rake-compiler-dock (= 1.12.0)
     redcarpet (3.6.1)
     regexp_parser (2.12.0)
     rexml (3.4.4)
-    rouge (3.30.0)
+    rouge (4.7.0)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -260,21 +261,21 @@ GEM
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
     sass (3.4.25)
-    sass-embedded (1.102.0-aarch64-linux-gnu)
+    sass-embedded (1.104.0-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.102.0-aarch64-linux-musl)
+    sass-embedded (1.104.0-aarch64-linux-musl)
       google-protobuf (~> 4.31)
-    sass-embedded (1.102.0-arm-linux-gnueabihf)
+    sass-embedded (1.104.0-arm-linux-gnueabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.102.0-arm-linux-musleabihf)
+    sass-embedded (1.104.0-arm-linux-musleabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.102.0-arm64-darwin)
+    sass-embedded (1.104.0-arm64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.102.0-x86_64-darwin)
+    sass-embedded (1.104.0-x86_64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.102.0-x86_64-linux-gnu)
+    sass-embedded (1.104.0-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.102.0-x86_64-linux-musl)
+    sass-embedded (1.104.0-x86_64-linux-musl)
       google-protobuf (~> 4.31)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -283,15 +284,15 @@ GEM
     schmooze (0.2.0)
     securerandom (0.4.1)
     servolux (0.13.0)
-    sprockets (4.2.2)
-      concurrent-ruby (~> 1.0)
+    sprockets (4.4.1)
+      concurrent-ruby (~> 1.1)
       logger
       rack (>= 2.2.4, < 4)
-    temple (0.10.6)
+    temple (0.10.7)
     terser (1.2.8)
       execjs (>= 0.3.0, < 3)
     thor (1.5.0)
-    tilt (2.8.0)
+    tilt (2.9.0)
     toml (0.3.0)
       parslet (>= 1.8.0, < 3.0.0)
     tzinfo (2.0.6)
@@ -318,11 +319,11 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  govuk_tech_docs!
+  govuk_tech_docs (~> 6.3)
   rspec
 
 RUBY VERSION
-   ruby 3.4.8p72
+   ruby 3.4.10p104
 
 BUNDLED WITH
    2.6.9


### PR DESCRIPTION
## Context

Bundle the GovukTechDocs from RubyGems instead of the git repo
Change the ruby version the docs app runs on to match the main application (3.4.10)

Closes https://github.com/DFE-Digital/publish-teacher-training/pull/6397

## Changes proposed in this pull request



## Guidance to review

I've run the tests and built the docs locally

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
