### PR TITLE
Full course data export CSV

### DIFF
--- a/app/controllers/support/courses/exports_controller.rb
+++ b/app/controllers/support/courses/exports_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Support
+  module Courses
+    class ExportsController < ApplicationController
+      def full_course_information
+        export = ::Exports::FullCourseInformationList.new(provider:)
+
+        respond_to do |format|
+          format.csv { send_data(export.data, filename: export.filename, disposition: :attachment) }
+        end
+      end
+
+    private
+
+      def provider
+        @provider ||= recruitment_cycle.providers.find(params[:provider_id])
+      end
+    end
+  end
+end

--- a/app/services/exports/accredited_course_list.rb
+++ b/app/services/exports/accredited_course_list.rb
@@ -47,8 +47,8 @@ module Exports
             course.study_mode_description.capitalize,
             start_date(course),
             course_length(enrichment&.course_length),
-            number_to_currency(enrichment&.fee_uk_eu),
-            number_to_currency(enrichment&.fee_international),
+            fee(course, enrichment&.fee_uk_eu),
+            fee(course, enrichment&.fee_international),
             decorated_course.find_url,
             campus_codes(course),
           ]

--- a/app/services/exports/course_columns.rb
+++ b/app/services/exports/course_columns.rb
@@ -2,10 +2,24 @@
 
 module Exports
   module CourseColumns
+    extend ActiveSupport::Concern
+
+    included do
+      include ActionView::Helpers::NumberHelper
+    end
+
     # A CSV carries no encoding declaration, so Excel falls back to the legacy
     # Windows code page and renders the UTF-8 "£" (C2 A3) as "Â£". This byte
     # order mark, written first, tells it the file is UTF-8.
     BYTE_ORDER_MARK = "\uFEFF"
+
+    # Salaried and apprenticeship courses charge no fees, so Publish never shows
+    # the fee rows for them. An amount can still be sitting on the enrichment
+    # from before the course changed funding, and printing it would tell a
+    # provider they charge a fee they do not.
+    def fee(course, amount)
+      number_to_currency(amount) if course.fee_based?
+    end
 
     def status(course)
       Publish::Courses::StatusTag.token(course).to_s.humanize

--- a/app/services/exports/course_information_list.rb
+++ b/app/services/exports/course_information_list.rb
@@ -42,8 +42,8 @@ module Exports
             course.study_mode_description.capitalize,
             start_date(course),
             course_length(enrichment&.course_length),
-            number_to_currency(enrichment&.fee_uk_eu),
-            number_to_currency(enrichment&.fee_international),
+            fee(course, enrichment&.fee_uk_eu),
+            fee(course, enrichment&.fee_international),
           ]
         end
       end

--- a/app/services/exports/full_course_information_list.rb
+++ b/app/services/exports/full_course_information_list.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Exports
+  # Every course description section as the provider wrote it, one row per
+  # course. CourseInformationList carries the basic fields only, which is not
+  # enough to review a cycle's copy away from Publish, so this repeats those
+  # columns and adds each long-form section beside them.
+  #
+  # The text goes out as the markdown held on the enrichment rather than
+  # rendered HTML, so an amended cell pastes straight back into Publish. The
+  # enrichment read is the most recent one, draft included, so a provider sees
+  # the copy their course page is showing them rather than an older published
+  # version sitting beneath an unpublished edit.
+  #
+  # Two sections changed shape for the 2027 cycle, and a cycle is fixed for the
+  # whole file, so their columns are chosen once rather than carried in every
+  # file and left blank in half of them.
+  #
+  # Each text column is headed with the question Publish asks rather than a
+  # short label, so a provider can match a column to the box they type into.
+  # The wording is repeated here rather than read from the form's locale keys:
+  # a CSV header is an interface of its own, and renaming a column should be a
+  # deliberate change rather than a side effect of reworking a form.
+  class FullCourseInformationList
+    include ActionView::Helpers::NumberHelper
+    include Publish::CourseInterviewLocationHelper
+    include CourseColumns
+
+    # The last cycle before salary_details gave way to salary_fee_details and
+    # salaried courses began stating the school experience they ask for.
+    FINAL_LEGACY_SECTIONS_CYCLE = 2026
+
+    HEADERS_BEFORE_SALARY = [
+      "Course name",
+      "Course code",
+      "Accredited provider",
+      "Status",
+      "Age range",
+      "Fee or salary",
+      "Qualification",
+      "Study mode",
+      "Start date",
+      "Course length",
+      "UK fee",
+      "Non-UK fee",
+      "When are the fees due? Is there a payment schedule? (optional)",
+      "Are there any additional fees or costs? (optional)",
+      "Does your organisation offer any financial support? (optional)",
+    ].freeze
+
+    HEADERS_AFTER_SCHOOL_EXPERIENCE = [
+      "How do you decide which schools to place trainees in?",
+      "How much time will they spend in each school?",
+      "Where will theoretical training take place? (optional)",
+      "How much time will they spend in theoretical training? (optional)",
+      "What will trainees do while in their placement schools?",
+      "How will they be supported and mentored? (optional)",
+      "What will trainees do during their theoretical training?",
+      "How will they be assessed? (optional)",
+      "What is the interview process? (optional)",
+      "Where will the interviews take place? (optional)",
+    ].freeze
+
+    def initialize(provider:)
+      @provider = provider
+    end
+
+    def data
+      BYTE_ORDER_MARK + CSV.generate(headers:, write_headers: true) do |csv|
+        courses.each { |course| csv << row(course) }
+      end
+    end
+
+    def filename
+      "full-course-information-#{provider.provider_code}-#{Time.zone.today}.csv"
+    end
+
+  private
+
+    attr_reader :provider
+
+    def headers
+      HEADERS_BEFORE_SALARY + [salary_header] + school_experience_headers + HEADERS_AFTER_SCHOOL_EXPERIENCE
+    end
+
+    def row(course)
+      enrichment = latest_enrichment(course)
+
+      values_before_salary(course, enrichment) +
+        [salary_value(enrichment)] +
+        school_experience_values(course) +
+        values_after_school_experience(enrichment)
+    end
+
+    def values_before_salary(course, enrichment)
+      [
+        course.name,
+        course.course_code,
+        accredited_provider(course),
+        status(course),
+        age_range(course),
+        I18n.t("publish.courses.course_table.funding.#{course.funding}"),
+        course.qualifications_summary,
+        course.study_mode_description.capitalize,
+        start_date(course),
+        course_length(enrichment&.course_length),
+        fee(course, enrichment&.fee_uk_eu),
+        fee(course, enrichment&.fee_international),
+        enrichment&.fee_schedule,
+        enrichment&.additional_fees,
+        enrichment&.financial_support,
+      ]
+    end
+
+    def values_after_school_experience(enrichment)
+      [
+        enrichment&.placement_selection_criteria,
+        enrichment&.duration_per_school,
+        enrichment&.theoretical_training_location,
+        enrichment&.theoretical_training_duration,
+        enrichment&.placement_school_activities,
+        enrichment&.support_and_mentorship,
+        enrichment&.theoretical_training_activities,
+        enrichment&.assessment_methods,
+        enrichment&.interview_process,
+        display_interview_location(enrichment&.interview_location),
+      ]
+    end
+
+    # Salaried and apprenticeship courses charge no fees, so Publish never shows
+    # the fee rows for them. An amount can still be sitting on the enrichment
+    # from before the course changed funding, and printing it would tell a
+    # provider they charge a fee they do not.
+    def fee(course, amount)
+      number_to_currency(amount) if course.fee_based?
+    end
+
+    def salary_header
+      if current_sections?
+        "Give details about any fees or other costs that the trainee might have to pay (optional)"
+      else
+        "Salary"
+      end
+    end
+
+    def salary_value(enrichment)
+      current_sections? ? enrichment&.salary_fee_details : enrichment&.salary_details
+    end
+
+    def school_experience_headers
+      current_sections? ? ["What school experience are you looking for?"] : []
+    end
+
+    def school_experience_values(course)
+      return [] unless current_sections?
+
+      [school_experience(course)]
+    end
+
+    # Only salaried and apprenticeship courses are asked the question, so a fee
+    # course leaves the cell empty rather than claiming it asks for none.
+    def school_experience(course)
+      case course.school_experience_required
+      when true then course.school_experience_required_content
+      when false then "Not required"
+      end
+    end
+
+    def current_sections?
+      provider.recruitment_cycle.after?(FINAL_LEGACY_SECTIONS_CYCLE)
+    end
+
+    # Matches CourseEnrichment.most_recent, which backs Course#latest_enrichment,
+    # but reads the preloaded rows rather than querying once per course.
+    def latest_enrichment(course)
+      course.enrichments.max_by { |enrichment| [enrichment.created_at, enrichment.id] }
+    end
+
+    def courses
+      Publish::Courses::Query.call(provider:).preload(:enrichments)
+    end
+
+    def accredited_provider(course)
+      code = course.accredited_provider_code
+      return provider.provider_name if code.blank? || code == provider.provider_code
+
+      course[:group_name] || code
+    end
+  end
+end

--- a/app/services/exports/full_course_information_list.rb
+++ b/app/services/exports/full_course_information_list.rb
@@ -129,14 +129,6 @@ module Exports
       ]
     end
 
-    # Salaried and apprenticeship courses charge no fees, so Publish never shows
-    # the fee rows for them. An amount can still be sitting on the enrichment
-    # from before the course changed funding, and printing it would tell a
-    # provider they charge a fee they do not.
-    def fee(course, amount)
-      number_to_currency(amount) if course.fee_based?
-    end
-
     def salary_header
       if current_sections?
         "Give details about any fees or other costs that the trainee might have to pay (optional)"

--- a/app/services/exports/full_course_information_list.rb
+++ b/app/services/exports/full_course_information_list.rb
@@ -14,9 +14,11 @@ module Exports
   # the copy their course page is showing them rather than an older published
   # version sitting beneath an unpublished edit.
   #
-  # Two sections changed shape for the 2027 cycle, and a cycle is fixed for the
-  # whole file, so their columns are chosen once rather than carried in every
-  # file and left blank in half of them.
+  # Some columns only ever apply to part of the estate: two sections changed
+  # shape for the 2027 cycle, and only teacher degree apprenticeships are asked
+  # about A levels. A cycle and a provider are both fixed for a whole file, so
+  # those columns are chosen once when the file is built rather than carried
+  # everywhere and left blank in most of it.
   #
   # Each text column is headed with the question Publish asks rather than a
   # short label, so a provider can match a column to the box they type into.
@@ -50,6 +52,36 @@ module Exports
       "Does your organisation offer any financial support? (optional)",
     ].freeze
 
+    DEGREE_HEADERS = [
+      "What is the minimum degree classification you require?",
+      "Degree subject requirements",
+    ].freeze
+
+    # Only teacher degree apprenticeship courses are asked about A levels. Both
+    # this and the GCSE section label their free text box "Details about
+    # equivalency tests you offer or accept", so each says which it means: a
+    # repeated header collapses the columns together when the CSV is parsed.
+    A_LEVEL_HEADERS = [
+      "What A level or equivalent qualification is required?",
+      "Will you consider candidates with pending A levels?",
+      "Will you consider candidates who need to take an equivalency test for their A levels?",
+      "Details about equivalency tests you offer or accept (A levels)",
+    ].freeze
+
+    GCSE_HEADERS = [
+      "GCSEs required",
+      "Will you consider candidates with pending GCSEs?",
+      "Will you consider candidates who need to take an equivalency test in English, maths or science?",
+      "Which subjects will you accept equivalency tests in?",
+      "Details about equivalency tests you offer or accept (GCSEs)",
+    ].freeze
+
+    GCSE_EQUIVALENCY_SUBJECTS = {
+      "English" => :accept_english_gcse_equivalency,
+      "Maths" => :accept_maths_gcse_equivalency,
+      "Science" => :accept_science_gcse_equivalency,
+    }.freeze
+
     HEADERS_AFTER_SCHOOL_EXPERIENCE = [
       "How do you decide which schools to place trainees in?",
       "How much time will they spend in each school?",
@@ -82,7 +114,13 @@ module Exports
     attr_reader :provider
 
     def headers
-      HEADERS_BEFORE_SALARY + [salary_header] + school_experience_headers + HEADERS_AFTER_SCHOOL_EXPERIENCE
+      HEADERS_BEFORE_SALARY +
+        [salary_header] +
+        school_experience_headers +
+        DEGREE_HEADERS +
+        a_level_headers +
+        GCSE_HEADERS +
+        HEADERS_AFTER_SCHOOL_EXPERIENCE
     end
 
     def row(course)
@@ -91,6 +129,9 @@ module Exports
       values_before_salary(course, enrichment) +
         [salary_value(enrichment)] +
         school_experience_values(course) +
+        degree_values(course) +
+        a_level_values(course) +
+        gcse_values(course) +
         values_after_school_experience(enrichment)
     end
 
@@ -127,6 +168,84 @@ module Exports
         enrichment&.interview_process,
         display_interview_location(enrichment&.interview_location),
       ]
+    end
+
+    # The grade is a choice rather than free text, so it reads back as the
+    # sentence the course page shows rather than the stored enum value.
+    def degree_values(course)
+      [
+        DegreeRowContent::DEGREE_GRADE_MAPPING[course.degree_grade],
+        course.degree_subject_requirements,
+      ]
+    end
+
+    def a_level_headers
+      any_teacher_degree_apprenticeship? ? A_LEVEL_HEADERS : []
+    end
+
+    def a_level_values(course)
+      return [] unless any_teacher_degree_apprenticeship?
+      return Array.new(A_LEVEL_HEADERS.length) unless course.teacher_degree_apprenticeship?
+
+      [
+        a_level_subject_requirements(course),
+        yes_or_no(course.accept_pending_a_level),
+        yes_or_no(course.accept_a_level_equivalency),
+        course.additional_a_level_equivalencies,
+      ]
+    end
+
+    # One requirement to a line, worded as the course page words them, so a
+    # subject and its minimum grade stay together in a single cell.
+    def a_level_subject_requirements(course)
+      requirements = course.a_level_subject_requirements.map do |requirement|
+        ALevelSubjectRequirementRowComponent.new(requirement).row_value
+      end
+
+      requirements.join("\n").presence
+    end
+
+    def gcse_values(course)
+      [
+        required_gcses(course),
+        yes_or_no(course.accept_pending_gcse),
+        yes_or_no(course.accept_gcse_equivalency),
+        gcse_equivalency_subjects(course),
+        course.additional_gcse_equivalencies,
+      ]
+    end
+
+    # Derived from the course level and the provider's required grade rather
+    # than written by anyone, but it is the first thing the GCSE row shows, so
+    # the file would not be a whole picture of the section without it.
+    def required_gcses(course)
+      subjects = case course.level
+                 when "primary" then "English, maths and science"
+                 when "secondary" then "English and maths"
+                 end
+      return if subjects.blank?
+
+      "Grade #{course.gcse_grade_required} (C) or above in #{subjects}, or equivalent qualification"
+    end
+
+    def gcse_equivalency_subjects(course)
+      GCSE_EQUIVALENCY_SUBJECTS
+        .select { |_subject, attribute| course.public_send(attribute).present? }
+        .keys
+        .to_sentence
+        .presence
+    end
+
+    def yes_or_no(answer)
+      return if answer.nil?
+
+      answer ? "Yes" : "No"
+    end
+
+    def any_teacher_degree_apprenticeship?
+      return @any_teacher_degree_apprenticeship if defined?(@any_teacher_degree_apprenticeship)
+
+      @any_teacher_degree_apprenticeship = provider.courses.teacher_degree_apprenticeship.exists?
     end
 
     def salary_header

--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -45,3 +45,43 @@
 <% end %>
 
 <%= govuk_pagination(pagy: @pagy) %>
+
+<% if @courses.any? %>
+  <div class="govuk-grid-row govuk-!-margin-top-6">
+    <div class="govuk-grid-column-full">
+      <div class="app-status-box">
+        <h2 class="govuk-heading-m"><%= t(".downloads.heading") %></h2>
+        <p class="govuk-body">
+          <%= govuk_link_to(
+            t(".downloads.course_information"),
+            download_course_information_publish_provider_recruitment_cycle_courses_path(
+              @provider.provider_code,
+              @provider.recruitment_cycle_year,
+              format: :csv,
+            ),
+          ) %>
+        </p>
+        <p class="govuk-body">
+          <%= govuk_link_to(
+            t(".downloads.schools"),
+            download_course_schools_publish_provider_recruitment_cycle_courses_path(
+              @provider.provider_code,
+              @provider.recruitment_cycle_year,
+              format: :csv,
+            ),
+          ) %>
+        </p>
+        <p class="govuk-body">
+          <%= govuk_link_to(
+            t(".downloads.full_course_information"),
+            download_full_course_information_support_recruitment_cycle_provider_courses_path(
+              @provider.recruitment_cycle_year,
+              @provider,
+              format: :csv,
+            ),
+          ) %>
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en/support/courses.yml
+++ b/config/locales/en/support/courses.yml
@@ -1,0 +1,9 @@
+en:
+  support:
+    courses:
+      index:
+        downloads:
+          heading: Download course information
+          course_information: Download basic course information (CSV)
+          schools: Download the schools attached to each course (CSV)
+          full_course_information: Download full course information (CSV)

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -46,6 +46,8 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
       end
 
       resources :courses do
+        get "/download-full-course-information", on: :collection, to: "courses/exports#full_course_information", as: :download_full_course_information
+
         resource :revert_withdrawal, only: %i[edit update], path: "revert-withdrawal", controller: "revert_withdrawal"
       end
 

--- a/spec/services/exports/accredited_course_list_spec.rb
+++ b/spec/services/exports/accredited_course_list_spec.rb
@@ -73,6 +73,20 @@ module Exports
         )
       end
 
+      it "leaves the fees empty for a course that charges none, whatever the enrichment holds" do
+        create_partner_course(:apprenticeship, name: "Apprenticeship course", enrichments: [
+          build(:course_enrichment, :published, fee_uk_eu: 9_790, fee_international: 15_000),
+        ])
+        create_partner_course(:salary, name: "Salaried course", enrichments: [
+          build(:course_enrichment, :published, fee_uk_eu: 9_790, fee_international: 15_000),
+        ])
+
+        expect(rows.map { |row| row.values_at("Course name", "UK fee", "Non-UK fee") }).to contain_exactly(
+          ["Apprenticeship course", nil, nil],
+          ["Salaried course", nil, nil],
+        )
+      end
+
       it "lists campus codes in a stable order, whatever order the sites load in" do
         create_partner_course(site_statuses: [
           create(:site_status, :findable, site: create(:site, code: "M")),

--- a/spec/services/exports/course_information_list_spec.rb
+++ b/spec/services/exports/course_information_list_spec.rb
@@ -61,6 +61,22 @@ module Exports
         expect(rows.first.to_h).to include("UK fee" => "£9,535", "Non-UK fee" => "£14,000")
       end
 
+      it "leaves the fees empty for a course that charges none, whatever the enrichment holds" do
+        create(:course, :apprenticeship, provider:, name: "Apprenticeship course", enrichments: [
+          build(:course_enrichment, :published, fee_uk_eu: 9_790, fee_international: 15_000),
+        ])
+        create(:course, :salary, provider:, name: "Salaried course", enrichments: [
+          build(:course_enrichment, :published, fee_uk_eu: 9_790, fee_international: 15_000),
+        ])
+
+        expect(rows.map { |row| row.values_at("Course name", "UK fee", "Non-UK fee") }).to eq(
+          [
+            ["Apprenticeship course", nil, nil],
+            ["Salaried course", nil, nil],
+          ],
+        )
+      end
+
       it "reports a rolled-over course's values, which the model counts as draft" do
         create(:course, :fee, provider:, name: "Geography", enrichments: [
           build(:course_enrichment, :rolled_over, fee_uk_eu: 9_000, course_length: "OneYear"),

--- a/spec/services/exports/full_course_information_list_spec.rb
+++ b/spec/services/exports/full_course_information_list_spec.rb
@@ -25,6 +25,15 @@ module Exports
           age_range_in_years: "11_to_16",
           study_mode: :full_time_or_part_time,
           start_date: Time.zone.local(provider.recruitment_cycle_year.to_i, 9, 1),
+          degree_grade: :two_one,
+          additional_degree_subject_requirements: true,
+          degree_subject_requirements: "A chemistry or closely related degree.",
+          accept_pending_gcse: true,
+          accept_gcse_equivalency: true,
+          accept_english_gcse_equivalency: true,
+          accept_maths_gcse_equivalency: true,
+          accept_science_gcse_equivalency: false,
+          additional_gcse_equivalencies: "We accept Equivalency Testing tests.",
           enrichments: [build(
             :course_enrichment,
             :published,
@@ -65,6 +74,13 @@ module Exports
           "Are there any additional fees or costs? (optional)" => "A £50 DBS check.",
           "Does your organisation offer any financial support? (optional)" => "Bursaries are available.",
           "Salary" => "Paid as an unqualified teacher.",
+          "What is the minimum degree classification you require?" => "2:1 or above, or equivalent",
+          "Degree subject requirements" => "A chemistry or closely related degree.",
+          "GCSEs required" => "Grade 4 (C) or above in English and maths, or equivalent qualification",
+          "Will you consider candidates with pending GCSEs?" => "Yes",
+          "Will you consider candidates who need to take an equivalency test in English, maths or science?" => "Yes",
+          "Which subjects will you accept equivalency tests in?" => "English and Maths",
+          "Details about equivalency tests you offer or accept (GCSEs)" => "We accept Equivalency Testing tests.",
           "How do you decide which schools to place trainees in?" => "We match on travel time.",
           "How much time will they spend in each school?" => "Two terms in each school.",
           "Where will theoretical training take place? (optional)" => "At our Frenchay campus.",
@@ -121,6 +137,47 @@ module Exports
             ["Salaried course", nil, nil],
           ],
         )
+      end
+
+      it "omits the A level columns, which no course in the cycle is asked about" do
+        create(:course, :fee, provider:, name: "Chemistry")
+
+        expect(rows.headers).not_to include("What A level or equivalent qualification is required?")
+      end
+
+      context "when the provider runs a teacher degree apprenticeship" do
+        it "carries the A levels that course asks for" do
+          create(:course, :fee, :with_teacher_degree_apprenticeship, :with_a_level_requirements, provider:, name: "Chemistry",
+                                                                                                 additional_a_level_equivalencies: "We accept the Access to HE Diploma.")
+
+          expect(rows.first.to_h).to include(
+            "What A level or equivalent qualification is required?" => "Any subject - Grade A or above",
+            "Will you consider candidates with pending A levels?" => "Yes",
+            "Will you consider candidates who need to take an equivalency test for their A levels?" => "Yes",
+            "Details about equivalency tests you offer or accept (A levels)" => "We accept the Access to HE Diploma.",
+          )
+        end
+
+        it "leaves the A level columns empty for a course that is never asked about them" do
+          create(:course, :fee, :with_teacher_degree_apprenticeship, :with_a_level_requirements, provider:, name: "Apprenticeship")
+          create(:course, :fee, provider:, name: "Biology")
+
+          expect(rows.find { |row| row["Course name"] == "Biology" }.to_h).to include(
+            "What A level or equivalent qualification is required?" => nil,
+            "Will you consider candidates with pending A levels?" => nil,
+          )
+        end
+
+        it "lists every A level a course asks for, one to a line" do
+          create(:course, :fee, :with_teacher_degree_apprenticeship, provider:, name: "Chemistry", a_level_subject_requirements: [
+            { uuid: SecureRandom.uuid, subject: "any_science_subject", minimum_grade_required: "B" },
+            { uuid: SecureRandom.uuid, subject: "other_subject", other_subject: "Chemistry", minimum_grade_required: "A*" },
+          ])
+
+          expect(rows.first["What A level or equivalent qualification is required?"]).to eq(
+            "Any science subject - Grade B or above\nChemistry - Grade A*",
+          )
+        end
       end
 
       it "omits school experience, which no course in the cycle can be asked for" do

--- a/spec/services/exports/full_course_information_list_spec.rb
+++ b/spec/services/exports/full_course_information_list_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Exports
+  describe FullCourseInformationList do
+    subject(:export) { described_class.new(provider: provider.reload) }
+
+    let(:provider) { create(:provider) }
+
+    def rows
+      CSV.parse(export.data.delete_prefix(Exports::CourseColumns::BYTE_ORDER_MARK), headers: true)
+    end
+
+    describe "#data" do
+      it "heads each text column with the question the provider answers in Publish" do
+        create(
+          :course,
+          :secondary,
+          :fee,
+          :resulting_in_pgce_with_qts,
+          provider:,
+          name: "Chemistry",
+          course_code: "2KGZ",
+          age_range_in_years: "11_to_16",
+          study_mode: :full_time_or_part_time,
+          start_date: Time.zone.local(provider.recruitment_cycle_year.to_i, 9, 1),
+          enrichments: [build(
+            :course_enrichment,
+            :published,
+            course_length: "OneYear",
+            fee_uk_eu: 9_790,
+            fee_international: 15_000,
+            fee_schedule: "Paid in three instalments.",
+            additional_fees: "A £50 DBS check.",
+            financial_support: "Bursaries are available.",
+            salary_details: "Paid as an unqualified teacher.",
+            placement_selection_criteria: "We match on travel time.",
+            duration_per_school: "Two terms in each school.",
+            theoretical_training_location: "At our Frenchay campus.",
+            theoretical_training_duration: "One day a week.",
+            placement_school_activities: "You will teach a reduced timetable.",
+            support_and_mentorship: "A school mentor meets you weekly.",
+            theoretical_training_activities: "Seminars on pedagogy.",
+            assessment_methods: "Two written assignments.",
+            interview_process: "A subject knowledge task and an interview.",
+            interview_location: "both",
+          )],
+        )
+
+        expect(rows.first.to_h).to eq(
+          "Course name" => "Chemistry",
+          "Course code" => "2KGZ",
+          "Accredited provider" => provider.provider_name,
+          "Status" => "Closed",
+          "Age range" => "11 to 16",
+          "Fee or salary" => "Fee-paying",
+          "Qualification" => "QTS with PGCE",
+          "Study mode" => "Full time or part time",
+          "Start date" => "September #{provider.recruitment_cycle_year}",
+          "Course length" => "1 year",
+          "UK fee" => "£9,790",
+          "Non-UK fee" => "£15,000",
+          "When are the fees due? Is there a payment schedule? (optional)" => "Paid in three instalments.",
+          "Are there any additional fees or costs? (optional)" => "A £50 DBS check.",
+          "Does your organisation offer any financial support? (optional)" => "Bursaries are available.",
+          "Salary" => "Paid as an unqualified teacher.",
+          "How do you decide which schools to place trainees in?" => "We match on travel time.",
+          "How much time will they spend in each school?" => "Two terms in each school.",
+          "Where will theoretical training take place? (optional)" => "At our Frenchay campus.",
+          "How much time will they spend in theoretical training? (optional)" => "One day a week.",
+          "What will trainees do while in their placement schools?" => "You will teach a reduced timetable.",
+          "How will they be supported and mentored? (optional)" => "A school mentor meets you weekly.",
+          "What will trainees do during their theoretical training?" => "Seminars on pedagogy.",
+          "How will they be assessed? (optional)" => "Two written assignments.",
+          "What is the interview process? (optional)" => "A subject knowledge task and an interview.",
+          "Where will the interviews take place? (optional)" => "Either in person or online",
+        )
+      end
+
+      it "reports an unpublished edit rather than the text published beneath it" do
+        create(:course, :fee, provider:, name: "Chemistry", enrichments: [
+          build(:course_enrichment, :published, interview_process: "The published interview process."),
+          build(:course_enrichment, :subsequent_draft, interview_process: "The edited interview process."),
+        ])
+
+        expect(rows.first.to_h).to include("What is the interview process? (optional)" => "The edited interview process.")
+      end
+
+      it "leaves the text columns empty when a course has no enrichment" do
+        create(:course, :fee, provider:, name: "Physical Education")
+
+        expect(rows.first.to_h).to include(
+          "Status" => "Draft",
+          "When are the fees due? Is there a payment schedule? (optional)" => nil,
+          "How do you decide which schools to place trainees in?" => nil,
+          "What is the interview process? (optional)" => nil,
+          "Where will the interviews take place? (optional)" => nil,
+        )
+      end
+
+      it "exports the text as markdown, so it can be pasted back into Publish" do
+        create(:course, :fee, provider:, name: "Biology", enrichments: [
+          build(:course_enrichment, :published, placement_school_activities: "You will:\n\n- teach\n- observe"),
+        ])
+
+        expect(rows.first["What will trainees do while in their placement schools?"]).to eq("You will:\n\n- teach\n- observe")
+      end
+
+      it "leaves the fees empty for a course that charges none, whatever the enrichment holds" do
+        create(:course, :apprenticeship, provider:, name: "Apprenticeship course", enrichments: [
+          build(:course_enrichment, :published, fee_uk_eu: 9_790, fee_international: 15_000),
+        ])
+        create(:course, :salary, provider:, name: "Salaried course", enrichments: [
+          build(:course_enrichment, :published, fee_uk_eu: 9_790, fee_international: 15_000),
+        ])
+
+        expect(rows.map { |row| row.values_at("Course name", "UK fee", "Non-UK fee") }).to eq(
+          [
+            ["Apprenticeship course", nil, nil],
+            ["Salaried course", nil, nil],
+          ],
+        )
+      end
+
+      it "omits school experience, which no course in the cycle can be asked for" do
+        create(:course, :salary, provider:, name: "Chemistry")
+
+        expect(rows.headers).not_to include("What school experience are you looking for?")
+      end
+
+      context "when the cycle takes fees rather than salary details" do
+        let(:provider) { create(:provider, :next_recruitment_cycle) }
+
+        it "heads the column with the question that replaced salary details" do
+          create(:course, :salary, provider:, name: "Chemistry", enrichments: [
+            build(:course_enrichment, :published, salary_fee_details: "There are no fees to pay."),
+          ])
+
+          expect(rows.first.to_h).to include(
+            "Give details about any fees or other costs that the trainee might have to pay (optional)" => "There are no fees to pay.",
+          )
+          expect(rows.headers).not_to include("Salary")
+        end
+
+        it "carries the school experience a salaried course asks for" do
+          create(:course, :salary, provider:, name: "Chemistry",
+                                   school_experience_required: true,
+                                   school_experience_required_content: "Spend two weeks in a secondary school.")
+
+          expect(rows.first.to_h).to include("What school experience are you looking for?" => "Spend two weeks in a secondary school.")
+        end
+
+        it "says so when a salaried course asks for no school experience" do
+          create(:course, :salary, provider:, name: "Biology", school_experience_required: false)
+
+          expect(rows.first.to_h).to include("What school experience are you looking for?" => "Not required")
+        end
+
+        it "leaves school experience empty for a course that is never asked the question" do
+          create(:course, :fee, provider:, name: "Physics")
+
+          expect(rows.first.to_h).to include("What school experience are you looking for?" => nil)
+        end
+      end
+    end
+
+    describe "#filename" do
+      it "carries the provider code and the date" do
+        expect(export.filename).to eq("full-course-information-#{provider.provider_code}-#{Time.zone.today}.csv")
+      end
+    end
+  end
+end

--- a/spec/system/support/providers/courses/downloading_full_course_information_spec.rb
+++ b/spec/system/support/providers/courses/downloading_full_course_information_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Downloading full course information from support" do
+  scenario "Support user downloads a provider's course description text" do
+    given_i_am_authenticated_as_an_admin_user
+    and_a_provider_has_a_course_with_description_text
+    when_i_visit_the_support_provider_courses_page
+    then_i_see_the_download_box
+    when_i_download_the_full_course_information
+    then_the_csv_carries_every_description_section
+  end
+
+  def provider
+    @provider ||= create(:provider)
+  end
+
+  def given_i_am_authenticated_as_an_admin_user
+    given_i_am_authenticated(user: create(:user, :admin))
+  end
+
+  def and_a_provider_has_a_course_with_description_text
+    create(:course, :fee, provider:, name: "Chemistry", enrichments: [
+      build(
+        :course_enrichment,
+        :published,
+        placement_selection_criteria: "We match on travel time.",
+        placement_school_activities: "You will teach a reduced timetable.",
+        theoretical_training_activities: "Seminars on pedagogy.",
+        interview_process: "A subject knowledge task and an interview.",
+      ),
+    ])
+  end
+
+  def when_i_visit_the_support_provider_courses_page
+    visit support_recruitment_cycle_provider_courses_path(provider.recruitment_cycle_year, provider)
+  end
+
+  def then_i_see_the_download_box
+    expect(page).to have_content("Download course information")
+    expect(page).to have_link("Download basic course information (CSV)")
+    expect(page).to have_link("Download the schools attached to each course (CSV)")
+    expect(page).to have_link("Download full course information (CSV)")
+  end
+
+  def when_i_download_the_full_course_information
+    click_link_or_button("Download full course information (CSV)")
+  end
+
+  def then_the_csv_carries_every_description_section
+    row = CSV.parse(page.body.delete_prefix(Exports::CourseColumns::BYTE_ORDER_MARK), headers: true).first
+
+    expect(row.to_h).to include(
+      "Course name" => "Chemistry",
+      "How do you decide which schools to place trainees in?" => "We match on travel time.",
+      "What will trainees do while in their placement schools?" => "You will teach a reduced timetable.",
+      "What will trainees do during their theoretical training?" => "Seminars on pedagogy.",
+      "What is the interview process? (optional)" => "A subject knowledge task and an interview.",
+    )
+  end
+end


### PR DESCRIPTION
## Context

We sometimes get requests from providers who want a comprehensive CSV of their course data. We currently offer a CSV download in Publish but it doesn't include all the longform content or requirements and eligibility cirteria for their courses.

As part of fulfilling a support requiest, we've built a "Full course" CSV download that is available in the Support interface.



## Changes proposed in this pull request

<img width="1099" height="322" alt="image" src="https://github.com/user-attachments/assets/d1c434ab-a5cd-4ff1-b6c4-10b01ec11454" />

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
