### PR TITLE
Fix flaky financial support spec

### DIFF
--- a/spec/components/shared/courses/financial_support/fees_and_financial_support_component/view_spec.rb
+++ b/spec/components/shared/courses/financial_support/fees_and_financial_support_component/view_spec.rb
@@ -73,7 +73,7 @@ describe Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::Vi
     it "renders the scholarships and bursary section" do
       FeatureFlag.activate(:bursaries_and_scholarships_announced)
       enrichment = create(:course_enrichment)
-      course = create(:course, :secondary, funding: "fee", enrichments: [enrichment], name: "History", subjects: [build(:secondary_subject, bursary_amount: "2000", scholarship: "1000"), build(:secondary_subject)]).decorate
+      course = create(:course, :secondary, funding: "fee", enrichments: [enrichment], name: "History", subjects: [build(:secondary_subject, :history, bursary_amount: "2000", scholarship: "1000"), build(:secondary_subject, :drama)]).decorate
 
       result = render_inline(described_class.new(course, enrichment))
 


### PR DESCRIPTION
## Context

The spec `spec/components/shared/courses/financial_support/fees_and_financial_support_component/view_spec.rb:73` failed at random about 1 run in 385. 

It built two subjects with the bare `:secondary_subject` factory, which picks a random name from a list of 34. 

The course factory makes the first subject the master subject, and the second subject becomes the subordinate subject.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
