### PR TITLE
Track click visa and radius links

### DIFF
--- a/app/components/find/courses/international_students_component/view.html.erb
+++ b/app/components/find/courses/international_students_component/view.html.erb
@@ -19,11 +19,24 @@
       <li>have indefinite leave to remain in the UK</li>
     </ul>
 
-    <% unless visa_type == :student_visa && sponsorship_availability != :available %>
-      <%= t(
-        "find.international_candidates.#{visa_type}.#{sponsorship_availability}.html",
-        provider_url: x_provider_url,
-      ) %>
+    <% if show_visa_guidance? %>
+      <p class="govuk-body">
+        <%= t(
+          "find.international_candidates.find_out_about_visa_types_html",
+          link: govuk_link_to(t("find.international_candidates.find_out_about_visa_types_link"), visa_types_url),
+        ) %>
+      </p>
+
+      <% if sponsorship_available? %>
+        <p class="govuk-body"><%= t("find.international_candidates.#{visa_type}.sponsorship") %></p>
+
+        <p class="govuk-body">
+          <%= t(
+            "find.international_candidates.#{visa_type}.contact_provider_html",
+            link: govuk_link_to(t("find.international_candidates.contact_the_training_provider"), contact_the_training_provider_url),
+          ) %>
+        </p>
+      <% end %>
     <% end %>
 
     <p class="govuk-body">Learn more about <%= govuk_link_to("training to teach in England as a non-UK citizen", find_track_click_path(url: t("find.get_into_teaching.url_train_to_teach_as_international_candidate"))) %>.</p>

--- a/app/components/find/courses/international_students_component/view.rb
+++ b/app/components/find/courses/international_students_component/view.rb
@@ -51,7 +51,10 @@ module Find
         end
 
         def contact_the_training_provider_url
-          x_provider_url
+          find_track_click_path(
+            utm_content: "#{visa_type}_#{sponsorship_availability}_contact_the_training_provider",
+            url: x_provider_url,
+          )
         end
 
         def course_subject_codes

--- a/app/components/find/courses/international_students_component/view.rb
+++ b/app/components/find/courses/international_students_component/view.rb
@@ -44,7 +44,10 @@ module Find
         end
 
         def visa_types_url
-          t("find.get_into_teaching.url_visas_for_non_uk_trainees")
+          find_track_click_path(
+            utm_content: "#{visa_type}_#{sponsorship_availability}_types_of_visa",
+            url: t("find.get_into_teaching.url_visas_for_non_uk_trainees"),
+          )
         end
 
         def contact_the_training_provider_url

--- a/app/components/find/courses/international_students_component/view.rb
+++ b/app/components/find/courses/international_students_component/view.rb
@@ -35,6 +35,22 @@ module Find
           @sponsorship_availability ||= course.public_send("can_sponsor_#{visa_type}") ? :available : :not_available
         end
 
+        def sponsorship_available?
+          sponsorship_availability == :available
+        end
+
+        def show_visa_guidance?
+          !(visa_type == :student_visa && !sponsorship_available?)
+        end
+
+        def visa_types_url
+          t("find.get_into_teaching.url_visas_for_non_uk_trainees")
+        end
+
+        def contact_the_training_provider_url
+          x_provider_url
+        end
+
         def course_subject_codes
           @course_subject_codes ||= course.subjects.pluck(:subject_code).compact
         end

--- a/app/components/shared/courses/how_to_choose_a_training_provider_component.html.erb
+++ b/app/components/shared/courses/how_to_choose_a_training_provider_component.html.erb
@@ -4,7 +4,7 @@
     <% if is_preview %>
       <%= govuk_link_to t(".content.find_out_how_to_choose_a_training_provider"), t("find.get_into_teaching.url_type_of_course_provider") %>
     <% else %>
-      <%= govuk_link_to t(".content.find_out_how_to_choose_a_training_provider"), find_track_click_path(utm: "how_to_choose_a_training_provider", url: t("find.get_into_teaching.url_type_of_course_provider")) %>
+      <%= govuk_link_to t(".content.find_out_how_to_choose_a_training_provider"), find_track_click_path(utm_content: "how_to_choose_a_training_provider", url: t("find.get_into_teaching.url_type_of_course_provider")) %>
     <% end %>
   </p>
 <% end %>

--- a/app/components/shared/courses/interview_preparation_component.html.erb
+++ b/app/components/shared/courses/interview_preparation_component.html.erb
@@ -4,7 +4,7 @@
     <% if is_preview %>
       <%= govuk_link_to t(".content.find_out_about_interview_preparation"), t("find.get_into_teaching.url_interview_preparation") %>
     <% else %>
-      <%= govuk_link_to t(".content.find_out_about_interview_preparation"), find_track_click_path(utm: "interview_preparation", url: t("find.get_into_teaching.url_interview_preparation")) %>
+      <%= govuk_link_to t(".content.find_out_about_interview_preparation"), find_track_click_path(utm_content: "interview_preparation", url: t("find.get_into_teaching.url_interview_preparation")) %>
     <% end %>
   </p>
 <% end %>

--- a/app/components/shared/courses/school_placement_activities_component.erb
+++ b/app/components/shared/courses/school_placement_activities_component.erb
@@ -5,7 +5,7 @@
     <% if is_preview %>
       <%= govuk_link_to t(".content.find_out_about_school_placement_activities"), t("find.get_into_teaching.url_school_placement_activities") %>
     <% else %>
-      <%= govuk_link_to t(".content.find_out_about_school_placement_activities"), find_track_click_path(utm: "school_placement_activities", url: t("find.get_into_teaching.url_school_placement_activities")) %>
+      <%= govuk_link_to t(".content.find_out_about_school_placement_activities"), find_track_click_path(utm_content: "school_placement_activities", url: t("find.get_into_teaching.url_school_placement_activities")) %>
     <% end %>
   </p>
 <% end %>

--- a/app/components/shared/courses/teacher_training_expectations_component.html.erb
+++ b/app/components/shared/courses/teacher_training_expectations_component.html.erb
@@ -4,7 +4,7 @@
     <% if is_preview %>
       <%= govuk_link_to t(".content.find_out_about_teacher_training"), t("find.get_into_teaching.url_initial_teacher_training") %>
     <% else %>
-      <%= govuk_link_to t(".content.find_out_about_teacher_training"), find_track_click_path(utm: "teacher_training_expectations", url: t("find.get_into_teaching.url_initial_teacher_training")) %>
+      <%= govuk_link_to t(".content.find_out_about_teacher_training"), find_track_click_path(utm_content: "teacher_training_expectations", url: t("find.get_into_teaching.url_initial_teacher_training")) %>
     <% end %>
   </p>
 <% end %>

--- a/app/services/courses/radius_quick_link_suggestions.rb
+++ b/app/services/courses/radius_quick_link_suggestions.rb
@@ -31,7 +31,7 @@ module Courses
     def build_link(values)
       {
         text: translate("radius_in_miles", count: values[:radius], course_count: format_course_count(values[:count])),
-        url: find_results_path(values[:radius]),
+        url: tracked_results_path(values[:radius]),
       }
     end
 
@@ -49,10 +49,21 @@ module Courses
       translate(key, count:)
     end
 
+    def tracked_results_path(radius)
+      url_helpers.find_track_click_path(
+        utm_content: "no_results_radius_quick_link_#{radius}_miles",
+        url: find_results_path(radius),
+      )
+    end
+
     def find_results_path(radius)
       query = @request_query.dup
       query["radius"] = radius
-      Rails.application.routes.url_helpers.find_results_path(**query)
+      url_helpers.find_results_path(**query)
+    end
+
+    def url_helpers
+      Rails.application.routes.url_helpers
     end
 
     def translate(key, **options)

--- a/config/locales/en/find.yml
+++ b/config/locales/en/find.yml
@@ -132,20 +132,15 @@ en:
       german: *british_council
       spanish: *british_council
     international_candidates:
+      find_out_about_visa_types_html: If you do not already have the right to study or work in the UK, you can %{link}.
+      find_out_about_visa_types_link: find out more about the types of visa you can apply for
+      contact_the_training_provider: contact the training provider
       skilled_worker_visa:
-        not_available:
-          html: <p class="govuk-body">If you do not already have the right to study or work in the UK, you can <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees">find out more about the types of visa you can apply for</a>.</p>
-        available:
-          html:
-            <p class="govuk-body">If you do not already have the right to study or work in the UK, you can <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees">find out more about the types of visa you can apply for</a>.</p>
-            <p class="govuk-body">To get a Skilled Worker visa, you’ll need to be sponsored by your employer.</p>
-            <p class="govuk-body">Before you apply for this course, <a class="govuk-link" href=%{provider_url}>contact the training provider</a> to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.</p>
+        sponsorship: To get a Skilled Worker visa, you’ll need to be sponsored by your employer.
+        contact_provider_html: Before you apply for this course, %{link} to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.
       student_visa:
-        available:
-          html:
-            <p class="govuk-body">If you do not already have the right to study or work in the UK, you can <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees">find out more about the types of visa you can apply for</a>.</p>
-            <p class="govuk-body">To get a Student visa, you’ll need to be sponsored by your training provider.</p>
-            <p class="govuk-body">Before you apply for this course, <a class="govuk-link" href=%{provider_url}>contact the training provider</a> to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.</p>
+        sponsorship: To get a Student visa, you’ll need to be sponsored by your training provider.
+        contact_provider_html: Before you apply for this course, %{link} to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.
       entitlement:
         html: <p class="govuk-body">You may be entitled to £10,000 from the UK government to help with the financial costs of moving to England.</p>
     get_into_teaching:

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -3,15 +3,24 @@
 require "rails_helper"
 
 describe Find::Courses::InternationalStudentsComponent::View, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:visa_types_url) { I18n.t("find.get_into_teaching.url_visas_for_non_uk_trainees") }
+
+  # Rendered in isolation the component has no `params[:action]`, so `preview?`
+  # is true and `x_provider_url` resolves to the Publish preview path.
+  def provider_url_for(course)
+    provider_publish_provider_recruitment_cycle_course_path(
+      course.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code,
+    )
+  end
+
   context "when the course is fee-paying and does not sponsor Student visas" do
-    before do
-      course = build(
-        :course,
-        funding_type: "fee",
-        can_sponsor_student_visa: false,
-      )
-      render_inline(described_class.new(course: CourseDecorator.new(course)))
-    end
+    let(:course) { build(:course, funding_type: "fee", can_sponsor_student_visa: false) }
+
+    before { render_inline(described_class.new(course: CourseDecorator.new(course))) }
 
     it "tells candidates they’ll need the right to study" do
       expect(page).to have_text("You’ll need the right to study in the UK")
@@ -19,14 +28,9 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
   end
 
   context "when the course is fee-paying and does sponsor Student visas" do
-    before do
-      course = build(
-        :course,
-        funding_type: "fee",
-        can_sponsor_student_visa: true,
-      )
-      render_inline(described_class.new(course: CourseDecorator.new(course)))
-    end
+    let(:course) { build(:course, funding_type: "fee", can_sponsor_student_visa: true) }
+
+    before { render_inline(described_class.new(course: CourseDecorator.new(course))) }
 
     it "tells candidates they’ll need the right to study" do
       expect(page).to have_text("You’ll need the right to study in the UK")
@@ -34,6 +38,18 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
 
     it "tells candidates visa sponsorship may be available, but they should check" do
       expect(page).to have_text("Before you apply for this course, contact the training provider to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.")
+    end
+
+    it "links to the types of visa candidates can apply for" do
+      expect(page).to have_link(
+        "find out more about the types of visa you can apply for",
+        href: visa_types_url,
+        visible: :all,
+      )
+    end
+
+    it "links to the training provider" do
+      expect(page).to have_link("contact the training provider", href: provider_url_for(course), visible: :all)
     end
 
     it "does not tell candidates the 3-year residency rule" do
@@ -46,14 +62,9 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
   end
 
   context "when the course is salaried and can sponsor Skilled Worker visas" do
-    before do
-      course = build(
-        :course,
-        funding: "salary",
-        can_sponsor_skilled_worker_visa: true,
-      )
-      render_inline(described_class.new(course: CourseDecorator.new(course)))
-    end
+    let(:course) { build(:course, funding: "salary", can_sponsor_skilled_worker_visa: true) }
+
+    before { render_inline(described_class.new(course: CourseDecorator.new(course))) }
 
     it "tells candidates they’ll need the right to work" do
       expect(page).to have_text("You’ll need the right to work in the UK")
@@ -62,35 +73,53 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     it "tells candidates visa sponsorship may be available, but they should check" do
       expect(page).to have_text("Before you apply for this course, contact the training provider to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.")
     end
+
+    it "links to the types of visa candidates can apply for" do
+      expect(page).to have_link(
+        "find out more about the types of visa you can apply for",
+        href: visa_types_url,
+        visible: :all,
+      )
+    end
+
+    it "links to the training provider" do
+      expect(page).to have_link("contact the training provider", href: provider_url_for(course), visible: :all)
+    end
   end
 
   context "when the course has a visa_type of student_visa and sponsorship_availability of :not_available" do
-    before do
-      course = build(
-        :course,
-        funding: "fee",
-        can_sponsor_skilled_worker_visa: false,
-      )
-      render_inline(described_class.new(course: CourseDecorator.new(course)))
-    end
+    let(:course) { build(:course, funding: "fee", can_sponsor_skilled_worker_visa: false) }
+
+    before { render_inline(described_class.new(course: CourseDecorator.new(course))) }
 
     it "does not show the content if visa cannont be sponsored" do
       expect(page).to have_no_text("If you do not already have the right to study or work in the UK, you can")
     end
+
+    it "does not link to the types of visa candidates can apply for" do
+      expect(page).to have_no_link("find out more about the types of visa you can apply for", visible: :all)
+    end
   end
 
   context "when the course is salaried and does not sponsor Skilled Worker visas" do
-    before do
-      course = build(
-        :course,
-        funding: "salary",
-        can_sponsor_skilled_worker_visa: false,
-      )
-      render_inline(described_class.new(course: CourseDecorator.new(course)))
-    end
+    let(:course) { build(:course, funding: "salary", can_sponsor_skilled_worker_visa: false) }
+
+    before { render_inline(described_class.new(course: CourseDecorator.new(course))) }
 
     it "tells candidates they’ll need the right to work" do
       expect(page).to have_text("You’ll need the right to work in the UK")
+    end
+
+    it "links to the types of visa candidates can apply for" do
+      expect(page).to have_link(
+        "find out more about the types of visa you can apply for",
+        href: visa_types_url,
+        visible: :all,
+      )
+    end
+
+    it "does not link to the training provider" do
+      expect(page).to have_no_link("contact the training provider", visible: :all)
     end
 
     it "does not tell candidates the 3-year residency rule" do
@@ -103,13 +132,9 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
   end
 
   context "when the course is an apprenticeship" do
-    before do
-      course = build(
-        :course,
-        funding: "apprenticeship",
-      )
-      render_inline(described_class.new(course: CourseDecorator.new(course)))
-    end
+    let(:course) { build(:course, funding: "apprenticeship") }
+
+    before { render_inline(described_class.new(course: CourseDecorator.new(course))) }
 
     it "tells candidates the 3-year residency rule" do
       expect(page).to have_text("To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course")

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -22,6 +22,10 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     )
   end
 
+  def tracked_provider_url_for(course, utm_content)
+    find_track_click_path(utm_content:, url: provider_url_for(course))
+  end
+
   context "when the course is fee-paying and does not sponsor Student visas" do
     let(:course) { build(:course, funding_type: "fee", can_sponsor_student_visa: false) }
 
@@ -54,7 +58,11 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     end
 
     it "links to the training provider" do
-      expect(page).to have_link("contact the training provider", href: provider_url_for(course), visible: :all)
+      expect(page).to have_link(
+        "contact the training provider",
+        href: tracked_provider_url_for(course, "student_visa_available_contact_the_training_provider"),
+        visible: :all,
+      )
     end
 
     it "does not tell candidates the 3-year residency rule" do
@@ -88,7 +96,11 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     end
 
     it "links to the training provider" do
-      expect(page).to have_link("contact the training provider", href: provider_url_for(course), visible: :all)
+      expect(page).to have_link(
+        "contact the training provider",
+        href: tracked_provider_url_for(course, "skilled_worker_visa_available_contact_the_training_provider"),
+        visible: :all,
+      )
     end
   end
 

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 describe Find::Courses::InternationalStudentsComponent::View, type: :component do
   include Rails.application.routes.url_helpers
 
-  let(:visa_types_url) { I18n.t("find.get_into_teaching.url_visas_for_non_uk_trainees") }
+  def tracked_visa_types_url(utm_content)
+    find_track_click_path(
+      utm_content:,
+      url: I18n.t("find.get_into_teaching.url_visas_for_non_uk_trainees"),
+    )
+  end
 
   # Rendered in isolation the component has no `params[:action]`, so `preview?`
   # is true and `x_provider_url` resolves to the Publish preview path.
@@ -43,7 +48,7 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     it "links to the types of visa candidates can apply for" do
       expect(page).to have_link(
         "find out more about the types of visa you can apply for",
-        href: visa_types_url,
+        href: tracked_visa_types_url("student_visa_available_types_of_visa"),
         visible: :all,
       )
     end
@@ -77,7 +82,7 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     it "links to the types of visa candidates can apply for" do
       expect(page).to have_link(
         "find out more about the types of visa you can apply for",
-        href: visa_types_url,
+        href: tracked_visa_types_url("skilled_worker_visa_available_types_of_visa"),
         visible: :all,
       )
     end
@@ -113,7 +118,7 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     it "links to the types of visa candidates can apply for" do
       expect(page).to have_link(
         "find out more about the types of visa you can apply for",
-        href: visa_types_url,
+        href: tracked_visa_types_url("skilled_worker_visa_not_available_types_of_visa"),
         visible: :all,
       )
     end

--- a/spec/components/shared/courses/how_to_choose_a_training_provider_component_spec.rb
+++ b/spec/components/shared/courses/how_to_choose_a_training_provider_component_spec.rb
@@ -23,7 +23,7 @@ describe Shared::Courses::HowToChooseATrainingProviderComponent, type: :componen
         expect(result).to have_link(
           "Find out how to choose a training provider.",
           href: find_track_click_path(
-            utm: "how_to_choose_a_training_provider",
+            utm_content: "how_to_choose_a_training_provider",
             url: I18n.t("find.get_into_teaching.url_type_of_course_provider"),
           ),
         )

--- a/spec/components/shared/courses/interview_preparation_component_spec.rb
+++ b/spec/components/shared/courses/interview_preparation_component_spec.rb
@@ -23,7 +23,7 @@ describe Shared::Courses::InterviewPreparationComponent, type: :component do
         expect(result).to have_link(
           "Find out how to prepare for your interview.",
           href: find_track_click_path(
-            utm: "interview_preparation",
+            utm_content: "interview_preparation",
             url: I18n.t("find.get_into_teaching.url_interview_preparation"),
           ),
         )

--- a/spec/components/shared/courses/school_placement_activities_component_spec.rb
+++ b/spec/components/shared/courses/school_placement_activities_component_spec.rb
@@ -23,7 +23,7 @@ describe Shared::Courses::SchoolPlacementActivitiesComponent, type: :component d
         expect(result).to have_link(
           ".",
           href: find_track_click_path(
-            utm: "school_placement_activities",
+            utm_content: "school_placement_activities",
             url: I18n.t("find.get_into_teaching.url_school_placement_activities"),
           ),
         )

--- a/spec/components/shared/courses/teacher_training_expectations_component_spec.rb
+++ b/spec/components/shared/courses/teacher_training_expectations_component_spec.rb
@@ -22,7 +22,7 @@ describe Shared::Courses::TeacherTrainingExpectationsComponent, type: :component
         expect(result).to have_link(
           "Find out what to expect in teacher training.",
           href: find_track_click_path(
-            utm: "teacher_training_expectations",
+            utm_content: "teacher_training_expectations",
             url: I18n.t("find.get_into_teaching.url_initial_teacher_training"),
           ),
         )

--- a/spec/requests/find/radius_quick_link_suggestions_spec.rb
+++ b/spec/requests/find/radius_quick_link_suggestions_spec.rb
@@ -47,6 +47,47 @@ RSpec.describe "API::RadiusQuickLinkSuggestions", type: :request do
       end
     end
 
+    context "with 3 courses in separate radius buckets, checking the links" do
+      before do
+        subject_record = find_or_create(:secondary_subject, :mathematics)
+
+        create(:course, :secondary, :published, subjects: [subject_record], site_statuses: [
+          build(:site_status, :findable, site: build(:site, latitude: 51.4550, longitude: -0.9711)),
+        ])
+      end
+
+      it "routes each suggestion through track_click, naming the radius" do
+        get "/api/radius_quick_link_suggestions", params: search_params
+
+        JSON.parse(response.body).each do |link|
+          uri = URI(link["url"])
+          query = Rack::Utils.parse_query(uri.query)
+
+          expect(uri.path).to eq("/track_click")
+          expect(query["utm_content"]).to match(/\Ano_results_radius_quick_link_\d+_miles\z/)
+          expect(query["url"]).to start_with("/results?")
+        end
+      end
+
+      # The destination is built from the visitor's own query string, and it is
+      # now the url a redirect acts on, so it must not be able to leave the site.
+      it "cannot be pushed off site by url_for options in the query string" do
+        get "/api/radius_quick_link_suggestions", params: search_params.merge(
+          host: "evil.com",
+          protocol: "https",
+          script_name: "//evil.com",
+        )
+
+        links = JSON.parse(response.body)
+        expect(links).not_to be_empty
+
+        links.each do |link|
+          expect(link["url"]).to start_with("/track_click?")
+          expect(Rack::Utils.parse_query(URI(link["url"]).query)["url"]).to start_with("/results?")
+        end
+      end
+    end
+
     context "when a bucket has over 100 results" do
       before do
         101.times do

--- a/spec/services/courses/radius_quick_link_suggestions_spec.rb
+++ b/spec/services/courses/radius_quick_link_suggestions_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Courses::RadiusQuickLinkSuggestions do
+  include Rails.application.routes.url_helpers
+
+  subject(:suggestions) do
+    described_class.new(
+      params: { subject_name: "Mathematics" },
+      i18n_scope: "api.radius_quick_link_suggestions",
+      request_query: { "subject_name" => "Mathematics" },
+      query_service:,
+    ).call
+  end
+
+  let(:query_service) { class_double(Courses::Query, call: relation) }
+  let(:relation) { instance_double(ActiveRecord::Relation, limit: courses) }
+
+  # minimum_distance_to_search_location is selected by the query rather than
+  # declared on Course, so stand in for it with a struct.
+  let(:searched_course) { Struct.new(:minimum_distance_to_search_location) }
+
+  # One course 30 miles away and one 80 miles away, so the 50 and 100 mile
+  # buckets are the ones with results.
+  let(:courses) { [searched_course.new(30), searched_course.new(80)] }
+
+  it "suggests a link for each radius that has courses" do
+    expect(suggestions.map { |link| link[:text] }).to eq(
+      ["50 miles (1 course)", "100 miles (2 courses)"],
+    )
+  end
+
+  it "routes every link through track_click" do
+    expect(suggestions.map { |link| URI(link[:url]).path }).to all(eq("/track_click"))
+  end
+
+  it "names the radius in the utm_content so each link can be told apart" do
+    utm_contents = suggestions.map { |link| Rack::Utils.parse_query(URI(link[:url]).query)["utm_content"] }
+
+    expect(utm_contents).to eq(
+      %w[no_results_radius_quick_link_50_miles no_results_radius_quick_link_100_miles],
+    )
+  end
+
+  it "keeps the widened search as the tracked destination" do
+    destinations = suggestions.map { |link| Rack::Utils.parse_query(URI(link[:url]).query)["url"] }
+
+    expect(destinations).to eq(
+      [
+        find_results_path(subject_name: "Mathematics", radius: 50),
+        find_results_path(subject_name: "Mathematics", radius: 100),
+      ],
+    )
+  end
+end

--- a/spec/system/find/course/viewing_a_course_spec.rb
+++ b/spec/system/find/course/viewing_a_course_spec.rb
@@ -266,6 +266,8 @@ private
 
     has_apply_for_course_buttons
 
+    has_tracked_visa_sponsorship_links
+
     expect(find_course_show_page).to have_no_content("When you apply you’ll need these codes for the Choices section of your application form")
 
     expect(find_course_show_page).not_to have_end_of_cycle_notice
@@ -287,6 +289,34 @@ private
       expect(uri.path).to eq("/track_click")
       expect(params["url"]).to eq(expected_url)
       expect(params["utm_content"]).to eq(expected_utm_contents[i])
+    end
+  end
+
+  def has_tracked_visa_sponsorship_links
+    expected_links = [
+      {
+        text: "find out more about the types of visa you can apply for",
+        url: I18n.t("find.get_into_teaching.url_visas_for_non_uk_trainees"),
+        utm_content: "student_visa_available_types_of_visa",
+      },
+      {
+        text: "contact the training provider",
+        url: find_provider_path(provider.provider_code, @course.course_code),
+        utm_content: "student_visa_available_contact_the_training_provider",
+      },
+    ]
+
+    expected_links.each do |expected|
+      # The visa sponsorship section is inside a collapsed details element.
+      links = all("a", text: expected[:text], exact_text: true, visible: :all)
+      expect(links.size).to eq(1)
+
+      uri = URI(links.first[:href])
+      params = Rack::Utils.parse_query(uri.query)
+
+      expect(uri.path).to eq("/track_click")
+      expect(params["url"]).to eq(expected[:url])
+      expect(params["utm_content"]).to eq(expected[:utm_content])
     end
   end
 

--- a/spec/system/find/results/no_results_spec.rb
+++ b/spec/system/find/results/no_results_spec.rb
@@ -100,6 +100,13 @@ RSpec.describe "No search results", :js, service: :find do
   end
 
   def then_i_click_on_radius_quick_link
+    link = find_link("100 miles (1 course)")
+    uri = URI(link[:href])
+    query = Rack::Utils.parse_query(uri.query)
+
+    expect(uri.path).to eq("/track_click")
+    expect(query["utm_content"]).to eq("no_results_radius_quick_link_100_miles")
+
     click_link "100 miles (1 course)"
     expect(page).to have_title("1 mathematics course in London - Find teacher training courses - GOV.UK")
     expect(page).to have_content("Mathematics - Reading")


### PR DESCRIPTION
## Context

Adds `track_click` tracking to three untracked candidate-facing links, so the upcoming analytics work has full coverage of service track links.

## What's tracked now

| Link | `utm_content` |
|---|---|
| Visa sponsorship → types of visa (fee course, sponsors) | `student_visa_available_types_of_visa` |
| Visa sponsorship → types of visa (salaried, sponsors) | `skilled_worker_visa_available_types_of_visa` |
| Visa sponsorship → types of visa (salaried, cannot sponsor) | `skilled_worker_visa_not_available_types_of_visa` |
| Visa sponsorship → contact the training provider | `<visa_type>_available_contact_the_training_provider` |
| No results → wider radius suggestions | `no_results_radius_quick_link_{10,20,50,100}_miles` |

The ticket only asks for courses that sponsor visas, but the types of visa link also renders on salaried courses that cannot sponsor a Skilled Worker visa, so that variant is covered too.

## Notes for review

- The two visa links were hand-written `<a>` tags inside a block of HTML in `find.yml`, one with an **unquoted** `href=%{provider_url}`. The first commit moves the anchors into `govuk_link_to` calls, matching `entry_requirements_component`, and changes nothing on the page — the unquoted attribute would have broken once an `&`-bearing track URL went into it.
- The radius links are built from the visitor's own query string, and that value is now what a redirect acts on. There's a spec proving `host`, `protocol` and `script_name` in the query can't push it off site: they arrive as string keys, so `url_for` treats them as ordinary query params. `safe_redirect_url` is a second barrier behind that.
- Publish preview needs no special handling — `/track_click` on the publish host resolves to `Publish::TrackController`, which no-ops the event.
- **Separate commit, worth flagging to whoever owns the dashboards:** four advice callout links passed `utm:` rather than `utm_content:`, and the specs mirrored the typo, so they've been recording clicks with a null `utm_content`. That value stops being null for `how_to_choose_a_training_provider`, `interview_preparation`, `school_placement_activities` and `teacher_training_expectations`.

