### PR TITLE
Set cycle dates for next 3 years

### DIFF
--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -212,10 +212,6 @@ module Find
       real_schedule_for(year.to_i).fetch(name)
     end
 
-    def self.last_recruitment_cycle_year?(year)
-      year == CYCLE_DATES.keys.last
-    end
-
     def self.cycle_year_range(year = current_year)
       "#{year} to #{year + 1}"
     end
@@ -234,7 +230,5 @@ module Find
     def self.real_schedule_for(year = current_year)
       CYCLE_DATES[year]
     end
-
-    private_class_method :last_recruitment_cycle_year?
   end
 end

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -55,6 +55,20 @@ module Find
         apply_deadline: Time.zone.local(2027, 9, 21, 18), # CONFIRMED
         find_closes: Time.zone.local(2027, 10, 4).end_of_day, # CONFIRMED
       },
+      2028 => {
+        find_opens: Time.zone.local(2027, 10, 5, 9), # CONFIRMED
+        apply_opens: Time.zone.local(2027, 10, 12, 9), # CONFIRMED
+        first_deadline_banner: Time.zone.local(2028, 7, 12, 9), # TBC
+        apply_deadline: Time.zone.local(2028, 9, 19, 18), # CONFIRMED
+        find_closes: Time.zone.local(2028, 10, 2).end_of_day, # CONFIRMED
+      },
+      2029 => {
+        find_opens: Time.zone.local(2028, 10, 3, 9), # CONFIRMED
+        apply_opens: Time.zone.local(2028, 10, 10, 9), # CONFIRMED
+        first_deadline_banner: Time.zone.local(2029, 7, 12, 9), # TBC
+        apply_deadline: Time.zone.local(2029, 9, 18, 18), # CONFIRMED
+        find_closes: Time.zone.local(2029, 10, 1).end_of_day, # CONFIRMED
+      },
     }.freeze
 
     def self.current_year

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -284,5 +284,42 @@ module Find
         expect(described_class.current_or_previous_year?(described_class.current_year.to_s)).to be(true)
       end
     end
+
+    describe "CYCLE_DATES" do
+      let(:cycles) { described_class::CYCLE_DATES }
+
+      it "opens Apply one week after Find in every cycle" do
+        offenders = cycles.reject { |_, dates| dates[:apply_opens].to_date == dates[:find_opens].to_date + 7 }
+
+        expect(offenders.keys).to be_empty
+      end
+
+      it "closes Find the day before the next cycle opens" do
+        offenders = cycles.reject do |year, dates|
+          next_cycle = cycles[year + 1]
+          next_cycle.nil? || dates[:find_closes].to_date + 1 == next_cycle[:find_opens].to_date
+        end
+
+        expect(offenders.keys).to be_empty
+      end
+
+      it "closes Find thirteen days after the Apply deadline" do
+        offenders = cycles.reject do |_, dates|
+          deadline = dates[:apply_deadline] || dates[:apply_1_deadline]
+          dates[:find_closes].to_date == deadline.to_date + 13
+        end
+
+        expect(offenders.keys).to be_empty
+      end
+
+      it "sets the first deadline banner between Find opening and the Apply deadline" do
+        offenders = cycles.reject do |_, dates|
+          deadline = dates[:apply_deadline] || dates[:apply_1_deadline]
+          dates[:first_deadline_banner].between?(dates[:find_opens], deadline)
+        end
+
+        expect(offenders.keys).to be_empty
+      end
+    end
   end
 end

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -57,14 +57,24 @@ module Find
         expect(described_class.cycle_year_for_time(time)).to eq(2027)
       end
 
+      it "returns 2028 for the exact time find opens" do
+        time = Time.zone.local(2027, 10, 5, 9, 0, 0)
+        expect(described_class.cycle_year_for_time(time)).to eq(2028)
+      end
+
+      it "returns 2029 for the exact time find opens" do
+        time = Time.zone.local(2028, 10, 3, 9, 0, 0)
+        expect(described_class.cycle_year_for_time(time)).to eq(2029)
+      end
+
       it "returns nil for a time before any defined cycle" do
         time = Time.zone.local(2019, 1, 1, 12, 0, 0)
         expect { described_class.cycle_year_for_time(time) }.to raise_error("NoRecruitmentCycleExists: time 2019-01-01 12:00:00")
       end
 
       it "returns nil for a time after the last defined cycle" do
-        time = Time.zone.local(2028, 1, 1, 12, 0, 0)
-        expect { described_class.cycle_year_for_time(time) }.to raise_error("NoRecruitmentCycleExists: time 2028-01-01 12:00:00")
+        time = Time.zone.local(2030, 1, 1, 12, 0, 0)
+        expect { described_class.cycle_year_for_time(time) }.to raise_error("NoRecruitmentCycleExists: time 2030-01-01 12:00:00")
       end
     end
 

--- a/spec/system/publish/courses/rolling_over_draft_courses_spec.rb
+++ b/spec/system/publish/courses/rolling_over_draft_courses_spec.rb
@@ -10,7 +10,7 @@ require "rails_helper"
 # Nothing here turns on which moment of the cycle it is, only on there being a
 # cycle to roll over into. The year is pinned rather than left to the real date
 # because Find::CycleTimetable::CYCLE_DATES is a hardcoded hash that ends at
-# 2027, so an unpinned cycle eventually asks it for a year it does not hold.
+# 2029, so an unpinned cycle eventually asks it for a year it does not hold.
 RSpec.describe "Rolling over draft courses one at a time", travel: mid_cycle(2025) do
   scenario "the provider's sites are not duplicated" do
     given_i_am_authenticated_as_a_provider_user

--- a/spec/system/publish/courses/rolling_over_draft_courses_spec.rb
+++ b/spec/system/publish/courses/rolling_over_draft_courses_spec.rb
@@ -9,8 +9,8 @@ require "rails_helper"
 #
 # Nothing here turns on which moment of the cycle it is, only on there being a
 # cycle to roll over into. The year is pinned rather than left to the real date
-# because Find::CycleTimetable::CYCLE_DATES is a hardcoded hash that ends at
-# 2029, so an unpinned cycle eventually asks it for a year it does not hold.
+# because Find::CycleTimetable::CYCLE_DATES is a hardcoded hash with a finite
+# last year, so an unpinned cycle eventually asks it for a year it does not hold.
 RSpec.describe "Rolling over draft courses one at a time", travel: mid_cycle(2025) do
   scenario "the provider's sites are not duplicated" do
     given_i_am_authenticated_as_a_provider_user


### PR DESCRIPTION
## Context

`Find::CycleTimetable::CYCLE_DATES` currently ends at 2027, so the app raises
`NoRecruitmentCycleExists` for anything after 2027-10-05. 

https://trello.com/c/Y62RccAx/1988-set-cycle-dates-for-next-3-years

## Changes proposed in this pull request

Adds the cycles already published by Apply.

## Guidance to review


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
