### PR TITLE
Fix visa sponsorship deadline date cannot be the last day

### DIFF
--- a/app/forms/publish/visa_sponsorship_application_deadline_date_form.rb
+++ b/app/forms/publish/visa_sponsorship_application_deadline_date_form.rb
@@ -61,7 +61,7 @@ module Publish
     def within_range
       set_date
 
-      unless @date.between?(first_valid_datetime, last_valid_datetime)
+      unless @date.to_date.between?(first_valid_datetime.to_date, last_valid_datetime.to_date)
         errors.add(
           :visa_sponsorship_application_deadline_at,
           :not_in_range,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1228,10 +1228,10 @@ private
     return if visa_sponsorship_application_deadline_at.nil?
 
     if visa_sponsorship_application_deadline_at.respond_to?(:to_time)
-      start_date = provider.recruitment_cycle.application_start_date.end_of_day.change(hour: 9)
-      end_date = provider.recruitment_cycle.application_end_date.end_of_day.change(hour: 18)
+      start_date = provider.recruitment_cycle.application_start_date.to_date
+      end_date = provider.recruitment_cycle.application_end_date.to_date
 
-      return if visa_sponsorship_application_deadline_at.between?(start_date, end_date)
+      return if visa_sponsorship_application_deadline_at.to_date.between?(start_date, end_date)
 
       errors.add(:visa_sponsorship_application_deadline_at, :within_range)
     else

--- a/app/wizards/course_wizard/steps/visa_sponsorship_application_deadline_at.rb
+++ b/app/wizards/course_wizard/steps/visa_sponsorship_application_deadline_at.rb
@@ -64,7 +64,7 @@ class CourseWizard
       def within_range
         set_date
 
-        unless @date.between?(first_valid_datetime, last_valid_datetime)
+        unless @date.to_date.between?(first_valid_datetime.to_date, last_valid_datetime.to_date)
           errors.add(
             :visa_sponsorship_application_deadline_at,
             :not_in_range,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -444,19 +444,25 @@ describe Course do
       let(:end_of_cycle) { provider.recruitment_cycle.application_end_date.end_of_day.change(hour: 18) }
 
       it "is invalid if date is before the recruitment cycle starts" do
-        course.visa_sponsorship_application_deadline_at = start_of_cycle - 1.hour
+        course.visa_sponsorship_application_deadline_at = start_of_cycle.to_date - 1.day
         course.validate
         expect(course.errors[:visa_sponsorship_application_deadline_at]).to eq ["Enter a date within the recruitment cycle"]
       end
 
       it "is invalid if date is after the recruitment cycle ends" do
-        course.visa_sponsorship_application_deadline_at = end_of_cycle + 1.hour
+        course.visa_sponsorship_application_deadline_at = end_of_cycle.to_date + 1.day
         course.validate
         expect(course.errors[:visa_sponsorship_application_deadline_at]).to eq ["Enter a date within the recruitment cycle"]
       end
 
       it "is valid if within cycle" do
         course.visa_sponsorship_application_deadline_at = end_of_cycle - 1.hour
+        course.validate
+        expect(course.errors[:visa_sponsorship_application_deadline_at].blank?).to be true
+      end
+
+      it "is valid on the last day of the recruitment cycle" do
+        course.visa_sponsorship_application_deadline_at = end_of_cycle.to_date.end_of_day
         course.validate
         expect(course.errors[:visa_sponsorship_application_deadline_at].blank?).to be true
       end

--- a/spec/wizards/add_course_wizard/steps/visa_sponsorship_application_deadline_at_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/visa_sponsorship_application_deadline_at_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe CourseWizard::Steps::VisaSponsorshipApplicationDeadlineAt do
       expect(wizard_step).to be_valid
     end
 
+    it "is valid when visa_sponsorship_application_deadline_at is the last day of the recruitment cycle" do
+      last_day = Find::CycleTimetable.date(:apply_deadline, recruitment_cycle_year).to_date
+      set_date_parts(last_day.year.to_s, last_day.month.to_s, last_day.day.to_s)
+
+      expect(wizard_step).to be_valid
+    end
+
     it "is invalid when all date fields are blank" do
       set_date_parts("", "", "")
 


### PR DESCRIPTION
## Context

Providers can set a closing date for applications that need visa sponsorship. The copy says that date must be between today and the last day of the recruitment cycle (for 2026, 15 September).

Entering **15/09/2026** was rejected. **14/09/2026** was accepted.

The field is a date, but validation compared datetimes. The entered date is stored as **11:59pm**. The cycle deadline is **6pm on 15 September**. 15 September 11:59pm is after 6pm, so the last day failed.

## Changes proposed in this pull request

Range checks now compare **calendar dates**, not times.

- Add course wizard (`VisaSponsorshipApplicationDeadlineAt`)
- Edit deadline form (`VisaSponsorshipApplicationDeadlineDateForm`)
- Course model (so saving 15 September does not fail later)

15 September is accepted. 16 September is still rejected. Error copy is unchanged (still mentions 6pm as when Apply closes).

Tests cover the last day on the wizard step and the Course model.

## Guidance to review

On Publish:

1. Add a course, say visa sponsorship is required, set the deadline to **15/09/2026**. It should continue.
2. Try **16/09/2026**. It should still show the in-range error.
3. Edit an existing course deadline to 15 September and save.

Worth a look: whether comparing dates (rather than extending the last valid time to 11:59pm) is the right rule. Users only enter a day.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.