### PR TITLE
Remove TTA links from primary courses

### DIFF
--- a/app/views/find/courses/_advice.html.erb
+++ b/app/views/find/courses/_advice.html.erb
@@ -2,7 +2,21 @@
   <h2 id="section-advice" class="app-callout__title"><%= t(".heading") %></h2>
 
   <span class="govuk-body">
-    <% if course.postgraduate_degree_type? %>
+    <% contact_git_link = govuk_link_to(
+         t(".contact_get_into_teaching_link_text"),
+         find_track_click_path(url: find_get_into_teaching_redirect_path(
+           @course.provider_code,
+           @course.course_code,
+           "help_and_support",
+         )),
+       ) %>
+
+    <% if course.primary_course? || !course.postgraduate_degree_type? %>
+      <%= t(
+            course.primary_course? ? ".primary.body_html" : ".undergraduate.body_html",
+            contact_git_link:,
+          ) %>
+    <% else %>
       <%= t(
             ".postgraduate.body_html",
             teacher_training_adviser_link: govuk_link_to(
@@ -13,28 +27,7 @@
                 "teacher_training_advisers",
               )),
             ),
-            contact_git_link:
-              govuk_link_to(
-                t(".contact_get_into_teaching_link_text"),
-                find_track_click_path(url: find_get_into_teaching_redirect_path(
-                  @course.provider_code,
-                  @course.course_code,
-                  "help_and_support",
-                )),
-              ),
-          ) %>
-    <% else %>
-      <%= t(
-            ".undergraduate.body_html",
-            contact_git_link:
-            govuk_link_to(
-              t(".contact_get_into_teaching_link_text"),
-              find_track_click_path(url: find_get_into_teaching_redirect_path(
-                @course.provider_code,
-                @course.course_code,
-                "help_and_support",
-              )),
-            ),
+            contact_git_link:,
           ) %>
     <% end %>
   </span>

--- a/app/views/find/courses/school_experience_interstitial.html.erb
+++ b/app/views/find/courses/school_experience_interstitial.html.erb
@@ -79,19 +79,39 @@
     <% end %>
 
     <%= govuk_inset_text classes: "app-callout app-callout--purple govuk-!-margin-top-4" do %>
-      <h2 class="govuk-heading-m"><%= t("find.courses.confirm_apply.school_experience_interruption.adviser_callout_heading") %></h2>
-      <p class="govuk-body govuk-!-margin-bottom-0">
-        <%= t(
-              "find.courses.confirm_apply.school_experience_interruption.adviser_callout_body_html",
-              teacher_training_adviser_link: govuk_link_to(
-                t("find.courses.confirm_apply.school_experience_interruption.adviser_callout_link_text"),
-                find_track_click_path(
-                  url: t("find.get_into_teaching.url_training_adviser"),
-                  utm_content: "school_experience_interruption_teacher_training_adviser",
+      <% if @course.primary_course? %>
+        <h2 class="govuk-heading-m"><%= t("find.courses.confirm_apply.school_experience_interruption.support_callout_heading") %></h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">
+          <%= t(
+                "find.courses.confirm_apply.school_experience_interruption.support_callout_body_html",
+                contact_git_link: govuk_link_to(
+                  t("find.courses.confirm_apply.school_experience_interruption.support_callout_link_text"),
+                  find_track_click_path(
+                    url: find_get_into_teaching_redirect_path(
+                      @course.provider_code,
+                      @course.course_code,
+                      "help_and_support",
+                    ),
+                    utm_content: "school_experience_interruption_contact_get_into_teaching",
+                  ),
                 ),
-              ),
-            ) %>
-      </p>
+              ) %>
+        </p>
+      <% else %>
+        <h2 class="govuk-heading-m"><%= t("find.courses.confirm_apply.school_experience_interruption.adviser_callout_heading") %></h2>
+        <p class="govuk-body govuk-!-margin-bottom-0">
+          <%= t(
+                "find.courses.confirm_apply.school_experience_interruption.adviser_callout_body_html",
+                teacher_training_adviser_link: govuk_link_to(
+                  t("find.courses.confirm_apply.school_experience_interruption.adviser_callout_link_text"),
+                  find_track_click_path(
+                    url: t("find.get_into_teaching.url_training_adviser"),
+                    utm_content: "school_experience_interruption_teacher_training_adviser",
+                  ),
+                ),
+              ) %>
+        </p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -25,6 +25,8 @@ en:
         heading: Support and advice
         postgraduate:
           body_html: You can %{teacher_training_adviser_link} or %{contact_git_link} for free support
+        primary:
+          body_html: You can %{contact_git_link} for free support
         undergraduate:
           body_html: You can %{contact_git_link} for free support
 

--- a/config/locales/en/find/courses/confirm_apply.yml
+++ b/config/locales/en/find/courses/confirm_apply.yml
@@ -25,3 +25,6 @@ en:
           adviser_callout_heading: Get free one-to-one support
           adviser_callout_body_html: Talk to a %{teacher_training_adviser_link} who can help you understand which courses you could be eligible for.
           adviser_callout_link_text: teacher training adviser
+          support_callout_heading: Support and advice
+          support_callout_body_html: You can %{contact_git_link} for free support
+          support_callout_link_text: contact Get Into Teaching

--- a/spec/system/find/course/viewing_a_course_spec.rb
+++ b/spec/system/find/course/viewing_a_course_spec.rb
@@ -93,6 +93,15 @@ RSpec.describe "Viewing a findable course" do
     then_i_am_redirected_to_the_git_help_and_support_page
   end
 
+  scenario "primary course support and advice does not offer a teacher training adviser" do
+    given_there_is_a_findable_primary_course
+    when_i_visit_the_course_page
+
+    then_i_see_the_primary_support_and_advice_callout
+    and_i_click("contact Get Into Teaching")
+    then_i_am_redirected_to_the_git_help_and_support_page
+  end
+
   scenario "user visits the provider page" do
     given_there_is_a_findable_course
     when_i_visit_the_course_page
@@ -158,6 +167,18 @@ private
           bursary_amount: "4000",
         ),
       ],
+    )
+  end
+
+  def given_there_is_a_findable_primary_course
+    @course = create(
+      :course,
+      :primary,
+      :published,
+      :open,
+      :with_full_time_sites,
+      name: "Primary",
+      subjects: [find_or_create(:primary_subject, :primary_with_mathematics)],
     )
   end
 
@@ -391,6 +412,22 @@ private
   def then_i_should_be_on_the_course_page
     expect(page).to have_current_path(
       find_course_path(provider_code: @course.provider_code, course_code: @course.course_code),
+    )
+  end
+
+  def then_i_see_the_primary_support_and_advice_callout
+    expect(page).to have_css("#section-advice-and-support", text: "Support and advice")
+    expect(page).to have_content("You can contact Get Into Teaching for free support")
+    expect(page).to have_no_link("get a teacher training adviser")
+    expect(page).to have_link(
+      "contact Get Into Teaching",
+      href: find_track_click_path(
+        url: find_get_into_teaching_redirect_path(
+          @course.provider_code,
+          @course.course_code,
+          "help_and_support",
+        ),
+      ),
     )
   end
 

--- a/spec/system/find/courses/apply_for_course_spec.rb
+++ b/spec/system/find/courses/apply_for_course_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe "Saving a course", service: :find do
     when_i_visit_school_experience_interstitial_page
 
     then_i_see_the_school_experience_interruption_page
+    and_i_see_the_teacher_training_adviser_callout
+  end
+
+  scenario "A signed-in candidate sees support and advice instead of a teacher training adviser on primary courses", travel: mid_cycle(2027) do
+    given_a_primary_salaried_course_with_required_school_experience_exists
+    when_i_visit_school_experience_interstitial_page
+
+    then_i_see_the_school_experience_interruption_page
+    and_i_see_the_primary_support_and_advice_callout
   end
 
   scenario "A signed-in candidate sees the school experience interruption and then confirm apply page", travel: mid_cycle(2027) do
@@ -114,7 +123,6 @@ RSpec.describe "Saving a course", service: :find do
       ),
     )
     expect(page).to have_content("Is a salaried course right for me?")
-    expect(page).to have_content("Get free one-to-one support")
     expect(page).to have_link(
       "bursaries or scholarships",
       href: find_track_click_path(
@@ -136,6 +144,51 @@ RSpec.describe "Saving a course", service: :find do
       course_code: "F314",
       provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
       subjects: [find_or_create(:secondary_subject, :art_and_design)],
+    )
+  end
+
+  def and_i_see_the_teacher_training_adviser_callout
+    expect(page).to have_content("Get free one-to-one support")
+    expect(page).to have_link(
+      "teacher training adviser",
+      href: find_track_click_path(
+        url: I18n.t("find.get_into_teaching.url_training_adviser"),
+        utm_content: "school_experience_interruption_teacher_training_adviser",
+      ),
+    )
+  end
+
+  def and_i_see_the_primary_support_and_advice_callout
+    expect(page).to have_content("Support and advice")
+    expect(page).to have_no_content("Get free one-to-one support")
+    expect(page).to have_no_link("teacher training adviser")
+    expect(page).to have_link(
+      "contact Get Into Teaching",
+      href: find_track_click_path(
+        url: find_get_into_teaching_redirect_path(
+          @course.provider_code,
+          @course.course_code,
+          "help_and_support",
+        ),
+        utm_content: "school_experience_interruption_contact_get_into_teaching",
+      ),
+    )
+  end
+
+  def given_a_primary_salaried_course_with_required_school_experience_exists
+    @course = create(
+      :course,
+      :with_full_time_sites,
+      :primary,
+      :salary,
+      :published,
+      :open,
+      name: "Primary with mathematics",
+      course_code: "P314",
+      school_experience_required: true,
+      school_experience_required_content: "You must have completed 10 days of school experience in the last 12 months.",
+      provider: create(:provider, provider_name: "York university"),
+      subjects: [find_or_create(:primary_subject, :primary_with_mathematics)],
     )
   end
 


### PR DESCRIPTION
## Context

Teacher training advisers (TTAs) are no longer offered to people looking at primary courses, including primary specialisms.

Find currently has two callouts that send people to Get Into Teaching (GiT) to get a TTA:

- **Support and advice** on the course page
- **Get free one-to-one support** on the school experience interruption page (shown before apply for some salaried and apprenticeship courses)

Those TTA links should not appear on primary courses. Secondary and further education should stay as they are.

## Changes proposed in this pull request

### Course page — Support and advice

`app/views/find/courses/_advice.html.erb` now chooses copy by subject as well as degree type.

- **Primary** (including specialisms): “You can contact Get Into Teaching for free support.” No TTA link.
- **Undergraduate / TDA** (non-primary): unchanged — contact GiT only.
- **Postgraduate secondary and further education**: unchanged — “get a teacher training adviser” or “contact Get Into Teaching”.

The GiT contact link still goes through `find_track_click_path` and `find_get_into_teaching_redirect_path(..., "help_and_support")`.

New locale: `find.courses.advice.primary.body_html`.

### School experience interruption page

`app/views/find/courses/school_experience_interstitial.html.erb` now swaps the second orange callout on primary courses.

- **Primary**: heading **Support and advice**, body “You can contact Get Into Teaching for free support.”
- **Non-primary**: unchanged **Get free one-to-one support** TTA callout.

The new GiT link is tracked with `utm_content: school_experience_interruption_contact_get_into_teaching` and the existing help-and-support redirect. The TTA link still uses `school_experience_interruption_teacher_training_adviser`.

New locales: `support_callout_heading`, `support_callout_body_html`, `support_callout_link_text`.

### Tests

- Course page: primary course shows the GiT-only callout, no TTA link, and the tracked contact link still works.
- Interruption page: secondary still shows the TTA callout with tracking; primary shows Support and advice with the tracked GiT link.

## Guidance to review

On Find, check:

1. **Primary course page** (including a primary specialism) — Support and advice has only “contact Get Into Teaching”. No TTA. Click the link and confirm it is tracked and goes to GiT help and support.
2. **Secondary or FE course page** — still has “get a teacher training adviser” and “contact Get Into Teaching”. Both still tracked.
3. **Primary salaried/apprenticeship interruption** (`/school-experience-interstitial`) — second callout is Support and advice, not the TTA box. GiT link tracked.
4. **Secondary salaried interruption** — still “Get free one-to-one support” with the TTA link tracked.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.