### PR TITLE
[Prototype] Find search results Aug 2026 - 'Not accepting applications' status tag hidden

### DIFF
--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -30,10 +30,10 @@ module Courses
         ])
       end
 
-      status_tag = application_status_tag
-      status_block = (content_tag(:div, status_tag, class: "app-saved-course__status-tag") if status_tag.present?)
+      # status_tag = application_status_tag
+      # status_block = (content_tag(:div, status_tag, class: "app-saved-course__status-tag") if status_tag.present?)
 
-      title_content = safe_join([course_link, status_block].compact)
+      title_content = safe_join([course_link].compact)
 
       classes = [
         ("govuk-grid-column-one-half" if save_toggle_button),


### PR DESCRIPTION
## Context

Remove status tag from summary card search results indicating that closed courses are not accepting applications.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
