### PR TITLE
Allowlist provider_school and course_school for DfE Analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -82,6 +82,13 @@ shared:
     - school_experience_required
     - school_experience_required_content
     - publish_without_schools_allowed
+  course_school:
+    - id
+    - course_id
+    - gias_school_id
+    - provider_school_id
+    - created_at
+    - updated_at
   course_site:
     - id
     - course_id
@@ -204,6 +211,14 @@ shared:
     - address3
     - about_us
     - value_proposition
+  provider_school:
+    - id
+    - provider_id
+    - gias_school_id
+    - site_code
+    - uuid
+    - created_at
+    - updated_at
   providers_onboarding_form_request:
     - id
     - status

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -32,14 +32,6 @@
   - remote_address
   - request_uuid
   - created_at
-  :provider_school:
-  - id
-  - provider_id
-  - gias_school_id
-  - site_code
-  - uuid
-  - created_at
-  - updated_at
   :data_hub_process_summary:
   - full_summary
   - updated_total_count
@@ -74,13 +66,6 @@
   - discarded_invalid_gias_urn
   - discarded_ids_lack_urn
   - discarded_invalid_urns
-  :course_school:
-  - id
-  - course_id
-  - gias_school_id
-  - provider_school_id
-  - created_at
-  - updated_at
   :candidate_recent_search:
   - filter_key_digest
   :candidate_email_alerts:

--- a/spec/services/provider_schools/removal_spec.rb
+++ b/spec/services/provider_schools/removal_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe ProviderSchools::Removal do
         .and change { Audited.audit_class.where(auditable_type: "Course::School", action: "destroy").count }.by(1)
     end
 
+    it "enqueues DfE Analytics delete events for the provider school and course school" do
+      allow(Settings.features).to receive(:send_request_data_to_bigquery).and_return(true)
+
+      course = create(:course, provider:)
+      create(:course_school, course:, provider_school:, gias_school: provider_school.gias_school)
+      create(
+        :course_school,
+        course:,
+        provider_school: other_provider_school,
+        gias_school: other_provider_school.gias_school,
+      )
+
+      removal.call
+
+      expect(:delete_entity).to have_been_enqueued_as_analytics_events
+    end
+
     it "does not remove the school if it becomes the only school on a course while locked" do
       course = create(:course, provider:)
       create(:course_school, course:, provider_school:, gias_school: provider_school.gias_school)

--- a/terraform/aks/workspace_variables/airbyte_stream_config.json
+++ b/terraform/aks/workspace_variables/airbyte_stream_config.json
@@ -561,6 +561,65 @@
         ]
       },
       {
+        "name": "course_school",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "course_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "gias_school_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "provider_school_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
         "name": "course_site",
         "syncMode": "incremental_append",
         "cursorField": [
@@ -1406,6 +1465,70 @@
           {
             "fieldPath": [
               "value_proposition"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "provider_school",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "provider_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "gias_school_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "site_code"
+            ]
+          },
+          {
+            "fieldPath": [
+              "uuid"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
             ]
           }
         ]


### PR DESCRIPTION
## Context

School removal destroys `provider_school` and related `course_school` rows. Those tables were left on the analytics blocklist (deferred in `04cbdc8f0`) so the school-removal deploy would not trigger a large Airbyte initial sync.

This PR allowlists them so create/update/delete history reaches BigQuery for Data & Insights. Separate from school-removal UX/locking.

**Deploy note:** Adding these Airbyte streams is likely to trigger an initial full sync of existing rows (hundreds of thousands). Confirm with Data/DevOps before production; plan for table size and sync window (deploy tasks can wait up to ~1 hour). Expect snapshot then CDC. Historical `import_entity` backfill only if Data asks — not required for Airbyte replication.

## Changes proposed in this pull request

- Move `provider_school` and `course_school` from `config/analytics_blocklist.yml` into `config/analytics.yml` (same columns as the deferred attempt)
- Restore both streams in `terraform/aks/workspace_variables/airbyte_stream_config.json` (`incremental_append`, CDC LSN cursor)
- Spec: assert DfE Analytics `delete_entity` on provider school removal that also detaches a course school

## Guidance to review

- Confirm column lists match the schema / previous allowlist attempt
- Confirm Airbyte stream shape matches other join tables (e.g. `course_site`)
- Before merging to production: coordinate with Data/DevOps on the initial sync window

