### PR TITLE
Make solid_cache_entries UNLOGGED to reduce WAL pressure

### DIFF
--- a/db/migrate/20260909161043_set_solid_cache_entries_unlogged.rb
+++ b/db/migrate/20260909161043_set_solid_cache_entries_unlogged.rb
@@ -1,0 +1,11 @@
+class SetSolidCacheEntriesUnlogged < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured { execute "ALTER TABLE solid_cache_entries SET UNLOGGED" }
+  end
+
+  def down
+    safety_assured { execute "ALTER TABLE solid_cache_entries SET LOGGED" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_27_153000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_09_161043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"


### PR DESCRIPTION
## Context

Solid Cache’s `solid_cache_entries` table is already deployed as a normal logged table. Before we switch Rails.cache to Solid Cache, we should make it `UNLOGGED` so disposable cache writes do not add unnecessary WAL / replication pressure (Airbyte is enabled on production).

This must land and deploy before the cache cutover PR.

## Changes proposed in this pull request

- Add a migration to `ALTER TABLE solid_cache_entries SET UNLOGGED` (with a `SET LOGGED` rollback).

## Guidance to review

- Confirm the migration matches the Apply `SET UNLOGGED` pattern (`disable_ddl_transaction!` + `safety_assured`).
- Safe while the table is still empty / unused in production.
