### PR TITLE
Upgrade govuk frontend and moj frontend

### DIFF
--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -26,7 +26,7 @@ body:not(.js-enabled) {
 }
 
 .course-accordion .govuk-accordion__section {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border-left: govuk-spacing(1) solid transparent;
 }
 

--- a/app/assets/stylesheets/components/_active-filters.scss
+++ b/app/assets/stylesheets/components/_active-filters.scss
@@ -61,7 +61,7 @@
 
   cursor: pointer;
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border: 1px solid $govuk-border-colour;
   border-radius: 0.3125em;
 
@@ -86,7 +86,7 @@
   &:hover {
     text-decoration: none;
 
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     border-color: $govuk-text-colour;
   }
 
@@ -99,7 +99,7 @@
   }
 
   &:active {
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 
   @include govuk-media-query($until: tablet) {

--- a/app/assets/stylesheets/components/_callout.scss
+++ b/app/assets/stylesheets/components/_callout.scss
@@ -3,7 +3,7 @@
 
   padding: govuk-spacing(3);
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   border-left-width: govuk-spacing(1);
 
   &.app-callout--light-purple {

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -5,7 +5,7 @@
 
   display: block;
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   > :last-child {
     margin-bottom: 0;

--- a/app/assets/stylesheets/components/_filters.scss
+++ b/app/assets/stylesheets/components/_filters.scss
@@ -1,11 +1,3 @@
-@import "@ministryofjustice/frontend/moj/settings/assets";
-@import "@ministryofjustice/frontend/moj/settings/measurements";
-@import "@ministryofjustice/frontend/moj/helpers/all";
-@import "@ministryofjustice/frontend/moj/objects/width-container";
-@import "@ministryofjustice/frontend/moj/objects/filter-layout";
-@import "@ministryofjustice/frontend/moj/objects/scrollable-pane";
-@import "@ministryofjustice/frontend/moj/components/filter/filter";
-
 .app-filter {
   box-shadow: none;
 

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -36,9 +36,33 @@
     width: auto;
 
     margin-left: auto;
+
+    @include govuk-media-query($until: desktop) {
+      flex-direction: column;
+
+      gap: 0;
+
+      align-items: stretch;
+
+      padding-bottom: govuk-spacing(3);
+    }
   }
 }
 
 .govuk-service-navigation .govuk-service-navigation__container {
   justify-content: space-between;
+}
+
+// Below desktop the account links stack full width, one per row.
+// govuk-frontend 6 removed the header navigation component that used to do
+// this, so the spacing, divider and link size are carried over from its v5
+// styles.
+@include govuk-media-query($until: desktop) {
+  .with-extra-content .account-options .govuk-link {
+    padding-top: govuk-spacing(3);
+    padding-bottom: govuk-spacing(2);
+
+    border-bottom: 1px solid govuk-colour("white");
+    @include govuk-font-size($size: 16);
+  }
 }

--- a/app/assets/stylesheets/components/_list.scss
+++ b/app/assets/stylesheets/components/_list.scss
@@ -9,7 +9,7 @@
       top: 0;
       left: -16px;
 
-      color: govuk-colour("dark-grey");
+      color: govuk-colour("black", $variant: "tint-25");
 
       content: "\2013";
     }

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -20,7 +20,7 @@
 }
 
 .app-pagination__item {
-  @include govuk-font(14);
+  @include govuk-font(16);
   float: left;
 
   width: 50%;

--- a/app/assets/stylesheets/components/_summary-card.scss
+++ b/app/assets/stylesheets/components/_summary-card.scss
@@ -12,7 +12,7 @@
   .app-summary-card__header {
     padding: govuk-spacing(3);
 
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
 
     @include govuk-media-query($from: desktop) {
       display: flex;

--- a/app/assets/stylesheets/find/components/_accordion.scss
+++ b/app/assets/stylesheets/find/components/_accordion.scss
@@ -16,7 +16,7 @@ body:not(.js-enabled) {
   .govuk-accordion__section {
     padding-bottom: govuk-spacing(1);
 
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     border-left: 5px solid $git-brand-colour;
   }
 

--- a/app/assets/stylesheets/find/components/_feedback.scss
+++ b/app/assets/stylesheets/find/components/_feedback.scss
@@ -12,5 +12,5 @@
 
   outline: 0;
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 }

--- a/app/assets/stylesheets/find/components/_homepage_search.scss
+++ b/app/assets/stylesheets/find/components/_homepage_search.scss
@@ -1,7 +1,7 @@
 .app-homepage-search-container {
   margin-bottom: govuk-spacing(4);
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(6);

--- a/app/assets/stylesheets/find/components/_quick-link-card.scss
+++ b/app/assets/stylesheets/find/components/_quick-link-card.scss
@@ -1,7 +1,7 @@
 .quick-link-card {
   padding: govuk-spacing(3);
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(4);

--- a/app/assets/stylesheets/find/components/_search-results.scss
+++ b/app/assets/stylesheets/find/components/_search-results.scss
@@ -49,7 +49,7 @@
   padding: govuk-spacing(3);
   margin-bottom: govuk-spacing(5);
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   .autocomplete__input {
     background-color: govuk-colour("white");

--- a/app/assets/stylesheets/govuk_style_setup.scss
+++ b/app/assets/stylesheets/govuk_style_setup.scss
@@ -1,8 +1,7 @@
 $govuk-fonts-path: "/";
 $govuk-images-path: "/";
-$govuk-new-typography-scale: true;
 
-@import "govuk-frontend/dist/govuk/all";
+@import "govuk-frontend/dist/govuk/index";
 
 $mobile-small-start: 400px;
 $mobile-small-end: 401px;

--- a/app/assets/stylesheets/publish/application.scss
+++ b/app/assets/stylesheets/publish/application.scss
@@ -54,7 +54,7 @@ $app-callout-light-blue-colour: #f3f8f6;
       top: 0;
       left: -16px;
 
-      color: govuk-colour("dark-grey");
+      color: govuk-colour("black", $variant: "tint-25");
 
       content: "\2013";
     }

--- a/app/assets/stylesheets/publish/application.scss
+++ b/app/assets/stylesheets/publish/application.scss
@@ -1,7 +1,25 @@
 // Entry point for your Sass build
+//
+// MOJ Frontend must load before govuk-frontend. It configures govuk-frontend's
+// `base` module with `@forward ... with (...)`, and Sass only lets a module be
+// configured on its first load. If govuk-frontend loads first, MOJ Frontend
+// fails with "This module was already loaded, so it can't be configured using
+// with".
+//
+// $moj-images-path has to be configured at load time, before MOJ Frontend
+// emits its CSS. "/" makes MOJ reference its icons by bare filename, which is
+// what Propshaft resolves against config.assets.paths.
+@use "node_modules/@ministryofjustice/frontend/moj/all" as * with (
+  $moj-images-path: "/"
+);
+
+// MOJ Frontend sets $govuk-include-default-font-face to false because it
+// assumes govuk-frontend has already emitted the GDS Transport @font-face
+// rules. Here govuk-frontend loads second, so turn them back on. The asset
+// paths are reset in ../govuk_style_setup.
+$govuk-include-default-font-face: true;
+
 @import "../govuk_style_setup";
-@import "@ministryofjustice/frontend/moj/all";
-$moj-images-path: "@ministryofjustice/frontend/moj/assets/images/";
 @import "dfe-autocomplete/src/dfe-autocomplete";
 @import "../one-login";
 

--- a/app/assets/stylesheets/publish/components/_inset-text.scss
+++ b/app/assets/stylesheets/publish/components/_inset-text.scss
@@ -33,6 +33,6 @@
   }
 }
 
-.app-inset-prompt { 
-  background-color: govuk-colour("light-grey");
+.app-inset-prompt {
+  background-color: govuk-colour("black", $variant: "tint-95");
 }

--- a/app/assets/stylesheets/publish/components/_school-search.scss
+++ b/app/assets/stylesheets/publish/components/_school-search.scss
@@ -8,7 +8,7 @@
 .app-school-search {
   padding: govuk-spacing(3);
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   @include govuk-responsive-margin(6, "top");
   @include govuk-responsive-margin(6, "bottom");

--- a/app/assets/stylesheets/publish/components/_status-box.scss
+++ b/app/assets/stylesheets/publish/components/_status-box.scss
@@ -16,7 +16,7 @@
 
   // Add a 2px solid border around tags which match colour of the text
   .govuk-tag--grey {
-    border: 2px solid govuk-shade(govuk-colour("dark-grey"), 30);
+    border: 2px solid govuk-shade(govuk-colour("black", $variant: "tint-25"), 30);
   }
 
   .govuk-tag--yellow {

--- a/app/assets/stylesheets/publish/components/_status-box.scss
+++ b/app/assets/stylesheets/publish/components/_status-box.scss
@@ -2,7 +2,7 @@
   @include govuk-responsive-margin(6, "bottom");
   padding: govuk-spacing(4);
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   > *:last-child {
     margin-bottom: 0;

--- a/app/components/filters/view.html.erb
+++ b/app/components/filters/view.html.erb
@@ -5,6 +5,9 @@
         <div class="moj-filter__header-title">
           <h2 class="govuk-heading-m">Filters</h2>
         </div>
+
+        <%# FilterToggleButton renders its close button into this container. %>
+        <div class="moj-filter__header-action"></div>
       </div>
 
       <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -1,15 +1,9 @@
-<%= govuk_header homepage_url: "https://www.gov.uk", classes: ["app-header--wide-logo", "govuk-header--full-width-border"] do |header| %>
+<%= govuk_header homepage_url: "https://www.gov.uk", classes: ["app-header--wide-logo", "govuk-header--full-width-border", "with-extra-content"] do |header| %>
   <% if current_user %>
-    <nav aria-label="Menu" class="govuk-header__navigation govuk-header__navigation--end app-header-account-options">
-      <ul class="govuk-header__navigation-list">
-        <li class="govuk-header__navigation-item">
-          <%= link_to current_user.full_name, Settings.dfe_signin.profile, class: "govuk-header__link" %>
-        </li>
-        <li class="govuk-header__navigation-item">
-          <%= link_to "Sign out", sign_out_path, class: "govuk-header__link" %>
-        </li>
-      </ul>
-    </nav>
+    <div class="govuk-header__content account-options">
+      <%= govuk_link_to(Settings.dfe_signin.profile, inverse: true, no_underline: true) { current_user.full_name } %>
+      <%= govuk_link_to(sign_out_path, inverse: true, no_underline: true) { "Sign out" } %>
+    </div>
   <% end %>
 <% end %>
 

--- a/app/javascript/publish/filters.js
+++ b/app/javascript/publish/filters.js
@@ -1,25 +1,26 @@
-import { FilterToggleButton } from '@ministryofjustice/frontend/moj/all'
+import { FilterToggleButton } from '@ministryofjustice/frontend'
 
 export default class FilterToggle {
   static init () {
-    const filterContainer = $('.moj-filter-layout__filter')
+    const filterContainer = document.querySelector('.moj-filter-layout__filter')
 
-    if (filterContainer.length) {
-      return new FilterToggleButton({
+    if (filterContainer) {
+      return new FilterToggleButton(filterContainer, {
         bigModeMediaQuery: '(min-width: 48.063em)',
         startHidden: false,
         toggleButton: {
-          container: $('.moj-action-bar__filter'),
           showText: 'Show filters',
           hideText: 'Hide filters',
           classes: 'govuk-button--secondary'
         },
+        toggleButtonContainer: {
+          selector: '.moj-action-bar__filter'
+        },
         closeButton: {
-          container: $('.moj-filter__header-action'),
           text: 'Close'
         },
-        filter: {
-          container: filterContainer
+        closeButtonContainer: {
+          selector: '.moj-filter__header-action'
         }
       })
     }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,5 +13,8 @@ Rails.application.config.assets.version = "1.0"
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
 # govuk-frontend related assets
-Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets/rebrand/images")
+Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets/images")
 Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets/fonts")
+
+# MOJ Frontend related assets
+Rails.application.config.assets.paths << Rails.root.join("node_modules/@ministryofjustice/frontend/moj/assets/images")

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "build": "yarn run build:css && yarn run build:js",
     "build:css": "yarn run build:css:publish && yarn run build:css:find",
-    "build:css:publish": "sass ./app/assets/stylesheets/publish/application.scss ./app/assets/builds/publish/application.css --no-source-map --load-path=node_modules --load-path=. --quiet-deps",
-    "build:css:find": "sass ./app/assets/stylesheets/find/application.scss ./app/assets/builds/find/application.css --no-source-map --load-path=node_modules --load-path=. --quiet-deps",
+    "build:css:publish": "sass  --silence-deprecation=import ./app/assets/stylesheets/publish/application.scss ./app/assets/builds/publish/application.css --no-source-map --load-path=node_modules --load-path=. --quiet-deps",
+    "build:css:find": "sass  --silence-deprecation=import ./app/assets/stylesheets/find/application.scss ./app/assets/builds/find/application.css --no-source-map --load-path=node_modules --load-path=. --quiet-deps",
     "build:js": "yarn run build:js:publish && yarn run build:js:find",
     "build:js:publish": "esbuild app/javascript/publish/*.* --bundle --sourcemap --outdir=app/assets/builds/publish",
     "build:js:find": "esbuild app/javascript/find/*.* --bundle --sourcemap --outdir=app/assets/builds/find",
@@ -39,9 +39,9 @@
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
-    "@ministryofjustice/frontend": "2.0.0",
+    "@ministryofjustice/frontend": "11.0.1",
     "dfe-autocomplete": "DFE-Digital/dfe-autocomplete#v1.0.0",
-    "govuk-frontend": "^5.11.1",
+    "govuk-frontend": "^6.5.0",
     "govuk-one-login-service-header": "https://github.com/govuk-one-login/service-header#v4.0.0",
     "jquery": "^4.0.0",
     "lodash.throttle": "^4.1.1",

--- a/spec/system/publish/courses/schools/search_schools_spec.rb
+++ b/spec/system/publish/courses/schools/search_schools_spec.rb
@@ -464,8 +464,8 @@ RSpec.describe "Publish - Searching the placement schools list", :js, type: :sys
       })()
     JS
 
-    # rgb(243, 242, 241) is govuk-colour("black", $variant: "tint-95").
-    expect(JSON.parse(style)).to eq("border" => "0px", "background" => "rgb(243, 242, 241)")
+    # rgb(243, 243, 243) is govuk-colour("black", $variant: "tint-95").
+    expect(JSON.parse(style)).to eq("border" => "0px", "background" => "rgb(243, 243, 243)")
   end
 
   def then_the_search_box_fills_the_panel

--- a/spec/system/publish/courses/schools/search_schools_spec.rb
+++ b/spec/system/publish/courses/schools/search_schools_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe "Publish - Searching the placement schools list", :js, type: :sys
       })()
     JS
 
-    # rgb(243, 242, 241) is govuk-colour("light-grey").
+    # rgb(243, 242, 241) is govuk-colour("black", $variant: "tint-95").
     expect(JSON.parse(style)).to eq("border" => "0px", "background" => "rgb(243, 242, 241)")
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,15 +513,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ministryofjustice/frontend@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@ministryofjustice/frontend@npm:2.0.0"
-  dependencies:
-    govuk-frontend: "npm:^5.0.0"
-    moment: "npm:^2.27.0"
+"@ministryofjustice/frontend@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@ministryofjustice/frontend@npm:11.0.1"
   peerDependencies:
-    jquery: ^3.6.0
-  checksum: 10c0/dec493546163121c3081afbbfd7a8934a0eb8eb805190bb734b7c6b56e5a85cff471e678fffab4e728b7b1ebfafde4c3e5743c62b45273713fc12ab82e199692
+    govuk-frontend: ^6.0.0
+    moment: 2.30.1
+  checksum: 10c0/db58569a6bdce434b0fef7fc9c9efca3b31d0ad289d05cadeb06ca3c00069705d45a12e19a68734c97e1999fb2e6919ef76b38ce4fcd6a53696387e02f318b33
   languageName: node
   linkType: hard
 
@@ -2670,17 +2668,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^5.0.0":
-  version: 5.11.1
-  resolution: "govuk-frontend@npm:5.11.1"
-  checksum: 10c0/e194673fb4147b5a536b014db48baadcb69506023973bdc4a97964d0d377dc42aa6ce1e4671ee73efbf38aa448c5d3e9d9504fbfd6ff9483e301071c3767eb94
-  languageName: node
-  linkType: hard
-
 "govuk-frontend@npm:^5.11.1":
   version: 5.13.0
   resolution: "govuk-frontend@npm:5.13.0"
   checksum: 10c0/af1c1495c9b543b442709a8131f4455019e07cd9eeea31a4a43b098496047d3468ed3c162d9b246b178c4a3d4214f64b85360bceea95406b188b3d42353593d4
+  languageName: node
+  linkType: hard
+
+"govuk-frontend@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "govuk-frontend@npm:6.5.0"
+  checksum: 10c0/dad7f5a8fd6ecce9984779e972825bf9b24d1c00fd8ce7c26dbdfbe9673cdbad1ca72b567898f77bbcd9c0291ae0176c1ee2e5cb47f1181ba3edb4e8a09dd9ee
   languageName: node
   linkType: hard
 
@@ -3802,13 +3800,6 @@ __metadata:
   dependencies:
     minipass: "npm:^7.1.2"
   checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
-  languageName: node
-  linkType: hard
-
-"moment@npm:^2.27.0":
-  version: 2.30.1
-  resolution: "moment@npm:2.30.1"
-  checksum: 10c0/865e4279418c6de666fca7786607705fd0189d8a7b7624e2e56be99290ac846f90878a6f602e34b4e0455c549b85385b1baf9966845962b313699e7cb847543a
   languageName: node
   linkType: hard
 
@@ -5335,10 +5326,10 @@ __metadata:
   resolution: "teacher-training-api@workspace:."
   dependencies:
     "@hotwired/stimulus": "npm:^3.2.2"
-    "@ministryofjustice/frontend": "npm:2.0.0"
+    "@ministryofjustice/frontend": "npm:11.0.1"
     dfe-autocomplete: "DFE-Digital/dfe-autocomplete#v1.0.0"
     esbuild: "npm:^0.28.2"
-    govuk-frontend: "npm:^5.11.1"
+    govuk-frontend: "npm:^6.5.0"
     govuk-one-login-service-header: "https://github.com/govuk-one-login/service-header#v4.0.0"
     jquery: "npm:^4.0.0"
     jsdom: "npm:^30.0.1"


### PR DESCRIPTION
## Context

This branch upgrades govuk-frontend from 5 to 6, and MOJ Frontend from 2 to 11. Both libraries make breaking changes. This branch fixes what breaks.

Two things.

First, MOJ Frontend must load before govuk-frontend in Sass. MOJ Frontend configures the govuk-frontend `base` module with `@forward ... with (...)`. Sass permits configuration only on the first load of a module. The MOJ Frontend documentation puts govuk-frontend first, and that order fails to compile.

Second, govuk-frontend 6 removes the header navigation component. The account links in the header lose their styles on Publish and on Support.

## Changes proposed in this pull request

- The Publish stylesheet compiles again.
- light-, dark- and mid-grey are deprecated. Replace them with the official suggestion.
- font size 14 is deprecated in govuk-frontend
- The GDS Transport fonts load again. MOJ Frontend turns them off, so we turn them on after it loads.
- The filter toggle button works again. MOJ Frontend 9 changes the `FilterToggleButton` API.
- Every page loads again. govuk-frontend 6 moves its images, so `image_path` raised `Propshaft::MissingAssetError`.
- The filter icons from MOJ Frontend load.
- We copied the values styles for the stacked links from govuk-frontend 5.11.1.
- The header account links have styles again. They stack below 769px, and they form one row above it.

## Guidance to review

Sign in to Support. Look at the header at 375px wide and at 1024px wide. Open a page with filters, make the window narrow, and use the "Show filters" button.


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
